### PR TITLE
Adding type hint in ExampleTest.php stub

### DIFF
--- a/stubs/ExampleTest.php
+++ b/stubs/ExampleTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Browser;
 
-use Laravel\Dusk\Browser;
 use Tests\DuskTestCase;
+use Laravel\Dusk\Browser;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class ExampleTest extends DuskTestCase

--- a/stubs/ExampleTest.php
+++ b/stubs/ExampleTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Browser;
 
+use Laravel\Dusk\Browser;
 use Tests\DuskTestCase;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
@@ -14,7 +15,7 @@ class ExampleTest extends DuskTestCase
      */
     public function testBasicExample()
     {
-        $this->browse(function ($browser) {
+        $this->browse(function (Browser $browser) {
             $browser->visit('/')
                     ->assertSee('Laravel');
         });


### PR DESCRIPTION
I think adding `Browser` type hint in `ExampleTest.php` stub will help in two ways:

 - Auto-completion for IDE
 - Better understanding for users ("what is `$browser` variable?", "what method can I call on this variable?")