### PR TITLE
Bug in formatting elements with similar names

### DIFF
--- a/tests/ElementResolverTest.php
+++ b/tests/ElementResolverTest.php
@@ -105,5 +105,14 @@ class ElementResolverTest extends PHPUnit_Framework_TestCase
         $resolver = new ElementResolver(new StdClass, 'prefix');
         $resolver->pageElements(['@modal' => '#modal']);
         $this->assertEquals('prefix #modal', $resolver->format('@modal'));
+
+        $resolver = new ElementResolver(new StdClass, 'prefix');
+        $resolver->pageElements([
+            '@modal' => '#first',
+            '@modal-second' => '#second'
+            ]);
+        $this->assertEquals('prefix #first', $resolver->format('@modal'));
+        $this->assertEquals('prefix #second', $resolver->format('@modal-second'));
+
     }
 }


### PR DESCRIPTION
## Problem
Given:

- there are two page elements
- the key of the second element contains the key of the first element

```php
[
  '@foo' => '#first',
  '@foobar' => '#second'
]
```
When:

- the format method replaces the value

Then:

- the second element is replaced in part with the first elements value `#firstbar` instead of `#second`

## Solution
I'm not sure how to solve this, `preg_replace` might be the proper solution?
PR provides a failing test.