### PR TITLE
remove non-existing class

### DIFF
--- a/stubs/ExampleTest.php
+++ b/stubs/ExampleTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Browser;
 
 use Tests\DuskTestCase;
-use Laravel\Dusk\Chrome;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class ExampleTest extends DuskTestCase


### PR DESCRIPTION
Laravel\Dusk\Chrome is not used and does not exists.