### PR TITLE
Split Arguments for PHPUnit and merged with defaults

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -45,7 +45,7 @@ class DuskCommand extends Command
     {
         $this->purgeScreenshots();
 
-        $options = implode(' ', array_slice($_SERVER['argv'], 2));
+        $options = array_slice($_SERVER['argv'], 2);
 
         return $this->withDuskEnvironment(function () use ($options) {
             return (new ProcessBuilder())
@@ -77,9 +77,7 @@ class DuskCommand extends Command
      */
     protected function phpunitArguments($options)
     {
-        return array_merge([], [
-            '-c', base_path('phpunit.dusk.xml'), $options
-        ]);
+        return array_merge(['-c', base_path('phpunit.dusk.xml')], $options);
     }
 
     /**


### PR DESCRIPTION
I originally made #115 and somewhat incorrectly used an array union which seemed to work but actually did not...

What I should have done done is used an `array_merge` like it did originally. I have tried this with `--group foo` and below is the output before the command is run by the `Process` class:

    string(98) "'vendor/bin/phpunit' '-c' 'PROJECT_ROOT/phpunit.dusk.xml' '--group' 'foo'"

Do you think its worth making a test with a mocked ProcessBuilder?