### PR TITLE
Add InteractWithJavascript trait

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -16,6 +16,7 @@ class Browser
         Concerns\InteractsWithMouse,
         Concerns\MakesAssertions,
         Concerns\WaitsForElements,
+        Concerns\InteractsWithJavascript,
         Macroable {
             __call as macroCall;
         }

--- a/src/Concerns/InteractsWithJavascript.php
+++ b/src/Concerns/InteractsWithJavascript.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Dusk\Concerns;
+
+trait InteractsWithJavascript
+{
+    /**
+     * Execute single or multiple Javascript code
+     *
+     * @param string|array $scripts
+     * @return $this
+     */
+    public function executeScripts($scripts)
+    {
+        $this->ensurejQueryIsAvailable();
+
+        if (is_array($scripts)) {
+            foreach ($scripts as $script) {
+                $this->driver->executeScript($script);
+            }
+
+            return $this;
+        }
+
+        $this->driver->executeScript($scripts);
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Sometimes in order to reproduce an error, you need to run certain Javascript commands to make it happen. On top of that, running Javascript gives an opportunity to use Laravel Dusk as browser automation for other tasks. That said, I added InteractWithJavascript trait which let you run single or multiple Javascript codes in your chain.
