### PR TITLE
Import Browser class

### DIFF
--- a/src/Console/stubs/page.stub
+++ b/src/Console/stubs/page.stub
@@ -2,6 +2,7 @@
 
 namespace DummyNamespace;
 
+use Laravel\Dusk\Browser;
 use Laravel\Dusk\Page as BasePage;
 
 class DummyClass extends BasePage


### PR DESCRIPTION
When using `php artisan dusk:page`, the `assert` method on the generated stub references a `Browser` class that isn't being imported. So it fails with:

```
1) Tests\Browser\ExampleTest::testBasicExample
ErrorException: Declaration of Tests\Browser\Pages\Dashboard::assert(Tests\Browser\Pages\Browser $browser) should be compatible with Laravel\Dusk\Page::assert(Laravel\Dusk\Browser $browser)
```

🕺🏻