### PR TITLE
Make waitUntilMissing work as expected.

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -39,20 +39,6 @@ trait WaitsForElements
     }
 
     /**
-     * Wait for the given selector to be not visible.
-     *
-     * @param  string  $selector
-     * @param  int  $seconds
-     * @return $this
-     */
-    public function waitUntilHidden($selector, $seconds = 5)
-    {
-        return $this->waitUsing($seconds, 100, function () use ($selector) {
-            return ! $this->resolver->findOrFail($selector)->isDisplayed();
-        });
-    }
-
-    /**
      * Wait for the given selector to be removed.
      *
      * @param  string  $selector
@@ -63,12 +49,12 @@ trait WaitsForElements
     {
         return $this->waitUsing($seconds, 100, function () use ($selector) {
             try {
-                $this->resolver->findOrFail($selector);
+                $missing = ! $this->resolver->findOrFail($selector)->isDisplayed();
             } catch (NoSuchElementException $e) {
-                return true;
+                $missing = true;
             }
 
-            return false;
+            return $missing;
         });
     }
 

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -7,6 +7,7 @@ use Exception;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
 use Facebook\WebDriver\Exception\TimeOutException;
+use Facebook\WebDriver\Exception\NoSuchElementException;
 
 trait WaitsForElements
 {
@@ -44,10 +45,30 @@ trait WaitsForElements
      * @param  int  $seconds
      * @return $this
      */
-    public function waitUntilMissing($selector, $seconds = 5)
+    public function waitUntilHidden($selector, $seconds = 5)
     {
         return $this->waitUsing($seconds, 100, function () use ($selector) {
             return ! $this->resolver->findOrFail($selector)->isDisplayed();
+        });
+    }
+
+    /**
+     * Wait for the given selector to be removed.
+     *
+     * @param  string  $selector
+     * @param  int  $seconds
+     * @return $this
+     */
+    public function waitUntilMissing($selector, $seconds = 5)
+    {
+        return $this->waitUsing($seconds, 100, function () use ($selector) {
+            try {
+                $this->resolver->findOrFail($selector);
+            } catch (NoSuchElementException $e) {
+                return true;
+            }
+
+            return false;
         });
     }
 


### PR DESCRIPTION
This is a PR to fix (what I consider at least) to be an issue with the `waitUntilMissing()` method in the **WaitsForElements** trait. From using the `assertMissing()` assertion in the **MakesAssertions** trait, I had assumed that this method would work the same way. That is, if I remove an element from the DOM using some JS or something, I can use this method to wait until it's gone. However this doesn't seem to be the case. If you are removing an element from the DOM and you attempt to use the `waitUntilMissing()` method, it's never going to work. `WaitUntilMissing()` is using `findOrFail()` to find an element and then check if it's visible or not. But if the element is being removed (not hidden) as you would expect when trying to use this method, the tests will always fail because the FB web driver **HttpCommandExecutor** class will throw a **NoSuchElementException** that then gets silently caught (I assume) by **WebDriverWait** class. This is pretty maddening to deal with. So what I've done here is this:

* Refactored the `waitUntilMissing()` method to use a try/catch block to catch this error (now implemented similar to the `assertMissing()` method).
* Implemented a `waitUntilHidden()` method that is essentially just the old `waitUntilMissing()` method renamed (It checks to see if an existing DOM element has been hidden).

I think this is a much consistent way to think about this stuff and is (to me at least) more correct semantically and less confusing all around.

- Made the waitUntilMissing() method work as expected (i.e it now detects when an element has been removed).
- Implemented a waitUntilHidden() method that can be used to detect when an element has been hidden.