### PR TITLE
Implement a method "isTtySupported" for setTty method.

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -53,7 +53,7 @@ class DuskCommand extends Command
                 ->setPrefix($this->binary())
                 ->setArguments($this->phpunitArguments($options))
                 ->getProcess()
-                ->setTty(PHP_OS !== 'WINNT')
+                ->setTty($this->isTtySupported())
                 ->run(function ($type, $line) {
                     $this->output->write($line);
                 });
@@ -187,5 +187,15 @@ class DuskCommand extends Command
         }
 
         return '.env.dusk';
+    }
+
+    /**
+     * Checks if the TTY mode is supported
+     *
+     * @return bool
+     */
+    protected function isTtySupported()
+    {
+        return PHP_OS !== 'WINNT' && (bool) @proc_open('echo 1 >/dev/null', [['file', '/dev/tty', 'r'], ['file', '/dev/tty', 'w'], ['file', '/dev/tty', 'w']], $pipes);
     }
 }


### PR DESCRIPTION
I tried dusk with PhantomJS on Wercker. and I have same issue this.
https://laracasts.com/discuss/channels/testing/tty-mode-requires-devtty-to-be-writable

Like that comment "run as script" can be executed.
but Wercker continued build when dusk fails, probably exit code does not return.
This problem will be occored on CircleCI, GitLab CI, cron and more.

I fixed that, change to the same logic Symfony\Component\Process\Process#setTty()
https://github.com/symfony/process/blob/master/Process.php#L1036

and this is execution result.

```
$ cat /tmp/test.php 
<?php

var_dump(PHP_OS !== 'WINNT');

var_dump(PHP_OS !== 'WINNT' && (bool) @proc_open('echo 1 >/dev/null', [['file', '/dev/tty', 'r'], ['file', '/dev/tty', 'w'], ['file', '/dev/tty', 'w']], $pipes));
```

iTerm2

```
$ php /tmp/test.php 
bool(true)
bool(true)
```

jenkins on MacOSX

```
+ php /tmp/test.php
bool(true)
bool(false) // no supported tty even if OS is not Windows.
```
