### PR TITLE
Fix test for jquery

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -209,7 +209,7 @@ class Browser
      */
     protected function ensurejQueryIsAvailable()
     {
-        if ($this->driver->executeScript("return window.$ == null")) {
+        if ($this->driver->executeScript("return window.jQuery == null")) {
             $this->driver->executeScript(file_get_contents(__DIR__.'/../bin/jquery.js'));
         }
     }


### PR DESCRIPTION
In [jQuery documentation](https://api.jquery.com/jquery.noconflict/) in `jQuery.noConflict` function you can find:

> Many JavaScript libraries use $ as a function or variable name, just as jQuery does. In jQuery's case, $ is just an alias for jQuery, so all functionality is available without using $. If you need to use another JavaScript library alongside jQuery, return control of $ back to the other library with a call to $.noConflict(). Old references of $ are saved during jQuery initialization;  noConflict() simply restores them.

So better way is to check if jQuery is defined or no.