### PR TITLE
Use consistent php binary for running dusk tests

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -46,7 +46,7 @@ class DuskCommand extends Command
         $options = implode(' ', array_slice($_SERVER['argv'], 2));
         $phpCommand = PHP_BINARY ?: 'php';
 
-        $this->withDuskEnvironment(function () use ($options) {
+        $this->withDuskEnvironment(function () use ($options, $phpCommand) {
             (new Process(trim($phpCommand . ' vendor/bin/phpunit -c "'.base_path('phpunit.dusk.xml').'" '.$options), base_path(), []))
                     ->setTty(true)
                     ->run(function ($type, $line) {

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -46,7 +46,7 @@ class DuskCommand extends Command
         $options = implode(' ', array_slice($_SERVER['argv'], 2));
 
         $this->withDuskEnvironment(function () use ($options) {
-            (new Process(trim(PHP_BINARY . ' vendor/bin/phpunit -c "'.base_path('phpunit.dusk.xml').'" '.$options), base_path(), []))
+            (new Process(trim(PHP_BINARY.' vendor/bin/phpunit -c "'.base_path('phpunit.dusk.xml').'" '.$options), base_path(), []))
                     ->setTty(true)
                     ->run(function ($type, $line) {
                         $this->output->write($line);

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -44,10 +44,9 @@ class DuskCommand extends Command
         $this->purgeScreenshots();
 
         $options = implode(' ', array_slice($_SERVER['argv'], 2));
-        $phpCommand = PHP_BINARY ?: 'php';
 
-        $this->withDuskEnvironment(function () use ($options, $phpCommand) {
-            (new Process(trim($phpCommand . ' vendor/bin/phpunit -c "'.base_path('phpunit.dusk.xml').'" '.$options), base_path(), []))
+        $this->withDuskEnvironment(function () use ($options) {
+            (new Process(trim(PHP_BINARY . ' vendor/bin/phpunit -c "'.base_path('phpunit.dusk.xml').'" '.$options), base_path(), []))
                     ->setTty(true)
                     ->run(function ($type, $line) {
                         $this->output->write($line);

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -44,9 +44,10 @@ class DuskCommand extends Command
         $this->purgeScreenshots();
 
         $options = implode(' ', array_slice($_SERVER['argv'], 2));
+        $phpCommand = PHP_BINARY ?: 'php';
 
         $this->withDuskEnvironment(function () use ($options) {
-            (new Process(trim('php vendor/bin/phpunit -c "'.base_path('phpunit.dusk.xml').'" '.$options), base_path(), []))
+            (new Process(trim($phpCommand . ' vendor/bin/phpunit -c "'.base_path('phpunit.dusk.xml').'" '.$options), base_path(), []))
                     ->setTty(true)
                     ->run(function ($type, $line) {
                         $this->output->write($line);


### PR DESCRIPTION
When trying to get dusk tests running on codeship, I ran into a problem where the php that was being triggered from the Process was call not consistent with the php binary I was using to run the command. This pull request tackles this by making using of the ```PHP_BINARY``` constant to use the same version of php.

I wrote this defensively as I wasn't sure if there might be circumstances under which the ```PHP_BINARY``` constant was not set.