### PR TITLE
Remove jQuery dependency from seeLink

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -221,7 +221,7 @@ trait MakesAssertions
             return Array.prototype.slice
             .call(document.querySelectorAll("{$selector}"))
             .some(function(element) {
-              return element.offsetHeight > 0 && element.offsetWidth > 0 && element.style.visibility !== "hidden" ;
+              return element.offsetHeight > 0 && element.offsetWidth > 0;
             });
 JS;
 

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -215,15 +215,15 @@ trait MakesAssertions
      */
     public function seeLink($link)
     {
-      $script = <<<JS
-          return Array.prototype.slice
-          .call(document.querySelectorAll("a"))
-          .some(function(element) {
-            return element.innerHTML === "{$link}" &&  element.offsetHeight > 0 && element.offsetWidth > 0;
-          });
+        $script = <<<JS
+            return Array.prototype.slice
+            .call(document.querySelectorAll("a"))
+            .some(function(element) {
+                return element.innerHTML === "{$link}" &&  element.offsetHeight > 0 && element.offsetWidth > 0;
+            });
 JS;
 
-      return $this->driver->executeScript($script);
+        return $this->driver->executeScript($script);
     }
 
     /**

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -215,11 +215,12 @@ trait MakesAssertions
      */
     public function seeLink($link)
     {
-        $selector = trim($this->resolver->format("a:contains('{$link}')"));
+        $selector = trim($this->resolver->format("a[href*='{$link}']"));
 
         $script = <<<JS
-            var link = $("{$selector}");
-            return link.length > 0 && link.is(':visible');
+            return Array.prototype.slice
+            .call(document.querySelectorAll("{$selector}"))
+            .some(function(element) { return element.offsetHeight > 0 && element.offsetWidth > 0 });
 JS;
 
         return $this->driver->executeScript($script);

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -220,7 +220,9 @@ trait MakesAssertions
         $script = <<<JS
             return Array.prototype.slice
             .call(document.querySelectorAll("{$selector}"))
-            .some(function(element) { return element.offsetHeight > 0 && element.offsetWidth > 0 });
+            .some(function(element) {
+              return element.offsetHeight > 0 && element.offsetWidth > 0 && element.style.visibility !== "hidden" ;
+            });
 JS;
 
         return $this->driver->executeScript($script);

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -215,17 +215,15 @@ trait MakesAssertions
      */
     public function seeLink($link)
     {
-        $selector = trim($this->resolver->format("a[href*='{$link}']"));
-
-        $script = <<<JS
-            return Array.prototype.slice
-            .call(document.querySelectorAll("{$selector}"))
-            .some(function(element) {
-              return element.offsetHeight > 0 && element.offsetWidth > 0;
-            });
+      $script = <<<JS
+          return Array.prototype.slice
+          .call(document.querySelectorAll("a"))
+          .some(function(element) {
+            return element.innerHTML === "{$link}" &&  element.offsetHeight > 0 && element.offsetWidth > 0;
+          });
 JS;
 
-        return $this->driver->executeScript($script);
+      return $this->driver->executeScript($script);
     }
 
     /**


### PR DESCRIPTION
This removes the jQuery dependency in the `seeLink` Method and uses Vanilla Javascript for checking if the link is displayed.

This PR resolves #27.