### PR TITLE
Fixed missing semicolon.

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -15,8 +15,8 @@ class Browser
         Concerns\InteractsWithElements,
         Concerns\InteractsWithMouse,
         Concerns\MakesAssertions,
-        Concerns\WaitsForElements,
-        Macroable {
+        Concerns\WaitsForElements;
+    use Macroable {
             __call as macroCall;
         }
 


### PR DESCRIPTION
There seems to be a problem with IDE and parsing the information when there was no semicolon ending the use statements. It seems when it's split in two use statements the problem is gone.