### PR TITLE
Add ability to check/uncheck checkboxes by value, allowing multi checkboxes

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -211,11 +211,12 @@ trait InteractsWithElements
      * Check the given checkbox.
      *
      * @param  string  $field
+     * @param  string  $value
      * @return $this
      */
-    public function check($field)
+    public function check($field, $value = null)
     {
-        $element = $this->resolver->resolveForChecking($field);
+        $element = $this->resolver->resolveForChecking($field, $value);
 
         if (! $element->isSelected()) {
             $element->click();
@@ -228,11 +229,12 @@ trait InteractsWithElements
      * Uncheck the given checkbox.
      *
      * @param  string  $field
+     * @param  string  $value
      * @return $this
      */
-    public function uncheck($field)
+    public function uncheck($field, $value = null)
     {
-        $element = $this->resolver->resolveForChecking($field);
+        $element = $this->resolver->resolveForChecking($field, $value);
 
         if ($element->isSelected()) {
             $element->click();

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -274,11 +274,12 @@ JS;
      * Assert that the given checkbox field is checked.
      *
      * @param  string  $field
+     * @param  string  $value
      * @return $this
      */
-    public function assertChecked($field)
+    public function assertChecked($field, $value = null)
     {
-        $element = $this->resolver->resolveForChecking($field);
+        $element = $this->resolver->resolveForChecking($field, $value);
 
         PHPUnit::assertTrue(
             $element->isSelected(),
@@ -292,11 +293,12 @@ JS;
      * Assert that the given checkbox field is not checked.
      *
      * @param  string  $field
+     * @param  string  $value
      * @return $this
      */
-    public function assertNotChecked($field)
+    public function assertNotChecked($field, $value = null)
     {
-        $element = $this->resolver->resolveForChecking($field);
+        $element = $this->resolver->resolveForChecking($field, $value);
 
         PHPUnit::assertFalse(
             $element->isSelected(),

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -128,16 +128,23 @@ class ElementResolver
      * Resolve the element for a given checkbox "field".
      *
      * @param  string  $field
+     * @param  string  $value
      * @return \Facebook\WebDriver\Remote\RemoteWebElement
      */
-    public function resolveForChecking($field)
+    public function resolveForChecking($field, $value = null)
     {
         if (! is_null($element = $this->findById($field))) {
             return $element;
         }
 
+        $selector = "input[type=checkbox][name='{$field}']";
+
+        if (! is_null($value)) {
+            $selector .= "[value='{$value}']";
+        }
+
         return $this->firstOrFail([
-            $field, "input[type=checkbox][name={$field}]"
+            $field, $selector
         ]);
     }
 


### PR DESCRIPTION
If you have more than one checkbox with the same name, but different values e.g.
```html
<input type="checkbox" name="foo[]" value="bar">
<input type="checkbox" name="foo[]" value="baz">
```
this change allows you to pass a second parameter to `check`, `uncheck`, `assertChecked` and `assertNotChecked` that lets you target the second checkbox
```php
$browser->check('foo[]', 'baz');
```