### PR TITLE
[WIP] Support browser kit in Dusk

### DIFF
--- a/src/BrowserKit/Concerns/InteractsWithPages.php
+++ b/src/BrowserKit/Concerns/InteractsWithPages.php
@@ -1,0 +1,663 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit\Concerns;
+
+use Closure;
+use InvalidArgumentException;
+use Illuminate\Http\UploadedFile;
+use Symfony\Component\DomCrawler\Form;
+use PHPUnit_Framework_Assert as PHPUnit;
+use Symfony\Component\DomCrawler\Crawler;
+use Laravel\Dusk\BrowserKit\HttpException;
+use Laravel\Dusk\BrowserKit\Constraints\HasText;
+use Laravel\Dusk\BrowserKit\Constraints\HasLink;
+use Laravel\Dusk\BrowserKit\Constraints\HasValue;
+use Laravel\Dusk\BrowserKit\Constraints\HasSource;
+use Laravel\Dusk\BrowserKit\Constraints\IsChecked;
+use Laravel\Dusk\BrowserKit\Constraints\HasElement;
+use Laravel\Dusk\BrowserKit\Constraints\IsSelected;
+use Laravel\Dusk\BrowserKit\Constraints\HasInElement;
+use Laravel\Dusk\BrowserKit\Constraints\PageConstraint;
+use Laravel\Dusk\BrowserKit\Constraints\ReversePageConstraint;
+use PHPUnit_Framework_ExpectationFailedException as PHPUnitException;
+
+trait InteractsWithPages
+{
+    /**
+     * Make a request to the application using the given form.
+     *
+     * @param  \Symfony\Component\DomCrawler\Form  $form
+     * @param  array  $uploads
+     * @return $this
+     */
+    protected function makeRequestUsingForm(Form $form, array $uploads = [])
+    {
+        $files = $this->convertUploadsForTesting($form, $uploads);
+
+        return $this->makeRequest(
+            $form->getMethod(), $form->getUri(), $this->extractParametersFromForm($form), [], $files
+        );
+    }
+
+    /**
+     * Extract the parameters from the given form.
+     *
+     * @param  \Symfony\Component\DomCrawler\Form  $form
+     * @return array
+     */
+    protected function extractParametersFromForm(Form $form)
+    {
+        parse_str(http_build_query($form->getValues()), $parameters);
+
+        return $parameters;
+    }
+
+    /**
+     * Follow redirects from the last response.
+     *
+     * @return $this
+     */
+    protected function followRedirects()
+    {
+        while ($this->response->isRedirect()) {
+            $this->makeRequest('GET', $this->response->getTargetUrl());
+        }
+
+        return $this;
+    }
+
+    /**
+     * Clear the inputs for the current page.
+     *
+     * @return $this
+     */
+    protected function clearInputs()
+    {
+        $this->inputs = [];
+
+        $this->uploads = [];
+
+        return $this;
+    }
+
+    /**
+     * Assert that the current page matches a given URI.
+     *
+     * @param  string  $uri
+     * @return $this
+     */
+    protected function seePageIs($uri)
+    {
+        $this->assertPageLoaded($uri = $this->prepareUrlForRequest($uri));
+
+        PHPUnit::assertEquals(
+            $uri, $this->currentUri, "Did not land on expected page [{$uri}].\n"
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the current page matches a given named route.
+     *
+     * @param  string  $route
+     * @param  array  $parameters
+     * @return $this
+     */
+    protected function seeRouteIs($route, $parameters = [])
+    {
+        return $this->seePageIs(route($route, $parameters));
+    }
+
+    /**
+     * Assert that a given page successfully loaded.
+     *
+     * @param  string  $uri
+     * @param  string|null  $message
+     * @return void
+     *
+     * @throws \Laravel\BrowserKitTesting\HttpException
+     */
+    public function assertPageLoaded($uri, $message = null)
+    {
+        $status = $this->getStatusCode();
+
+        try {
+            PHPUnit::assertEquals(200, $status);
+        } catch (PHPUnitException $e) {
+            $message = $message ?: "A request to [{$uri}] failed. Received status code [{$status}].";
+
+            $responseException = isset($this->response->exception)
+                ? $this->response->exception : null;
+
+            throw new HttpException($message, null, $responseException);
+        }
+    }
+
+    /**
+     * Narrow the test content to a specific area of the page.
+     *
+     * @param  string  $element
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function within($element, Closure $callback)
+    {
+        $this->subCrawlers[] = $this->crawler()->filter($element);
+
+        $callback();
+
+        array_pop($this->subCrawlers);
+
+        return $this;
+    }
+
+    /**
+     * Get the current crawler according to the test context.
+     *
+     * @return \Symfony\Component\DomCrawler\Crawler
+     */
+    protected function crawler()
+    {
+        if (! empty($this->subCrawlers)) {
+            return end($this->subCrawlers);
+        }
+
+        return $this->crawler;
+    }
+
+    /**
+     * Assert the given constraint.
+     *
+     * @param  \Laravel\BrowserKitTesting\Constraints\PageConstraint  $constraint
+     * @param  bool  $reverse
+     * @param  string  $message
+     * @return $this
+     */
+    protected function assertInPage(PageConstraint $constraint, $reverse = false, $message = '')
+    {
+        if ($reverse) {
+            $constraint = new ReversePageConstraint($constraint);
+        }
+
+        PHPUnit::assertThat($this->crawler(), $constraint, $message);
+
+        return $this;
+    }
+
+    /**
+     * Assert that a given string is seen on the current HTML.
+     *
+     * @param  string  $text
+     * @param  bool  $negate
+     * @return $this
+     */
+    public function assertSee($text, $negate = false)
+    {
+        return $this->assertInPage(new HasSource($text), $negate);
+    }
+
+    /**
+     * Assert that a given string is not seen on the current HTML.
+     *
+     * @param  string  $text
+     * @return $this
+     */
+    public function dontSee($text)
+    {
+        return $this->assertInPage(new HasSource($text), true);
+    }
+
+    /**
+     * Assert that an element is present on the page.
+     *
+     * @param  string  $selector
+     * @param  array  $attributes
+     * @param  bool  $negate
+     * @return $this
+     */
+    public function seeElement($selector, array $attributes = [], $negate = false)
+    {
+        return $this->assertInPage(new HasElement($selector, $attributes), $negate);
+    }
+
+    /**
+     * Assert that an element is not present on the page.
+     *
+     * @param  string  $selector
+     * @param  array  $attributes
+     * @return $this
+     */
+    public function dontSeeElement($selector, array $attributes = [])
+    {
+        return $this->assertInPage(new HasElement($selector, $attributes), true);
+    }
+
+    /**
+     * Assert that a given string is seen on the current text.
+     *
+     * @param  string  $text
+     * @param  bool  $negate
+     * @return $this
+     */
+    public function seeText($text, $negate = false)
+    {
+        return $this->assertInPage(new HasText($text), $negate);
+    }
+
+    /**
+     * Assert that a given string is not seen on the current text.
+     *
+     * @param  string  $text
+     * @return $this
+     */
+    public function dontSeeText($text)
+    {
+        return $this->assertInPage(new HasText($text), true);
+    }
+
+    /**
+     * Assert that a given string is seen inside an element.
+     *
+     * @param  string  $element
+     * @param  string  $text
+     * @param  bool  $negate
+     * @return $this
+     */
+    public function assertSeeIn($element, $text, $negate = false)
+    {
+        return $this->assertInPage(new HasInElement($element, $text), $negate);
+    }
+
+    /**
+     * Assert that a given string is not seen inside an element.
+     *
+     * @param  string  $element
+     * @param  string  $text
+     * @return $this
+     */
+    public function dontSeeInElement($element, $text)
+    {
+        return $this->assertInPage(new HasInElement($element, $text), true);
+    }
+
+    /**
+     * Assert that a given link is seen on the page.
+     *
+     * @param  string $text
+     * @param  string|null $url
+     * @param  bool  $negate
+     * @return $this
+     */
+    public function seeLink($text, $url = null, $negate = false)
+    {
+        return $this->assertInPage(new HasLink($text, $url), $negate);
+    }
+
+    /**
+     * Assert that a given link is not seen on the page.
+     *
+     * @param  string  $text
+     * @param  string|null  $url
+     * @return $this
+     */
+    public function dontSeeLink($text, $url = null)
+    {
+        return $this->assertInPage(new HasLink($text, $url), true);
+    }
+
+    /**
+     * Assert that an input field contains the given value.
+     *
+     * @param  string  $selector
+     * @param  string  $expected
+     * @param  bool  $negate
+     * @return $this
+     */
+    public function seeInField($selector, $expected, $negate = false)
+    {
+        return $this->assertInPage(new HasValue($selector, $expected), $negate);
+    }
+
+    /**
+     * Assert that an input field does not contain the given value.
+     *
+     * @param  string  $selector
+     * @param  string  $value
+     * @return $this
+     */
+    public function dontSeeInField($selector, $value)
+    {
+        return $this->assertInPage(new HasValue($selector, $value), true);
+    }
+
+    /**
+     * Assert that the expected value is selected.
+     *
+     * @param  string  $selector
+     * @param  string  $value
+     * @param  bool  $negate
+     * @return $this
+     */
+    public function seeIsSelected($selector, $value, $negate = false)
+    {
+        return $this->assertInPage(new IsSelected($selector, $value), $negate);
+    }
+
+    /**
+     * Assert that the given value is not selected.
+     *
+     * @param  string  $selector
+     * @param  string  $value
+     * @return $this
+     */
+    public function dontSeeIsSelected($selector, $value)
+    {
+        return $this->assertInPage(new IsSelected($selector, $value), true);
+    }
+
+    /**
+     * Assert that the given checkbox is selected.
+     *
+     * @param  string  $selector
+     * @param  bool  $negate
+     * @return $this
+     */
+    public function seeIsChecked($selector, $negate = false)
+    {
+        return $this->assertInPage(new IsChecked($selector), $negate);
+    }
+
+    /**
+     * Assert that the given checkbox is not selected.
+     *
+     * @param  string  $selector
+     * @return $this
+     */
+    public function dontSeeIsChecked($selector)
+    {
+        return $this->assertInPage(new IsChecked($selector), true);
+    }
+
+    /**
+     * Click a link with the given body, name, or ID attribute.
+     *
+     * @param  string  $name
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function click($name)
+    {
+        $link = $this->crawler()->selectLink($name);
+
+        if (! count($link)) {
+            $link = $this->filterByNameOrId($name, 'a');
+
+            if (! count($link)) {
+                throw new InvalidArgumentException(
+                    "Could not find a link with a body, name, or ID attribute of [{$name}]."
+                );
+            }
+        }
+
+        $this->visit($link->link()->getUri());
+
+        return $this;
+    }
+
+    /**
+     * Fill an input field with the given text.
+     *
+     * @param  string  $text
+     * @param  string  $element
+     * @return $this
+     */
+    protected function type($text, $element)
+    {
+        return $this->storeInput($element, $text);
+    }
+
+    /**
+     * Check a checkbox on the page.
+     *
+     * @param  string  $element
+     * @return $this
+     */
+    protected function check($element)
+    {
+        return $this->storeInput($element, true);
+    }
+
+    /**
+     * Uncheck a checkbox on the page.
+     *
+     * @param  string  $element
+     * @return $this
+     */
+    protected function uncheck($element)
+    {
+        return $this->storeInput($element, false);
+    }
+
+    /**
+     * Select an option from a drop-down.
+     *
+     * @param  string  $option
+     * @param  string  $element
+     * @return $this
+     */
+    protected function select($option, $element)
+    {
+        return $this->storeInput($element, $option);
+    }
+
+    /**
+     * Attach a file to a form field on the page.
+     *
+     * @param  string  $absolutePath
+     * @param  string  $element
+     * @return $this
+     */
+    protected function attach($absolutePath, $element)
+    {
+        $this->uploads[$element] = $absolutePath;
+
+        return $this->storeInput($element, $absolutePath);
+    }
+
+    /**
+     * Submit a form using the button with the given text value.
+     *
+     * @param  string  $buttonText
+     * @return $this
+     */
+    protected function press($buttonText)
+    {
+        return $this->submitForm($buttonText, $this->inputs, $this->uploads);
+    }
+
+    /**
+     * Submit a form on the page with the given input.
+     *
+     * @param  string  $buttonText
+     * @param  array  $inputs
+     * @param  array  $uploads
+     * @return $this
+     */
+    protected function submitForm($buttonText, $inputs = [], $uploads = [])
+    {
+        $this->makeRequestUsingForm($this->fillForm($buttonText, $inputs), $uploads);
+
+        return $this;
+    }
+
+    /**
+     * Fill the form with the given data.
+     *
+     * @param  string  $buttonText
+     * @param  array  $inputs
+     * @return \Symfony\Component\DomCrawler\Form
+     */
+    protected function fillForm($buttonText, $inputs = [])
+    {
+        if (! is_string($buttonText)) {
+            $inputs = $buttonText;
+
+            $buttonText = null;
+        }
+
+        return $this->getForm($buttonText)->setValues($inputs);
+    }
+
+    /**
+     * Get the form from the page with the given submit button text.
+     *
+     * @param  string|null  $buttonText
+     * @return \Symfony\Component\DomCrawler\Form
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function getForm($buttonText = null)
+    {
+        try {
+            if ($buttonText) {
+                return $this->crawler()->selectButton($buttonText)->form();
+            }
+
+            return $this->crawler()->filter('form')->form();
+        } catch (InvalidArgumentException $e) {
+            throw new InvalidArgumentException(
+                "Could not find a form that has submit button [{$buttonText}]."
+            );
+        }
+    }
+
+    /**
+     * Store a form input in the local array.
+     *
+     * @param  string  $element
+     * @param  string  $text
+     * @return $this
+     */
+    protected function storeInput($element, $text)
+    {
+        $this->assertFilterProducesResults($element);
+
+        $element = str_replace(['#', '[]'], '', $element);
+
+        $this->inputs[$element] = $text;
+
+        return $this;
+    }
+
+    /**
+     * Assert that a filtered Crawler returns nodes.
+     *
+     * @param  string  $filter
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function assertFilterProducesResults($filter)
+    {
+        $crawler = $this->filterByNameOrId($filter);
+
+        if (! count($crawler)) {
+            throw new InvalidArgumentException(
+                "Nothing matched the filter [{$filter}] CSS query provided for [{$this->currentUri}]."
+            );
+        }
+    }
+
+    /**
+     * Filter elements according to the given name or ID attribute.
+     *
+     * @param  string  $name
+     * @param  array|string  $elements
+     * @return \Symfony\Component\DomCrawler\Crawler
+     */
+    protected function filterByNameOrId($name, $elements = '*')
+    {
+        $name = str_replace('#', '', $name);
+
+        $id = str_replace(['[', ']'], ['\\[', '\\]'], $name);
+
+        $elements = is_array($elements) ? $elements : [$elements];
+
+        array_walk($elements, function (&$element) use ($name, $id) {
+            $element = "{$element}#{$id}, {$element}[name='{$name}']";
+        });
+
+        return $this->crawler()->filter(implode(', ', $elements));
+    }
+
+    /**
+     * Convert the given uploads to UploadedFile instances.
+     *
+     * @param  \Symfony\Component\DomCrawler\Form  $form
+     * @param  array  $uploads
+     * @return array
+     */
+    protected function convertUploadsForTesting(Form $form, array $uploads)
+    {
+        $files = $form->getFiles();
+
+        $names = array_keys($files);
+
+        $files = array_map(function (array $file, $name) use ($uploads) {
+            return isset($uploads[$name])
+                ? $this->getUploadedFileForTesting($file, $uploads, $name)
+                : $file;
+        }, $files, $names);
+
+        $uploads = array_combine($names, $files);
+
+        foreach ($uploads as $key => $file) {
+            if (preg_match('/.*?(?:\[.*?\])+/', $key)) {
+                $this->prepareArrayBasedFileInput($uploads, $key, $file);
+            }
+        }
+
+        return $uploads;
+    }
+
+    /**
+     * Store an array based file upload with the proper nested array structure.
+     *
+     * @param  array  $uploads
+     * @param  string  $key
+     * @param  mixed  $file
+     */
+    protected function prepareArrayBasedFileInput(&$uploads, $key, $file)
+    {
+        preg_match_all('/([^\[\]]+)/', $key, $segments);
+
+        $segments = array_reverse($segments[1]);
+
+        $newKey = array_pop($segments);
+
+        foreach ($segments as $segment) {
+            $file = [$segment => $file];
+        }
+
+        $uploads[$newKey] = $file;
+
+        unset($uploads[$key]);
+    }
+
+    /**
+     * Create an UploadedFile instance for testing.
+     *
+     * @param  array  $file
+     * @param  array  $uploads
+     * @param  string  $name
+     * @return \Illuminate\Http\UploadedFile
+     */
+    protected function getUploadedFileForTesting($file, $uploads, $name)
+    {
+        return new UploadedFile(
+            $file['tmp_name'], basename($uploads[$name]), $file['type'], $file['size'], $file['error'], true
+        );
+    }
+}

--- a/src/BrowserKit/Constraints/FormFieldConstraint.php
+++ b/src/BrowserKit/Constraints/FormFieldConstraint.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit\Constraints;
+
+use Symfony\Component\DomCrawler\Crawler;
+
+abstract class FormFieldConstraint extends PageConstraint
+{
+    /**
+     * The name or ID of the element.
+     *
+     * @var string
+     */
+    protected $selector;
+
+    /**
+     * The expected value.
+     *
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  string  $selector
+     * @param  mixed  $value
+     * @return void
+     */
+    public function __construct($selector, $value)
+    {
+        $this->selector = $selector;
+        $this->value = (string) $value;
+    }
+
+    /**
+     * Get the valid elements.
+     *
+     * Multiple elements should be separated by commas without spaces.
+     *
+     * @return string
+     */
+    abstract protected function validElements();
+
+    /**
+     * Get the form field.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler  $crawler
+     * @return \Symfony\Component\DomCrawler\Crawler
+     *
+     * @throws \PHPUnit_Framework_ExpectationFailedException
+     */
+    protected function field(Crawler $crawler)
+    {
+        $field = $crawler->filter(implode(', ', $this->getElements()));
+
+        if ($field->count() > 0) {
+            return $field;
+        }
+
+        $this->fail($crawler, sprintf(
+            'There is no %s with the name or ID [%s]',
+            $this->validElements(), $this->selector
+        ));
+    }
+
+    /**
+     * Get the elements relevant to the selector.
+     *
+     * @return array
+     */
+    protected function getElements()
+    {
+        $name = str_replace('#', '', $this->selector);
+
+        $id = str_replace(['[', ']'], ['\\[', '\\]'], $name);
+
+        return collect(explode(',', $this->validElements()))->map(function ($element) use ($name, $id) {
+            return "{$element}#{$id}, {$element}[name='{$name}']";
+        })->all();
+    }
+}

--- a/src/BrowserKit/Constraints/HasElement.php
+++ b/src/BrowserKit/Constraints/HasElement.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit\Constraints;
+
+use Symfony\Component\DomCrawler\Crawler;
+
+class HasElement extends PageConstraint
+{
+    /**
+     * The name or ID of the element.
+     *
+     * @var string
+     */
+    protected $selector;
+
+    /**
+     * The attributes the element should have.
+     *
+     * @var array
+     */
+    protected $attributes;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  string  $selector
+     * @param  array  $attributes
+     * @return void
+     */
+    public function __construct($selector, array $attributes = [])
+    {
+        $this->selector = $selector;
+        $this->attributes = $attributes;
+    }
+
+    /**
+     * Check if the element is found in the given crawler.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler|string  $crawler
+     * @return bool
+     */
+    public function matches($crawler)
+    {
+        $elements = $this->crawler($crawler)->filter($this->selector);
+
+        if ($elements->count() == 0) {
+            return false;
+        }
+
+        if (empty($this->attributes)) {
+            return true;
+        }
+
+        $elements = $elements->reduce(function ($element) {
+            return $this->hasAttributes($element);
+        });
+
+        return $elements->count() > 0;
+    }
+
+    /**
+     * Determines if the given element has the attributes.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler  $element
+     * @return bool
+     */
+    protected function hasAttributes(Crawler $element)
+    {
+        foreach ($this->attributes as $name => $value) {
+            if (is_numeric($name)) {
+                if (is_null($element->attr($value))) {
+                    return false;
+                }
+            } else {
+                if ($element->attr($name) != $value) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        $message = "the element [{$this->selector}]";
+
+        if (! empty($this->attributes)) {
+            $message .= ' with the attributes '.json_encode($this->attributes);
+        }
+
+        return $message;
+    }
+}

--- a/src/BrowserKit/Constraints/HasInElement.php
+++ b/src/BrowserKit/Constraints/HasInElement.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit\Constraints;
+
+use Symfony\Component\DomCrawler\Crawler;
+
+class HasInElement extends PageConstraint
+{
+    /**
+     * The name or ID of the element.
+     *
+     * @var string
+     */
+    protected $element;
+
+    /**
+     * The text expected to be found.
+     *
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  string  $element
+     * @param  string  $text
+     * @return void
+     */
+    public function __construct($element, $text)
+    {
+        $this->text = $text;
+        $this->element = $element;
+    }
+
+    /**
+     * Check if the source or text is found within the element in the given crawler.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler|string  $crawler
+     * @return bool
+     */
+    public function matches($crawler)
+    {
+        $elements = $this->crawler($crawler)->filter($this->element);
+
+        $pattern = $this->getEscapedPattern($this->text);
+
+        foreach ($elements as $element) {
+            $element = new Crawler($element);
+
+            if (preg_match("/$pattern/i", $element->html())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the description of the failure.
+     *
+     * @return string
+     */
+    protected function getFailureDescription()
+    {
+        return sprintf('[%s] contains %s', $this->element, $this->text);
+    }
+
+    /**
+     * Returns the reversed description of the failure.
+     *
+     * @return string
+     */
+    protected function getReverseFailureDescription()
+    {
+        return sprintf('[%s] does not contain %s', $this->element, $this->text);
+    }
+}

--- a/src/BrowserKit/Constraints/HasLink.php
+++ b/src/BrowserKit/Constraints/HasLink.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit\Constraints;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\URL;
+
+class HasLink extends PageConstraint
+{
+    /**
+     * The text expected to be found.
+     *
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * The URL expected to be linked in the <a> tag.
+     *
+     * @var string|null
+     */
+    protected $url;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  string  $text
+     * @param  string|null  $url
+     * @return void
+     */
+    public function __construct($text, $url = null)
+    {
+        $this->url = $url;
+        $this->text = $text;
+    }
+
+    /**
+     * Check if the link is found in the given crawler.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler|string  $crawler
+     * @return bool
+     */
+    public function matches($crawler)
+    {
+        $links = $this->crawler($crawler)->selectLink($this->text);
+
+        if ($links->count() == 0) {
+            return false;
+        }
+
+        // If the URL is null we assume the developer only wants to find a link
+        // with the given text regardless of the URL. So if we find the link
+        // we will return true. Otherwise, we will look for the given URL.
+        if ($this->url == null) {
+            return true;
+        }
+
+        $absoluteUrl = $this->absoluteUrl();
+
+        foreach ($links as $link) {
+            $linkHref = $link->getAttribute('href');
+
+            if ($linkHref == $this->url || $linkHref == $absoluteUrl) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Add a root if the URL is relative (helper method of the hasLink function).
+     *
+     * @return string
+     */
+    protected function absoluteUrl()
+    {
+        if (! Str::startsWith($this->url, ['http', 'https'])) {
+            return URL::to($this->url);
+        }
+
+        return $this->url;
+    }
+
+    /**
+     * Returns the description of the failure.
+     *
+     * @return string
+     */
+    public function getFailureDescription()
+    {
+        $description = "has a link with the text [{$this->text}]";
+
+        if ($this->url) {
+            $description .= " and the URL [{$this->url}]";
+        }
+
+        return $description;
+    }
+
+    /**
+     * Returns the reversed description of the failure.
+     *
+     * @return string
+     */
+    protected function getReverseFailureDescription()
+    {
+        $description = "does not have a link with the text [{$this->text}]";
+
+        if ($this->url) {
+            $description .= " and the URL [{$this->url}]";
+        }
+
+        return $description;
+    }
+}

--- a/src/BrowserKit/Constraints/HasSource.php
+++ b/src/BrowserKit/Constraints/HasSource.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit\Constraints;
+
+class HasSource extends PageConstraint
+{
+    /**
+     * The expected HTML source.
+     *
+     * @var string
+     */
+    protected $source;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  string  $source
+     * @return void
+     */
+    public function __construct($source)
+    {
+        $this->source = $source;
+    }
+
+    /**
+     * Check if the source is found in the given crawler.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler|string  $crawler
+     * @return bool
+     */
+    protected function matches($crawler)
+    {
+        $pattern = $this->getEscapedPattern($this->source);
+
+        return preg_match("/{$pattern}/i", $this->html($crawler));
+    }
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return "the HTML [{$this->source}]";
+    }
+}

--- a/src/BrowserKit/Constraints/HasText.php
+++ b/src/BrowserKit/Constraints/HasText.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit\Constraints;
+
+class HasText extends PageConstraint
+{
+    /**
+     * The expected text.
+     *
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  string  $text
+     * @return void
+     */
+    public function __construct($text)
+    {
+        $this->text = $text;
+    }
+
+    /**
+     * Check if the plain text is found in the given crawler.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler|string  $crawler
+     * @return bool
+     */
+    protected function matches($crawler)
+    {
+        $pattern = $this->getEscapedPattern($this->text);
+
+        return preg_match("/{$pattern}/i", $this->text($crawler));
+    }
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return "the text [{$this->text}]";
+    }
+}

--- a/src/BrowserKit/Constraints/HasValue.php
+++ b/src/BrowserKit/Constraints/HasValue.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit\Constraints;
+
+use Symfony\Component\DomCrawler\Crawler;
+
+class HasValue extends FormFieldConstraint
+{
+    /**
+     * Get the valid elements.
+     *
+     * @return string
+     */
+    protected function validElements()
+    {
+        return 'input,textarea';
+    }
+
+    /**
+     * Check if the input contains the expected value.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler|string  $crawler
+     * @return bool
+     */
+    public function matches($crawler)
+    {
+        $crawler = $this->crawler($crawler);
+
+        return $this->getInputOrTextAreaValue($crawler) == $this->value;
+    }
+
+    /**
+     * Get the value of an input or textarea.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler  $crawler
+     * @return string
+     *
+     * @throws \PHPUnit_Framework_ExpectationFailedException
+     */
+    public function getInputOrTextAreaValue(Crawler $crawler)
+    {
+        $field = $this->field($crawler);
+
+        return $field->nodeName() == 'input'
+            ? $field->attr('value')
+            : $field->text();
+    }
+
+    /**
+     * Return the description of the failure.
+     *
+     * @return string
+     */
+    protected function getFailureDescription()
+    {
+        return sprintf(
+            'the field [%s] contains the expected value [%s]',
+            $this->selector, $this->value
+        );
+    }
+
+    /**
+     * Returns the reversed description of the failure.
+     *
+     * @return string
+     */
+    protected function getReverseFailureDescription()
+    {
+        return sprintf(
+            'the field [%s] does not contain the expected value [%s]',
+            $this->selector, $this->value
+        );
+    }
+}

--- a/src/BrowserKit/Constraints/IsChecked.php
+++ b/src/BrowserKit/Constraints/IsChecked.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit\Constraints;
+
+class IsChecked extends FormFieldConstraint
+{
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  string  $selector
+     * @return void
+     */
+    public function __construct($selector)
+    {
+        $this->selector = $selector;
+    }
+
+    /**
+     * Get the valid elements.
+     *
+     * @return string
+     */
+    protected function validElements()
+    {
+        return "input[type='checkbox']";
+    }
+
+    /**
+     * Determine if the checkbox is checked.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler|string  $crawler
+     * @return bool
+     */
+    public function matches($crawler)
+    {
+        $crawler = $this->crawler($crawler);
+
+        return ! is_null($this->field($crawler)->attr('checked'));
+    }
+
+    /**
+     * Return the description of the failure.
+     *
+     * @return string
+     */
+    protected function getFailureDescription()
+    {
+        return "the checkbox [{$this->selector}] is checked";
+    }
+
+    /**
+     * Returns the reversed description of the failure.
+     *
+     * @return string
+     */
+    protected function getReverseFailureDescription()
+    {
+        return "the checkbox [{$this->selector}] is not checked";
+    }
+}

--- a/src/BrowserKit/Constraints/IsSelected.php
+++ b/src/BrowserKit/Constraints/IsSelected.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit\Constraints;
+
+use DOMElement;
+use Symfony\Component\DomCrawler\Crawler;
+
+class IsSelected extends FormFieldConstraint
+{
+    /**
+     * Get the valid elements.
+     *
+     * @return string
+     */
+    protected function validElements()
+    {
+        return 'select,input[type="radio"]';
+    }
+
+    /**
+     * Determine if the select or radio element is selected.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler|string  $crawler
+     * @return bool
+     */
+    protected function matches($crawler)
+    {
+        $crawler = $this->crawler($crawler);
+
+        return in_array($this->value, $this->getSelectedValue($crawler));
+    }
+
+    /**
+     * Get the selected value of a select field or radio group.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler  $crawler
+     * @return array
+     *
+     * @throws \PHPUnit_Framework_ExpectationFailedException
+     */
+    public function getSelectedValue(Crawler $crawler)
+    {
+        $field = $this->field($crawler);
+
+        return $field->nodeName() == 'select'
+            ? $this->getSelectedValueFromSelect($field)
+            : [$this->getCheckedValueFromRadioGroup($field)];
+    }
+
+    /**
+     * Get the selected value from a select field.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler  $select
+     * @return array
+     */
+    protected function getSelectedValueFromSelect(Crawler $select)
+    {
+        $selected = [];
+
+        foreach ($select->children() as $option) {
+            if ($option->nodeName === 'optgroup') {
+                foreach ($option->childNodes as $child) {
+                    if ($child->hasAttribute('selected')) {
+                        $selected[] = $this->getOptionValue($child);
+                    }
+                }
+            } elseif ($option->hasAttribute('selected')) {
+                $selected[] = $this->getOptionValue($option);
+            }
+        }
+
+        return $selected;
+    }
+
+    /**
+     * Get the selected value from an option element.
+     *
+     * @param  \DOMElement  $option
+     * @return string
+     */
+    protected function getOptionValue(DOMElement $option)
+    {
+        if ($option->hasAttribute('value')) {
+            return $option->getAttribute('value');
+        }
+
+        return $option->textContent;
+    }
+
+    /**
+     * Get the checked value from a radio group.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler  $radioGroup
+     * @return string|null
+     */
+    protected function getCheckedValueFromRadioGroup(Crawler $radioGroup)
+    {
+        foreach ($radioGroup as $radio) {
+            if ($radio->hasAttribute('checked')) {
+                return $radio->getAttribute('value');
+            }
+        }
+    }
+
+    /**
+     * Returns the description of the failure.
+     *
+     * @return string
+     */
+    protected function getFailureDescription()
+    {
+        return sprintf(
+            'the element [%s] has the selected value [%s]',
+            $this->selector, $this->value
+        );
+    }
+
+    /**
+     * Returns the reversed description of the failure.
+     *
+     * @return string
+     */
+    protected function getReverseFailureDescription()
+    {
+        return sprintf(
+            'the element [%s] does not have the selected value [%s]',
+            $this->selector, $this->value
+        );
+    }
+}

--- a/src/BrowserKit/Constraints/PageConstraint.php
+++ b/src/BrowserKit/Constraints/PageConstraint.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit\Constraints;
+
+use PHPUnit_Framework_Constraint;
+use Symfony\Component\DomCrawler\Crawler;
+use SebastianBergmann\Comparator\ComparisonFailure;
+use PHPUnit_Framework_ExpectationFailedException as FailedExpection;
+
+abstract class PageConstraint extends PHPUnit_Framework_Constraint
+{
+    /**
+     * Make sure we obtain the HTML from the crawler or the response.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler|string  $crawler
+     * @return string
+     */
+    protected function html($crawler)
+    {
+        return is_object($crawler) ? $crawler->html() : $crawler;
+    }
+
+    /**
+     * Make sure we obtain the HTML from the crawler or the response.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler|string  $crawler
+     * @return string
+     */
+    protected function text($crawler)
+    {
+        return is_object($crawler) ? $crawler->text() : strip_tags($crawler);
+    }
+
+    /**
+     * Create a crawler instance if the given value is not already a Crawler.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler|string  $crawler
+     * @return \Symfony\Component\DomCrawler\Crawler
+     */
+    protected function crawler($crawler)
+    {
+        return is_object($crawler) ? $crawler : new Crawler($crawler);
+    }
+
+    /**
+     * Get the escaped text pattern for the constraint.
+     *
+     * @param  string  $text
+     * @return string
+     */
+    protected function getEscapedPattern($text)
+    {
+        $rawPattern = preg_quote($text, '/');
+
+        $escapedPattern = preg_quote(e($text), '/');
+
+        return $rawPattern == $escapedPattern
+            ? $rawPattern : "({$rawPattern}|{$escapedPattern})";
+    }
+
+    /**
+     * Throw an exception for the given comparison and test description.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler|string  $crawler
+     * @param  string  $description
+     * @param  \SebastianBergmann\Comparator\ComparisonFailure|null  $comparisonFailure
+     * @return void
+     *
+     * @throws \PHPUnit_Framework_ExpectationFailedException
+     */
+    protected function fail($crawler, $description, ComparisonFailure $comparisonFailure = null)
+    {
+        $html = $this->html($crawler);
+
+        $failureDescription = sprintf(
+            "%s\n\n\nFailed asserting that %s",
+            $html, $this->getFailureDescription()
+        );
+
+        if (! empty($description)) {
+            $failureDescription .= ": {$description}";
+        }
+
+        if (trim($html) != '') {
+            $failureDescription .= '. Please check the content above.';
+        } else {
+            $failureDescription .= '. The response is empty.';
+        }
+
+        throw new FailedExpection($failureDescription, $comparisonFailure);
+    }
+
+    /**
+     * Get the description of the failure.
+     *
+     * @return string
+     */
+    protected function getFailureDescription()
+    {
+        return 'the page contains '.$this->toString();
+    }
+
+    /**
+     * Returns the reversed description of the failure.
+     *
+     * @return string
+     */
+    protected function getReverseFailureDescription()
+    {
+        return 'the page does not contain '.$this->toString();
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * Placeholder method to avoid forcing definition of this method.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return '';
+    }
+}

--- a/src/BrowserKit/Constraints/ReversePageConstraint.php
+++ b/src/BrowserKit/Constraints/ReversePageConstraint.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit\Constraints;
+
+class ReversePageConstraint extends PageConstraint
+{
+    /**
+     * The page constraint instance.
+     *
+     * @var \Laravel\BrowserKitTesting\Constraints\PageConstraint
+     */
+    protected $pageConstraint;
+
+    /**
+     * Create a new reverse page constraint instance.
+     *
+     * @param  \Laravel\BrowserKitTesting\Constraints\PageConstraint  $pageConstraint
+     * @return void
+     */
+    public function __construct(PageConstraint $pageConstraint)
+    {
+        $this->pageConstraint = $pageConstraint;
+    }
+
+    /**
+     * Reverse the original page constraint result.
+     *
+     * @param  \Symfony\Component\DomCrawler\Crawler  $crawler
+     * @return bool
+     */
+    public function matches($crawler)
+    {
+        return ! $this->pageConstraint->matches($crawler);
+    }
+
+    /**
+     * Get the description of the failure.
+     *
+     * This method will attempt to negate the original description.
+     *
+     * @return string
+     */
+    protected function getFailureDescription()
+    {
+        return $this->pageConstraint->getReverseFailureDescription();
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return $this->pageConstraint->toString();
+    }
+}

--- a/src/BrowserKit/SupportsBrowserKit.php
+++ b/src/BrowserKit/SupportsBrowserKit.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit;
+
+use Symfony\Component\DomCrawler\Form;
+use Laravel\Dusk\BrowserKit\TestResponse;
+
+trait SupportsBrowserKit
+{
+    /**
+     * Visit the given URI with a GET request.
+     *
+     * @param  string  $uri
+     * @return $this
+     */
+    public function visit($uri)
+    {
+        return $this->makeRequest('GET', $uri);
+    }
+
+    /**
+     * Visit the given named route with a GET request.
+     *
+     * @param  string  $route
+     * @param  array  $parameters
+     * @return $this
+     */
+    public function visitRoute($route, $parameters = [])
+    {
+        return $this->makeRequest('GET', route($route, $parameters));
+    }
+
+    /**
+     * Make a request to the application and create a Crawler instance.
+     *
+     * @param  string  $method
+     * @param  string  $uri
+     * @param  array  $parameters
+     * @param  array  $cookies
+     * @param  array  $files
+     * @return $this
+     */
+    protected function makeRequest($method, $uri, $parameters = [], $cookies = [], $files = [])
+    {
+        //todo: do we need this here?
+        //$uri = $this->prepareUrlForRequest($uri);
+
+        $response = $this->call($method, $uri, $parameters, $cookies, $files);
+
+        $response = $this->followRedirects($response);
+
+        $response = TestResponse::fromBaseResponse($response);
+
+        $response->initialize($this);
+
+        $response->assertPageLoaded($uri);
+
+        return $response;
+    }
+
+    /**
+     * Follow redirects from the last response.
+     *
+     * @return $this
+     */
+    protected function followRedirects($response)
+    {
+        while ($response->isRedirect()) {
+            $response = $this->makeRequest('GET', $response->getTargetUrl());
+        }
+
+        return $response;
+    }
+}

--- a/src/BrowserKit/TestResponse.php
+++ b/src/BrowserKit/TestResponse.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Laravel\Dusk\BrowserKit;
+
+use Symfony\Component\DomCrawler\Crawler;
+use Laravel\Dusk\BrowserKit\Concerns\InteractsWithPages;
+use \Illuminate\Foundation\Testing\TestResponse as FoundationTestResponse;
+
+class TestResponse extends FoundationTestResponse
+{
+    use InteractsWithPages;
+
+    /**
+     * The current URL being viewed.
+     *
+     * @var string
+     */
+    protected $currentUri;
+
+    /**
+     * The DomCrawler instance.
+     *
+     * @var \Symfony\Component\DomCrawler\Crawler
+     */
+    protected $crawler;
+
+    /**
+     * Nested crawler instances used by the "within" method.
+     *
+     * @var array
+     */
+    protected $subCrawlers = [];
+
+    /**
+     * All of the stored inputs for the current page.
+     *
+     * @var array
+     */
+    protected $inputs = [];
+
+    /**
+     * All of the stored uploads for the current page.
+     *
+     * @var array
+     */
+    protected $uploads = [];
+
+    /**
+     * Set the current URI and initialize the crawler
+     *
+     * @param  string  $currentUri
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function initialize($currentUri)
+    {
+        $this->crawler = new Crawler($this->getContent(), $currentUri);
+
+        $this->currentUri = $currentUri;
+
+        return $this;
+    }
+}

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -8,12 +8,13 @@ use Throwable;
 use ReflectionFunction;
 use Illuminate\Support\Collection;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Laravel\Dusk\BrowserKit\SupportsBrowserKit;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Illuminate\Foundation\Testing\TestCase as FoundationTestCase;
 
 abstract class TestCase extends FoundationTestCase
 {
-    use SupportsChrome;
+    use SupportsChrome, SupportsBrowserKit;
 
     /**
      * All of the active browser instances.


### PR DESCRIPTION
While testing JS is super awesome! It's not as fast as our old friend PHP browser kit.

That's why I'm trying to add support for Browser kit in Dusk so the developer can write and run fast tests when JS is not required/crucial. For example for static or simple pages.

The idea is to support most of the methods and the same API in the browser kit. 

The browser kit is a test response decorator similar to the one included in 5.4 but with the crawler and more methods.

My idea for the usage so far is this:

Full web driver:

```
$this->browse(function ($browser) {
    $browser->visit(...)->assertSee(...); 
});
```

Browser kit:

`$this->visit(...)->assertSee(...)`

This is just a WIP, as most of the methods are not working at the moment. 