### PR TITLE
Add note for setting the APP_URI setting in .env

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ To run your tests, use the `dusk` command. The `dusk` command accepts any argume
 
     php artisan dusk
 
-> Make sure you set the `APP_URI` in your `.env` file to match your local environment. For example `APP_URI=http://dusk.dev`
+> Make sure you set the `APP_URL` in your `.env` file to match your local environment. For example `APP_URL=http://dusk.dev`
 
 #### Environments
 

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ To run your tests, use the `dusk` command. The `dusk` command accepts any argume
 
     php artisan dusk
 
+> Make sure you set the `APP_URI` in your `.env` file to match your local environment. For example `APP_URI=http://dusk.dev`
+
 #### Environments
 
 To force Dusk to use its own environment file, create a `.env.dusk.{environment}` file in the root of your project. For example, if you will be initiating the `dusk` command from your `local` environment, you should create a `.env.dusk.local` file.


### PR DESCRIPTION
Hi,

When running Dusk the first time by just following the installation guide it will fail, since the APP_URI is not set correctly. Some of us use Hometead or Valet, so `http://localhost` is not valid. 

I added a small note, maybe you want to update the wording or the position, but I think we should at least point this out.