### PR TITLE
Provide custom logout route

### DIFF
--- a/src/Concerns/InteractsWithAuthentication.php
+++ b/src/Concerns/InteractsWithAuthentication.php
@@ -36,6 +36,6 @@ trait InteractsWithAuthentication
      */
     public function logout()
     {
-        return $this->visit(route('logout', [], false));
+        return $this->visit('/_dusk/logout/');
     }
 }

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -19,6 +19,11 @@ class DuskServiceProvider extends ServiceProvider
             'uses' => 'Laravel\Dusk\Http\Controllers\LoginController@login'
         ]);
 
+        Route::get('/_dusk/logout', [
+            'middleware' => 'web',
+            'uses' => 'Laravel\Dusk\Http\Controllers\LoginController@logout'
+        ]);
+
         $this->app->booted(function () {
             $this->makeLogoutAccessibleViaGet();
         });

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -23,24 +23,6 @@ class DuskServiceProvider extends ServiceProvider
             'middleware' => 'web',
             'uses' => 'Laravel\Dusk\Http\Controllers\LoginController@logout'
         ]);
-
-        $this->app->booted(function () {
-            $this->makeLogoutAccessibleViaGet();
-        });
-    }
-
-    /**
-     * Make the "logout" named route accessible over the GET verb.
-     *
-     * @return void
-     */
-    protected function makeLogoutAccessibleViaGet()
-    {
-        Route::getRoutes()->refreshNameLookups();
-
-        if ($route = Route::getRoutes()->getByName('logout')) {
-            Route::get($route->uri, $route->action);
-        }
     }
 
     /**

--- a/src/Http/Controllers/LoginController.php
+++ b/src/Http/Controllers/LoginController.php
@@ -24,4 +24,9 @@ class LoginController
 
         Auth::login($user);
     }
+
+    public function logout()
+    {
+        Auth::logout();
+    }
 }


### PR DESCRIPTION
I ran into another issue because in my app the logout's route is post and not get, therefore the following call: `return $this->visit(route('logout', [], false));`  was throwing an error instead of the logout action.

I think Dusk should provide its own logout action to avoid that issue, also to avoid assuming that the logout's route is defined with the "logout" name, etc. 