### PR TITLE
Add assertions for radio selection

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -351,6 +351,44 @@ JS;
 
         return $this;
     }
+    
+    /**
+     * Assert that the given radio field is selected.
+     *
+     * @param  string  $field
+     * @param  string  $value
+     * @return $this
+     */
+    function assertRadioSelected($field, $value)
+    {
+        $element = $this->resolver->resolveForRadioSelection($field, $value);
+
+        PHPUnit::assertTrue(
+            $element->isSelected(),
+            "Expected radio [{$field}] to be selected, but it wasn't."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given radio field is not selected.
+     *
+     * @param  string  $field
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertRadioNotSelected($field, $value = null)
+    {
+        $element = $this->resolver->resolveForRadioSelection($field, $value);
+
+        PHPUnit::assertFalse(
+            $element->isSelected(),
+            "Radio [{$field}] was unexpectedly selected."
+        );
+
+        return $this;
+    }
 
     /**
      * Assert that the given select field has the given value selected.


### PR DESCRIPTION
Given the available assertions I could not figure a way to assert that a radio input was selected (or not). That seems like an oversight to me so I hope these methods help with that. Otherwise how do you make that assertion?