### PR TITLE
Make sure the user is always logged out after the test finishes

### DIFF
--- a/src/Concerns/InteractsWithAuthentication.php
+++ b/src/Concerns/InteractsWithAuthentication.php
@@ -7,6 +7,13 @@ use Laravel\Dusk\Browser;
 trait InteractsWithAuthentication
 {
     /**
+     * Indicates if the user was authenticated using the loginAs method.
+     *
+     * @var bool
+     */
+    protected $loggedIn = false;
+
+    /**
      * Log into the application as the default user.
      *
      * @return $this
@@ -26,6 +33,8 @@ trait InteractsWithAuthentication
     {
         $userId = method_exists($userId, 'getKey') ? $userId->getKey() : $userId;
 
+        $this->loggedIn = true;
+
         return $this->visit('/_dusk/login/'.$userId);
     }
 
@@ -36,6 +45,22 @@ trait InteractsWithAuthentication
      */
     public function logout()
     {
+        $this->loggedIn = false;
+        
         return $this->visit(route('logout', [], false));
+    }
+
+    /**
+     * Log out a user if it is logged in.
+     *
+     * @return $this
+     */
+    public function logoutIfLoggedIn()
+    {
+        if ($this->loggedIn) {
+            return $this->logout();
+        }
+
+        return $this;
     }
 }

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -96,6 +96,8 @@ abstract class TestCase extends FoundationTestCase
             throw $e;
         } finally {
             static::$browsers = $this->closeAllButPrimary($browsers);
+
+            static::$browsers->first()->logoutIfLoggedIn();
         }
     }
 


### PR DESCRIPTION
I noticed an issue involving tests with authentication.

If I logged in the user in my first test, like so:

```
        $this->browse(function ($browser) {
            $browser->loginAs($this->user());
        });
```

It remains authenticated in the following tests because the main browser remains open (`closeAllButPrimary`). These of course can create some false positives, etc. 

This is why I'm adding this flag to make sure the user is log out after the test is completed. So the next test can begin with a clean state.