### PR TITLE
Fix DuskTestCase not found in upgraded Laravel installation

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -45,6 +45,10 @@ class InstallCommand extends Command
             mkdir(base_path('tests/Browser/screenshots'), 0755, true);
         }
 
+        if (! file_exists(base_path('tests/CreatesApplication.php'))) {
+            copy(__DIR__.'/../../stubs/CreatesApplication.php', base_path('tests/CreatesApplication.php'));
+        }
+
         copy(__DIR__.'/../../stubs/ExampleTest.php', base_path('tests/Browser/ExampleTest.php'));
         copy(__DIR__.'/../../stubs/HomePage.php', base_path('tests/Browser/Pages/HomePage.php'));
         copy(__DIR__.'/../../stubs/DuskTestCase.php', base_path('tests/DuskTestCase.php'));

--- a/stubs/CreatesApplication.php
+++ b/stubs/CreatesApplication.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    /**
+     * Creates the application.
+     *
+     * @return \Illuminate\Foundation\Application
+     */
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}


### PR DESCRIPTION
If Laravel is upgraded from previous version in a project, running `php artisan dusk` would throw the following error:

    PHP Fatal error:  Class 'Tests\DuskTestCase' not found in /var/www/html/projectname/tests/Browser/ExampleTest.php on line 9

Even though the file `DuskTestCase` exists, the issue is that `CreatesApplication` trait which is used in the class wasn't present in previous versions of Laravel. So if it doesn't exists then create it.

Also in the `composer.json` file, the following needs to be present.

    "autoload-dev": {
        "psr-4": {
            "Tests\\": "tests/"
        }
    },

I think that should be mentioned in the Laravel upgrade guide or Dusk installation.