### PR TITLE
Accept relative or absolute URLs in the assert path is method

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -44,9 +44,10 @@ trait MakesAssertions
      */
     public function assertPathIs($path)
     {
-        PHPUnit::assertEquals($path, parse_url(
+        PHPUnit::assertEquals(
+            $this->normalizeUrl($path),
             $this->driver->getCurrentURL()
-        )['path']);
+        );
 
         return $this;
     }
@@ -424,5 +425,24 @@ JS;
         );
 
         return $this;
+    }
+
+    /**
+     * Turn the given URI into a fully qualified URL.
+     *
+     * @param  string  $uri
+     * @return string
+     */
+    protected function normalizeUrl($uri)
+    {
+        if (! Str::startsWith($uri, 'http')) {
+            if (! Str::startsWith($uri, '/')) {
+                $uri = '/'.$uri;
+            }
+
+            $uri = config('app.url').$uri;
+        }
+
+        return $uri;
     }
 }


### PR DESCRIPTION
This change makes the `assertPathIs` method more versatile: 

```
                ->assertPathIs("/post/{$post->slug}")
                ->assertPathIs("post/{$post->slug}")
                ->assertPathIs("http://forum.app/post/{$post->slug}")
                ->assertPathIs(route('posts.show', [$post->slug]));
```