### PR TITLE
Add the assert route is method.

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -52,6 +52,18 @@ trait MakesAssertions
     }
 
     /**
+     * Assert that the current URL path matches the given route.
+     *
+     * @param  string  $route
+     * @param  array  $parameters
+     * @return $this
+     */
+    public function assertRouteIs($route, $parameters = [])
+    {
+        return $this->assertPathIs(route($route, $parameters, false));
+    }
+
+    /**
      * Assert that the given cookie is present.
      *
      * @param  string  $name


### PR DESCRIPTION
So we can write this:

`->assertRouteIs('posts.show', [$post->id, $post->slug];`

Instead of this:

`->assertRouteIs(route('posts.show', [$post->id, $post->slug], false));`

So we don't have to hard code the urls in the tests (if we are using route names) and also since `assertPathIs` only accepts relative URLs at the moment, this is better so we don't have to remind adding the `false` parameter at the end of the route function every time.