### PR TITLE
Add assert code has and assert code missing methods

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -164,6 +164,34 @@ trait MakesAssertions
     }
 
     /**
+     * Assert that the given source code is present on the page.
+     *
+     * @param  string  $code
+     * @return $this
+     */
+    public function assertSourceHas($code)
+    {
+        PHPUnit::assertContains(
+            $code, $this->driver->getPageSource(),
+            "Did not find expected source code [$code]"
+        );
+    }
+
+    /**
+     * Assert that the given source code is not present on the page.
+     *
+     * @param  string  $code
+     * @return $this
+     */
+    public function assertSourceMissing($code)
+    {
+        PHPUnit::assertNotContains(
+            $code, $this->driver->getPageSource(),
+            "Found unexpected source code [$code]"
+        );
+    }
+
+    /**
      * Assert that the given link is visible.
      *
      * @param  string  $link


### PR DESCRIPTION
I have some tests with the old browser kit to make sure the content of a post was converted from markdown to valid and escaped HTML. So I tried to reproduce the test with Dusk:

```
            $browser->visit($post->url)
                ->assertSee($xssAttack)  // see the plain text
                ->assertCodeMissing($xssAttack); // but not the HTML code (because it was escaped)
```

I'll leave this PR in case you find it useful.