### PR TITLE
Retain consistency of test methods with integrated

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ $this->browse(function ($first, $second) {
     $second->loginAs(User::find(2))
             ->visit('/home')
             ->waitForText('Message')
-            ->type('message', 'Hey Taylor')
+            ->type('Hey Taylor', 'message')
             ->press('Send');
 
     $first->waitForText('Hey Taylor')

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -143,11 +143,11 @@ trait InteractsWithElements
     /**
      * Type the given value in the given field.
      *
-     * @param  string  $field
      * @param  string  $value
+     * @param  string  $field
      * @return $this
      */
-    public function type($field, $value)
+    public function type($value, $field)
     {
         $this->resolver->resolveForTyping($field)->clear()->sendKeys($value);
 
@@ -170,11 +170,11 @@ trait InteractsWithElements
     /**
      * Select the given value of a drop-down field.
      *
+     * @param  string  $value
      * @param  string  $field
-     * @param  stirng  $value
      * @return $this
      */
-    public function select($field, $value)
+    public function select($value, $field)
     {
         $element = $this->resolver->resolveForSelection($field);
 
@@ -194,11 +194,11 @@ trait InteractsWithElements
     /**
      * Select the given value of a radio button field.
      *
+     * @param  string  $value
      * @param  string  $field
-     * @param  stirng  $value
      * @return $this
      */
-    public function radio($field, $value)
+    public function radio($value, $field)
     {
         $this->resolver->resolveForRadioSelection($field, $value)->click();
 
@@ -242,11 +242,11 @@ trait InteractsWithElements
     /**
      * Attach the given file to the field.
      *
-     * @param  string  $field
      * @param  string  $path
+     * @param  string  $field
      * @return $this
      */
-    public function attach($field, $path)
+    public function attach($path, $field)
     {
         $element = $this->resolver->resolveForAttachment($field);
 


### PR DESCRIPTION
With Laravel's existing testing capabilities, the method signature is always ```$value```, ```$field```. The new dusk methods reverse this.

To make it easier to adopt, and apply convention I've standardised this.

The ```value()``` method is an exception to this however. I can resolve that using the following (which I can submit separately if you like):

```
/**
     * Directly get or set the value attribute of an input field.
     *
     * @param  string  $value
     * @param  string|null  $selector
     * @return $this
     */
    public function value($value, $selector = null)
    {
        if (func_num_args() == 1) {
            return $this->resolver->findOrFail($value)->getAttribute('value');
        }
        
        $selector = $this->resolver->format($selector);

        $this->driver->executeScript(
            "document.querySelector('{$selector}').value = '{$value}';"
        );

        return $this;
    }
```

I'm not 100% happy with this however, as when one argument is passed, the parameter named ```$value``` is being used as a selector which makes readability a little off. I'd be happy to see alternative ways in how this could be tackled.