### PR TITLE
Reload environment to use valid environment variables in tests

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Dusk\Console;
 
+use Dotenv\Dotenv;
 use Illuminate\Console\Command;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
@@ -107,6 +108,7 @@ class DuskCommand extends Command
     {
         if (file_exists(base_path($this->duskFile()))) {
             $this->backupEnvironment();
+            $this->reloadEnvironment();
         }
 
         $this->writeConfiguration();
@@ -118,6 +120,14 @@ class DuskCommand extends Command
         if (file_exists(base_path($this->duskFile()))) {
             $this->restoreEnvironment();
         }
+    }
+
+    /**
+     * Reload environment to use valid environment variables. 
+     */
+    protected function reloadEnvironment()
+    {
+        (new Dotenv(base_path()))->overload();
     }
 
     /**


### PR DESCRIPTION
At the moment I think it's working the wrong way when you have custom dusk .env file.

For example if you define in `.env` file 

```
APP_URL=http://abc.app 
```

and in `.env.dusk.local` you will define:

```
APP_URL=http://def.app 
```

Dusk will try to open `http://abc.app` url and not `http://def.app`. Also other settings will be used from original `.env` file and not from  `.env.dusk.local` so in case you use any of them in assertions, assertions will fail because tests and app is using now 2 different .env files in such case