### PR TITLE
Use an authentication token for Dusk login

### DIFF
--- a/src/Concerns/InteractsWithAuthentication.php
+++ b/src/Concerns/InteractsWithAuthentication.php
@@ -6,6 +6,8 @@ use Laravel\Dusk\Browser;
 
 trait InteractsWithAuthentication
 {
+    use ManagesAuthenticationTokens;
+
     /**
      * Log into the application as the default user.
      *
@@ -26,7 +28,9 @@ trait InteractsWithAuthentication
     {
         $userId = method_exists($userId, 'getKey') ? $userId->getKey() : $userId;
 
-        return $this->visit('/_dusk/login/'.$userId);
+        $token = $this->generateAuthToken($userId);
+
+        return $this->visit('/_dusk/login/'.$userId.'?token='.$token);
     }
 
     /**

--- a/src/Concerns/ManagesAuthenticationTokens.php
+++ b/src/Concerns/ManagesAuthenticationTokens.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * (c) CAMC Ltd.
+ * @author: Mike Smith <mike.smith@camc-ltd.co.uk>
+ */
+
+namespace Laravel\Dusk\Concerns;
+
+use Illuminate\Support\Facades\Storage;
+
+trait ManagesAuthenticationTokens
+{
+    protected static $keyPrefix = 'Dusk-authToken-';
+
+    /**
+     * @param $userId
+     * @return string
+     */
+    public function generateAuthToken($userId)
+    {
+        $token = str_random(40);
+        Storage::disk('local')->put(static::$keyPrefix.$userId, $token);
+        return $token;
+    }
+
+    /**
+     * @param $userId
+     * @param $token
+     * @return bool
+     */
+    public function verifyAuthToken($userId, $token)
+    {
+        if (Storage::disk('local')->get(static::$keyPrefix.$userId) === $token) {
+            Storage::disk('local')->delete(static::$keyPrefix.$userId);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Concerns/ManagesAuthenticationTokens.php
+++ b/src/Concerns/ManagesAuthenticationTokens.php
@@ -6,6 +6,7 @@
 
 namespace Laravel\Dusk\Concerns;
 
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Facades\Storage;
 
 trait ManagesAuthenticationTokens
@@ -30,10 +31,15 @@ trait ManagesAuthenticationTokens
      */
     public function verifyAuthToken($userId, $token)
     {
-        if (Storage::disk('local')->get(static::$keyPrefix.$userId) === $token) {
-            Storage::disk('local')->delete(static::$keyPrefix.$userId);
-            return true;
+        try {
+            if (Storage::disk('local')->get(static::$keyPrefix.$userId) === $token) {
+                Storage::disk('local')->delete(static::$keyPrefix.$userId);
+                return true;
+            }
+        } catch (FileNotFoundException $e) {
+            return false;
         }
+
         return false;
     }
 }

--- a/src/Http/Controllers/LoginController.php
+++ b/src/Http/Controllers/LoginController.php
@@ -18,11 +18,9 @@ class LoginController
      */
     public function login($userId)
     {
-        \Log::debug('here');
         if (!$this->verifyAuthToken($userId, request('token'))) {
             throw new AuthenticationException('Invalid Dusk Token for userId');
         }
-        \Log::debug('somehow');
 
         $model = config('auth.providers.users.model');
 

--- a/src/Http/Controllers/LoginController.php
+++ b/src/Http/Controllers/LoginController.php
@@ -2,18 +2,28 @@
 
 namespace Laravel\Dusk\Http\Controllers;
 
+use Illuminate\Auth\AuthenticationException;
+use Laravel\Dusk\Concerns\ManagesAuthenticationTokens;
 use Illuminate\Support\Facades\Auth;
 
 class LoginController
 {
+    use ManagesAuthenticationTokens;
     /**
      * Login using the given user ID / email.
      *
      * @param  string  $userId
      * @return Response
+     * @throws AuthenticationException
      */
     public function login($userId)
     {
+        \Log::debug('here');
+        if (!$this->verifyAuthToken($userId, request('token'))) {
+            throw new AuthenticationException('Invalid Dusk Token for userId');
+        }
+        \Log::debug('somehow');
+
         $model = config('auth.providers.users.model');
 
         if (str_contains($userId, '@')) {


### PR DESCRIPTION
As noted in issue #57, I am concerned about the possibility of exposing the dusk login controller in an inappropriate environment and thereby having a security hole out in the wild. To this end, I have implemented an extension to the login process, where the ```InteractsWithAuthentication``` trait will store a token on the file system that the ```LoginController``` can verify for the given user.

The rationale behind this is that the token is generated in the backend, and thereby is not accessible for any would be attacker. Additionally, the token store is removed after use so that it cannot be accidentally left on a filesystem.

I had planned to use the cache, but testing revealed that the cache file was not being written by the test process until after the request was made, so this wasn't appropriate for sharing with the web server process. The additional advantage of using the file approach is that we are not dependent on the cache system not being configured for using an in memory scheme.

There may be better approaches to this (I was wondering about injecting an appropriate session variable into the browser request), but this seemed like the least invasive approach I could take that would mitigate the risk I am concerned with.