### PR TITLE
Add assertQueryIs and assertFragmentIs

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -50,6 +50,45 @@ trait MakesAssertions
 
         return $this;
     }
+    
+    
+    /**
+     * Assert that the current URL query matches the given query.
+     *
+     * @param  string  $query
+     * @return $this
+     */
+    public function assertQueryIs($query)
+    {
+        $url = parse_url($this->driver->getCurrentURL());
+
+        if(!isset($url['query'])) {
+            $url['query'] = '';
+        }
+
+        PHPUnit::assertEquals($query, $url['query']);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the current URL fragment matches the given fragment.
+     *
+     * @param  string  $fragment
+     * @return $this
+     */
+    public function assertFragmentIs($fragment)
+    {
+        $url = parse_url($this->driver->getCurrentURL());
+
+        if(!isset($url['fragment'])) {
+            $url['fragment'] = '';
+        }
+
+        PHPUnit::assertEquals($fragment, $url['fragment']);
+
+        return $this;
+    }
 
     /**
      * Assert that the given cookie is present.


### PR DESCRIPTION
This provides two more assertions for the URL.
- `assertQueryIs`
- `assertFragmentIs`

Using `parse_url` function, an example URL `http://app.dev/foo?bar=baz#qux` will be split up into
```php
[
  "scheme" => "http"
  "host" => "app.dev"
  "path" => "/foo"
  "query" => "bar=baz"
  "fragment" => "qux"
]
```
Currently existing `assertPathIs` method allows only for assertion of the `path` substring and there may be situations where we need to check for other parts of the URL.

If the `query` part is not present, it is treated as an empty string, which allows for following:
```php
$browser->assertQueryIs('');
// or
$browser->assertQueryIs(null);
```
when we need to check if the query is empty. Same with `fragment`.