### PR TITLE
Add assertAuthentication, assertGuest and assertIsAuthenticated methods

### DIFF
--- a/src/Concerns/InteractsWithAuthentication.php
+++ b/src/Concerns/InteractsWithAuthentication.php
@@ -3,6 +3,7 @@
 namespace Laravel\Dusk\Concerns;
 
 use Laravel\Dusk\Browser;
+use PHPUnit_Framework_Assert as PHPUnit;
 
 trait InteractsWithAuthentication
 {
@@ -37,5 +38,66 @@ trait InteractsWithAuthentication
     public function logout()
     {
         return $this->visit('/_dusk/logout/');
+    }
+
+    /**
+     * Return the ID and the class name of the authenticated user.
+     *
+     * @param  string|null  $guard
+     * @return array
+     */
+    protected function currentUserInfo($guard = null)
+    {
+        $response = $this->visit("/_dusk/user/$guard");
+
+        return json_decode(strip_tags($response->driver->getPageSource()), true);
+    }
+
+    /**
+     * Assert that the user is authenticated.
+     *
+     * @param  string|null  $guard
+     * @return $this
+     */
+    public function assertAuthentication($guard = null)
+    {
+        PHPUnit::assertNotEmpty($this->currentUserInfo($guard), 'The user is not authenticated');
+
+        return $this;
+    }
+
+    /**
+     * Assert that the user is not authenticated.
+     *
+     * @param  string|null  $guard
+     * @return $this
+     */
+    public function assertGuest($guard = null)
+    {
+        PHPUnit::assertEmpty($this->currentUserInfo($guard), 'The user is authenticated');
+
+        return $this;
+    }
+
+    /**
+     * Assert that the user is authenticated as the given user.
+     *
+     * @param  $user
+     * @param  string|null  $guard
+     * @return $this
+     */
+    public function assertAuthenticatedAs($user, $guard = null)
+    {
+        $expected = [
+            'id' => $user->getAuthIdentifier(),
+            'className' => get_class($user),
+        ];
+
+        PHPUnit::assertSame(
+            $expected, $this->currentUserInfo($guard),
+            'The currently authenticated user is not who was expected'
+        );
+
+        return $this;
     }
 }

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -16,12 +16,17 @@ class DuskServiceProvider extends ServiceProvider
     {
         Route::get('/_dusk/login/{userId}', [
             'middleware' => 'web',
-            'uses' => 'Laravel\Dusk\Http\Controllers\LoginController@login'
+            'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
         ]);
 
         Route::get('/_dusk/logout', [
             'middleware' => 'web',
-            'uses' => 'Laravel\Dusk\Http\Controllers\LoginController@logout'
+            'uses' => 'Laravel\Dusk\Http\Controllers\UserController@logout',
+        ]);
+
+        Route::get('/_dusk/user/{guard?}', [
+            'middleware' => 'web',
+            'uses' => 'Laravel\Dusk\Http\Controllers\UserController@user',
         ]);
     }
 

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -4,7 +4,7 @@ namespace Laravel\Dusk\Http\Controllers;
 
 use Illuminate\Support\Facades\Auth;
 
-class LoginController
+class UserController
 {
     /**
      * Login using the given user ID / email.
@@ -33,5 +33,25 @@ class LoginController
     public function logout()
     {
         Auth::logout();
+    }
+
+    /**
+     * Retrieve the authenticated user identifier and class name.
+     *
+     * @param  string|null  $guard
+     * @return array
+     */
+    public function user($guard = null)
+    {
+        $user = Auth::guard($guard)->user();
+
+        if (!$user) {
+            return [];
+        }
+
+        return [
+            'id' => $user->getAuthIdentifier(),
+            'className' => get_class($user),
+        ];
     }
 }


### PR DESCRIPTION
Add methods to assert a user is: authenticated, guest, or authenticated as a certain user.

There is one issue here, though, by calling `visit` again (to get the user info), the current page is changed, so these methods need to be called at the end of the test: 

```
            $browser->visit($token->url)
                ->assertPathIs('/')
                ->assertAuthenticatedAs($user);
```

```
            $browser->visitRoute('login', ['token' => $invalidToken])
                ->assertRouteIs('token')
                ->assertSee('The token is invalid.')
                ->assertGuest();
```

Of course this could be fixed somehow but I'll leave this PR for now.