### PR TITLE
Save Browser console logs on failure

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -7,6 +7,7 @@ use BadMethodCallException;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Facebook\WebDriver\WebDriverDimension;
+use Laravel\Dusk\Helpers\ConsoleLogFormatter;
 
 class Browser
 {
@@ -33,6 +34,13 @@ class Browser
      * @var string
      */
     public static $storeScreenshotsAt;
+
+    /**
+     * The directory that will contain any JavaScript console logs.
+     *
+     * @var string
+     */
+    public static $storeConsoleLogsAt;    
 
     /**
      * Get the callback which resolves the default user to authenticate.
@@ -187,6 +195,30 @@ class Browser
         );
 
         return $this;
+    }
+
+    /**
+     * Store JavaScript console logs with given name.
+     *
+     * @param string $name
+     */
+    public function saveConsoleLogs($name)
+    {
+        $formatter = new ConsoleLogFormatter();
+
+        file_put_contents(
+            sprintf('%s/%s', rtrim(static::$storeConsoleLogsAt, '/'), $name),
+            $formatter->get($this->consoleLogs()));        
+    }
+
+    /**
+     * Get JavaScript console logs.
+     *
+     * @return array
+     */
+    protected function consoleLogs()
+    {
+        return $this->driver->manage()->getLog('browser');   
     }
 
     /**

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -44,6 +44,7 @@ class DuskCommand extends Command
     public function handle()
     {
         $this->purgeScreenshots();
+        $this->purgeConsoleLogs();
 
         $options = implode(' ', array_slice($_SERVER['argv'], 2));
 
@@ -92,6 +93,22 @@ class DuskCommand extends Command
         $files = Finder::create()->files()
                         ->in(base_path('tests/Browser/screenshots'))
                         ->name('failure-*');
+
+        foreach ($files as $file) {
+            @unlink($file->getRealPath());
+        }
+    }
+
+    /**
+     * Purge the failure JavaScript console logs
+     *
+     * @return void
+     */
+    protected function purgeConsoleLogs()
+    {
+        $files = Finder::create()->files()
+            ->in(base_path('tests/Browser/jsconsole'))
+            ->name('failure-*');
 
         foreach ($files as $file) {
             @unlink($file->getRealPath());

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -45,14 +45,17 @@ class InstallCommand extends Command
             mkdir(base_path('tests/Browser/screenshots'), 0755, true);
         }
 
+        if (! is_dir(base_path('tests/Browser/jsconsole'))) {
+            mkdir(base_path('tests/Browser/jsconsole'), 0755, true);
+        }
+
         copy(__DIR__.'/../../stubs/ExampleTest.php', base_path('tests/Browser/ExampleTest.php'));
         copy(__DIR__.'/../../stubs/HomePage.php', base_path('tests/Browser/Pages/HomePage.php'));
         copy(__DIR__.'/../../stubs/DuskTestCase.php', base_path('tests/DuskTestCase.php'));
         copy(__DIR__.'/../../stubs/Page.php', base_path('tests/Browser/Pages/Page.php'));
 
-        file_put_contents(base_path('tests/Browser/screenshots/.gitignore'), '*
-!.gitignore
-');
+        file_put_contents(base_path('tests/Browser/screenshots/.gitignore'), "*\n!.gitignore");
+        file_put_contents(base_path('tests/Browser/jsconsole/.gitignore'), "*\n!.gitignore");
 
         $this->info('Dusk scaffolding installed successfully.');
     }

--- a/src/Helpers/ConsoleLogFormatter.php
+++ b/src/Helpers/ConsoleLogFormatter.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Laravel\Dusk\Helpers;
+
+class ConsoleLogFormatter
+{
+    /**
+     * Get formatted logs
+     *
+     * @param array $logs
+     *
+     * @return string
+     */
+    public function get(array $logs)
+    {
+        $output = [];
+        foreach ($logs as $index => $record) {
+            $output[] = $this->formatRecord($record, $index);
+        }
+
+        return implode("\n", $output);
+    }
+
+    /**
+     * Get formatted single log record
+     *
+     * @param array $log
+     * @param int $index
+     *
+     * @return string
+     */
+    protected function formatRecord(array $log, $index)
+    {
+        return sprintf("%s. %s (%s) on %s\n%s\n-------",
+            $index + 1,
+            ! empty($log['level']) ? ucfirst(strtolower($log['level'])) : '',
+            ! empty($log['source']) ? $log['source'] : '',
+            ! empty($log['timestamp']) ? date('Y-m-d H:i:s',
+                (int)round($log['timestamp'] / 1000.0)) : '',
+            ! empty($log['message']) ? trim(str_replace('\n', "\n", $log['message'])) : ''
+        );
+    }
+}

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -40,6 +40,7 @@ abstract class TestCase extends FoundationTestCase
         Browser::$baseUrl = $this->baseUrl();
 
         Browser::$storeScreenshotsAt = base_path('tests/Browser/screenshots');
+        Browser::$storeConsoleLogsAt = base_path('tests/Browser/jsconsole');
 
         Browser::$userResolver = function () {
             return $this->user();
@@ -141,6 +142,7 @@ abstract class TestCase extends FoundationTestCase
     {
         $browsers->each(function ($browser, $key) {
             $browser->screenshot('failure-'.$this->getName().'-'.$key);
+            $browser->saveConsoleLogs('failure-'.$this->getName().'-'.$key.'.txt');
         });
     }
 


### PR DESCRIPTION
As requested https://github.com/laravel/dusk/issues/77 it might be very useful to see actual console logs to know what happened