### PR TITLE
Force config:cache for enviroment file change

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -80,6 +80,7 @@ class DuskCommand extends Command
     {
         if (file_exists(base_path($this->duskFile()))) {
             $this->backupEnvironment();
+            \Artisan::call('config:cache');
         }
 
         $this->writeConfiguration();
@@ -90,6 +91,7 @@ class DuskCommand extends Command
 
         if (file_exists(base_path($this->duskFile()))) {
             $this->restoreEnvironment();
+            \Artisan::call('config:cache');
         }
     }
 


### PR DESCRIPTION
The .env.dusk or .env.dusk[enviroment] do not create a new file and by default the .env when I ran php artisan dusk.

I'm using Fedora v24. This PR fixed my problem so I think  could solve it to others.