### PR TITLE
Add required url for browser page

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -5,6 +5,16 @@ namespace Laravel\Dusk;
 class Page
 {
     /**
+     * Get the URL for the page.
+     *
+     * @return string
+     */
+    public function url()
+    {
+        return '/';
+    }
+    
+    /**
      * Assert that the browser is on the page.
      *
      * @param  \Laravel\Dusk\Browser  $browser


### PR DESCRIPTION
Hi,

I added the `url` method since you need it when you want to `visit(new Login())` for example. See the code here for that: https://github.com/laravel/dusk/blob/master/src/Browser.php#L83

Another option would be adding the `url` method to a higher page class, like for example the stub file or `tests/Browser/Pages/Page.php`.

Let me know what you think! 