### PR TITLE
Add docblocks for cookie expiry and standardise expiry

### DIFF
--- a/src/Concerns/InteractsWithCookies.php
+++ b/src/Concerns/InteractsWithCookies.php
@@ -11,14 +11,14 @@ trait InteractsWithCookies
      *
      * @param  string  $name
      * @param  string|null  $value
-     * @param  mixed  $expiration
+     * @param  int|DateTimeInterface|null $expiry
      * @param  array  $options
      * @return string
      */
-    public function cookie($name, $value = null, $expiration = null, array $options = [])
+    public function cookie($name, $value = null, $expiry = null, array $options = [])
     {
         if ($value) {
-            return $this->addCookie($name, $value, $expiration, $options);
+            return $this->addCookie($name, $value, $expiry, $options);
         }
 
         if ($cookie = $this->driver->manage()->getCookieNamed($name)) {
@@ -29,15 +29,16 @@ trait InteractsWithCookies
     /**
      * Get or set a plain cookie's value.
      *
-     * @param  string  $name
-     * @param  string|null  $value
-     * @param  array  $options
+     * @param  string $name
+     * @param  string|null $value
+     * @param int|DateTimeInterface|null $expiry
+     * @param  array $options
      * @return string
      */
-    public function plainCookie($name, $value = null, $expiration = null, array $options = [])
+    public function plainCookie($name, $value = null, $expiry = null, array $options = [])
     {
         if ($value) {
-            return $this->addCookie($name, $value, $expiration, $options, false);
+            return $this->addCookie($name, $value, $expiry, $options, false);
         }
 
         if ($cookie = $this->driver->manage()->getCookieNamed($name)) {
@@ -50,12 +51,12 @@ trait InteractsWithCookies
      *
      * @param  string  $name
      * @param  string  $value
-     * @param  mixed  $expiry
+     * @param  int|DateTimeInterface|null  $expiry
      * @param  array  $options
      * @param  bool  $encrypt
      * @return $this
      */
-    public function addCookie($name, $value, $expiry, array $options = [], $encrypt = true)
+    public function addCookie($name, $value, $expiry = null, array $options = [], $encrypt = true)
     {
         if ($encrypt) {
             $value = encrypt($value);


### PR DESCRIPTION
- Add doc blocks with proper types (```integer```, ```DateTimeInterface``` or ```null```)
- Rename occurances of ```$expiration``` to ```$expiry``` for consistency
- Add ```null``` default value on ```$expiry``` param of ```addCookie()``` method to support other methods

I've changed the type hint of ```expiry``` from ```string``` to ```int```.