### PR TITLE
Display Environmental variable fix for majority of Linux versions

### DIFF
--- a/src/SupportsChrome.php
+++ b/src/SupportsChrome.php
@@ -21,7 +21,7 @@ trait SupportsChrome
         if (PHP_OS === 'Darwin') {
             static::$chromeProcess = new Process('./chromedriver-mac', realpath(__DIR__.'/../bin'), null, null, null);
         } else {
-            static::$chromeProcess = new Process('./chromedriver-linux', realpath(__DIR__.'/../bin'), null, null, null);
+            static::$chromeProcess = new Process('./chromedriver-linux', realpath(__DIR__.'/../bin'), ['DISPLAY' => ':0'], null, null);
         }
 
         static::$chromeProcess->start();


### PR DESCRIPTION
This fix will allow for most Linux versions to properly access the display to launch the chrome window.