### PR TITLE
Add url method to stub

### DIFF
--- a/stubs/HomePage.php
+++ b/stubs/HomePage.php
@@ -7,6 +7,16 @@ use Laravel\Dusk\Browser;
 class HomePage extends Page
 {
     /**
+     * Get the URL for the page.
+     *
+     * @return string
+     */
+    public function url()
+    {
+        return '/';
+    }
+
+    /**
      * Assert that the browser is on the page.
      *
      * @return void


### PR DESCRIPTION
I was getting an "Error: Call to undefined method Tests\Browser\Pages\HomePage::url()" error. I guess all page objects require that method, but it wasn't on the `HomePage` stub yet.

🕺🏻