### PR TITLE
Add option to type in an element without clearing

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -147,11 +147,16 @@ trait InteractsWithElements
      *
      * @param  string  $field
      * @param  string  $value
+     * @param  bool    $clear 
      * @return $this
      */
-    public function type($field, $value)
+    public function type($field, $value, $clear = true)
     {
-        $this->resolver->resolveForTyping($field)->clear()->sendKeys($value);
+        $resolvedField = $this->resolver->resolveForTyping($field);
+        if ($clear) {
+            $resolvedField->clear();
+        }
+        $resolvedField->sendKeys($value);
 
         return $this;
     }


### PR DESCRIPTION
The ChromeDriver gives an error when trying to type in a 'date' field.

This commit adds a `$clear` parameter to the `type()` method that allows a user to continue typing into a field (and thus work around the ChromeDriver error).

usage:
```php
$browser->type('@datefield', 01012016, false);
```

It might be that the ```keys()``` method is exactly for this use case.
In that case it might be nice to provide some documentation / exception handling or automatic fallback for the ChromeDriver.