### PR TITLE
Sort before replacing pages shorthand

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -334,8 +334,12 @@ class ElementResolver
      */
     public function format($selector)
     {
+        $sortedElements = collect($this->elements)->sortByDesc(function($element, $key){
+            return strlen($key);
+        })->toArray();
+
         $selector = str_replace(
-            array_keys($this->elements), array_values($this->elements), $selector
+            array_keys($sortedElements), array_values($sortedElements), $selector
         );
 
         return trim($this->prefix.' '.$selector);

--- a/tests/ElementResolverTest.php
+++ b/tests/ElementResolverTest.php
@@ -105,5 +105,13 @@ class ElementResolverTest extends PHPUnit_Framework_TestCase
         $resolver = new ElementResolver(new StdClass, 'prefix');
         $resolver->pageElements(['@modal' => '#modal']);
         $this->assertEquals('prefix #modal', $resolver->format('@modal'));
+
+        $resolver = new ElementResolver(new StdClass, 'prefix');
+        $resolver->pageElements([
+            '@modal' => '#first',
+            '@modal-second' => '#second'
+        ]);
+        $this->assertEquals('prefix #first', $resolver->format('@modal'));
+        $this->assertEquals('prefix #second', $resolver->format('@modal-second'));
     }
 }


### PR DESCRIPTION
This PR sorts the defined shorthand selectors by key length so that we replace full keys before keys with names as subset of another key.

So we replace `@foobar` before replacing `@foo`.