### PR TITLE
make screenshot dir configurable

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -28,6 +28,13 @@ class Browser
     public static $baseUrl;
 
     /**
+     * The directory to place screenshots.
+     *
+     * @var string
+     */
+    public static $screenshotDir;
+
+    /**
      * Get the callback which resolves the default user to authenticate.
      *
      * @var \Closure
@@ -175,7 +182,7 @@ class Browser
      */
     public function screenshot($name)
     {
-        $this->driver->takeScreenshot(base_path('tests/Browser/screenshots/'.$name.'.png'));
+        $this->driver->takeScreenshot(sprintf('%s/%s.png', rtrim(static::$screenshotDir, '/'), $name));
 
         return $this;
     }

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -38,6 +38,7 @@ abstract class TestCase extends FoundationTestCase
     public function propagateScaffoldingToBrowser()
     {
         Browser::$baseUrl = $this->baseUrl();
+        Browser::$screenshotDir = base_path('tests/Browser/screenshots');
 
         Browser::$userResolver = function () {
             return $this->user();


### PR DESCRIPTION
I have been playing with integrating dusk into a Symfony app. I had to extend `Browser` to customize the screenshot directory. Not a huge deal but would be nice if it was configurable.