### PR TITLE
Fix running tests in Linux

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -66,7 +66,7 @@ class DuskCommand extends Command
      */
     protected function binary()
     {
-        return PHP_OS === 'WINNT' ? base_path('vendor\bin\phpunit.bat') : PHP_BINARY;
+        return PHP_OS === 'WINNT' ? base_path('vendor\bin\phpunit.bat') : 'vendor/bin/phpunit';
     }
 
     /**
@@ -76,13 +76,7 @@ class DuskCommand extends Command
      */
     protected function phpunitArguments($options)
     {
-        $executable = [];
-
-        if (PHP_OS !== 'WINNT') {
-            $executable = ['vendor/bin/phpunit'];
-        }
-
-        return array_merge($executable, [
+        return array_merge([], [
             '-c', base_path('phpunit.dusk.xml'), $options
         ]);
     }


### PR DESCRIPTION
When running `php artisan dusk` command in current release I'm getting displayed content of `vendor/bin/phpunit` file instead of running it. I'm using Docker container on Windows host (running Dusk in Docker container). 

I've verified this after SSH into container and the problem is like this:

When I run `vendor/bin/phpunit` commands test are executed without any problem but when I run `php vendor/bin/phpunit` I'm getting the content of `vendor/bin/phpunit` file. This is exactly what DuskCommand does at the moment (it runs `php vendor/bin/phpunit` instead of `vendor/bin/phpunit`).

If decided to approve, I would recommend to test if it doesn't break anything when running in native Linux OS and in Mac OS.

The problem was also noticed here: https://github.com/laravel/dusk/issues/50