### PR TITLE
Add the possibility to extend the browser class.

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -108,16 +108,27 @@ abstract class TestCase extends FoundationTestCase
     protected function createBrowsersFor(Closure $callback)
     {
         if (count(static::$browsers) === 0) {
-            static::$browsers = collect([new Browser($this->createWebDriver())]);
+            static::$browsers = collect([$this->newBrowser($this->createWebDriver())]);
         }
 
         $additional = $this->browsersNeededFor($callback) - 1;
 
         for ($i = 0; $i < $additional; $i++) {
-            static::$browsers->push(new Browser($this->createWebDriver()));
+            static::$browsers->push($this->newBrowser($this->createWebDriver()));
         }
 
         return static::$browsers;
+    }
+
+    /**
+     * Create a new Browser instance.
+     *
+     * @param  \Facebook\WebDriver\Remote\RemoteWebDriver  $driver
+     * @return \Laravel\Dusk\Browser
+     */
+    protected function newBrowser($driver)
+    {
+        return new Browser($driver);
     }
 
     /**


### PR DESCRIPTION
With this change it is now possible to extend the browser class by overriding the `newBrowser` method in the `DuskTestCase` class:

```
    /**
     * Create a new Browser instance.
     *
     * @param  \Facebook\WebDriver\Remote\RemoteWebDriver  $driver
     * @return \Laravel\Dusk\Browser
     */
    protected function newBrowser($driver)
    {
        return new MyBrowser($driver);
    }
```

`class MyBrowser extends Browser`

Possible solution to: https://github.com/laravel/dusk/issues/97

I know the Browser class is macroable but sometimes it is better to just extend it, especially when you want to add a lot of new functionality.