### PR TITLE
Changed argument parsing to separate parameters

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -45,7 +45,7 @@ class DuskCommand extends Command
     {
         $this->purgeScreenshots();
 
-        $options = implode(' ', array_slice($_SERVER['argv'], 2));
+        $options = array_slice($_SERVER['argv'], 2);
 
         return $this->withDuskEnvironment(function () use ($options) {
             return (new ProcessBuilder())
@@ -77,9 +77,7 @@ class DuskCommand extends Command
      */
     protected function phpunitArguments($options)
     {
-        return array_merge([], [
-            '-c', base_path('phpunit.dusk.xml'), $options
-        ]);
+        return ['-c', base_path('phpunit.dusk.xml')] + $options;
     }
 
     /**


### PR DESCRIPTION
It seems the argument parsing did not quite work as I expected. I was trying to add the parameter `--log-junit build/log.xml` which I hoped would be passed through to to PhpUnit like the docs suggested. 

Unfortunately it seems because it was being imploded it was being parsed to the `ProcessBuilder` as below which caused the following error `unrecognized option --log-junit junit.xml`
```php
array:3 [
  0 => "-c"
  1 => "/var/www/html/phpunit.dusk.xml"
  2 => "--log-junit junit.xml"
]
```
By making these changes it is now able to separate the arguments and the command works.
```php
array:4 [
  0 => "-c"
  1 => "/var/www/html/phpunit.dusk.xml"
  2 => "--log-junit"
  3 => "junit.xml"
]
```

I also changed the array merge because I am not sure it was being used properly before and so I changed it to do an array union to add the defaults to the custom options.

If you think I am doing this wrong just let me know.