### PR TITLE
Make url() method on Page mandatory

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -2,8 +2,15 @@
 
 namespace Laravel\Dusk;
 
-class Page
+abstract class Page
 {
+    /**
+     * Get the URL for the page.
+     *
+     * @return string
+     */
+    abstract public function url();
+
     /**
      * Assert that the browser is on the page.
      *

--- a/stubs/Page.php
+++ b/stubs/Page.php
@@ -4,7 +4,7 @@ namespace Tests\Browser\Pages;
 
 use Laravel\Dusk\Page as BasePage;
 
-class Page extends BasePage
+abstract class Page extends BasePage
 {
     /**
      * Get the global element shortcuts for the site.


### PR DESCRIPTION
Currently, using a Page object within your tests and running `php artisan dusk` would fail likewise:
> Error: Call to undefined method Tests\Browser\Pages\HomePage::url()

Additionally, it is here just assumed to be implemented:
https://github.com/laravel/dusk/blob/master/src/Browser.php#L86

It stands to reason that a page opened through the browser must have a url, therefore a blueprint for each implementation of Page should require one.