### PR TITLE
Store the HTML output of the failed tests.

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -36,6 +36,13 @@ class Browser
     public static $storeScreenshotsAt;
 
     /**
+     * The directory that will contain any source codes.
+     *
+     * @var string
+     */
+    public static $storeOutputAt;
+
+    /**
      * Get the callback which resolves the default user to authenticate.
      *
      * @var \Closure
@@ -197,6 +204,21 @@ class Browser
     {
         $this->driver->takeScreenshot(
             sprintf('%s/%s.png', rtrim(static::$storeScreenshotsAt, '/'), $name)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Store the page source.
+     *
+     * @param $name
+     */
+    public function storeOutput($name)
+    {
+        file_put_contents(
+            sprintf('%s/%s.html', rtrim(static::$storeOutputAt, '/'), $name),
+            $this->driver->getPageSource()
         );
 
         return $this;

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -43,7 +43,7 @@ class DuskCommand extends Command
      */
     public function handle()
     {
-        $this->purgeScreenshots();
+        $this->purgeScreenshotsAndOutput();
 
         $options = implode(' ', array_slice($_SERVER['argv'], 2));
 
@@ -83,14 +83,17 @@ class DuskCommand extends Command
     }
 
     /**
-     * Purge the failure screenshots
+     * Purge the failure screenshots and source codes.
      *
      * @return void
      */
-    protected function purgeScreenshots()
+    protected function purgeScreenshotsAndOutput()
     {
         $files = Finder::create()->files()
-                        ->in(base_path('tests/Browser/screenshots'))
+                        ->in([
+                            base_path('tests/Browser/screenshots'),
+                            base_path('tests/Browser/output'),
+                        ])
                         ->name('failure-*');
 
         foreach ($files as $file) {

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -45,14 +45,22 @@ class InstallCommand extends Command
             mkdir(base_path('tests/Browser/screenshots'), 0755, true);
         }
 
+        if (! is_dir(base_path('tests/Browser/output'))) {
+            mkdir(base_path('tests/Browser/output'), 0755, true);
+        }
+
         copy(__DIR__.'/../../stubs/ExampleTest.stub', base_path('tests/Browser/ExampleTest.php'));
         copy(__DIR__.'/../../stubs/HomePage.stub', base_path('tests/Browser/Pages/HomePage.php'));
         copy(__DIR__.'/../../stubs/DuskTestCase.stub', base_path('tests/DuskTestCase.php'));
         copy(__DIR__.'/../../stubs/Page.stub', base_path('tests/Browser/Pages/Page.php'));
 
-        file_put_contents(base_path('tests/Browser/screenshots/.gitignore'), '*
+        $content = '*
 !.gitignore
-');
+';
+
+        file_put_contents(base_path('tests/Browser/screenshots/.gitignore'), $content);
+
+        file_put_contents(base_path('tests/Browser/output/.gitignore'), $content);
 
         $this->info('Dusk scaffolding installed successfully.');
     }

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -41,6 +41,8 @@ abstract class TestCase extends FoundationTestCase
 
         Browser::$storeScreenshotsAt = base_path('tests/Browser/screenshots');
 
+        Browser::$storeOutputAt = base_path('tests/Browser/output');
+
         Browser::$userResolver = function () {
             return $this->user();
         };
@@ -140,7 +142,10 @@ abstract class TestCase extends FoundationTestCase
     protected function captureFailuresFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
-            $browser->screenshot('failure-'.$this->getName().'-'.$key);
+            $name = 'failure-'.$this->getName().'-'.$key;
+
+            $browser->screenshot($name)
+                ->storeOutput($name);
         });
     }
 


### PR DESCRIPTION
This PR creates an output folder inside Browser/ that will store the HTML of the failed tests (similar to the screenshot feature).

I think having the output together with the screenshot will be very useful to debug those failing tests :)