### PR TITLE
Log console content into files

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -36,6 +36,13 @@ class Browser
     public static $storeScreenshotsAt;
 
     /**
+     * The directory that will contain any console log.
+     *
+     * @var string
+     */
+    public static $storeConsoleLogAt;
+
+    /**
      * Get the callback which resolves the default user to authenticate.
      *
      * @var \Closure
@@ -197,6 +204,22 @@ class Browser
     {
         $this->driver->takeScreenshot(
             sprintf('%s/%s.png', rtrim(static::$storeScreenshotsAt, '/'), $name)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Store the console output with the given name.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function logConsole($name)
+    {
+        file_put_contents(
+            sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name)
+            , json_encode($this->driver->manage()->getLog('browser'), JSON_PRETTY_PRINT)
         );
 
         return $this;

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -45,6 +45,10 @@ class InstallCommand extends Command
             mkdir(base_path('tests/Browser/screenshots'), 0755, true);
         }
 
+        if (! is_dir(base_path('tests/Browser/console'))) {
+            mkdir(base_path('tests/Browser/console'), 0755, true);
+        }
+
         copy(__DIR__.'/../../stubs/ExampleTest.stub', base_path('tests/Browser/ExampleTest.php'));
         copy(__DIR__.'/../../stubs/HomePage.stub', base_path('tests/Browser/Pages/HomePage.php'));
         copy(__DIR__.'/../../stubs/DuskTestCase.stub', base_path('tests/DuskTestCase.php'));

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -41,6 +41,8 @@ abstract class TestCase extends FoundationTestCase
 
         Browser::$storeScreenshotsAt = base_path('tests/Browser/screenshots');
 
+        Browser::$storeConsoleLogAt = base_path('tests/Browser/console');
+
         Browser::$userResolver = function () {
             return $this->user();
         };
@@ -95,6 +97,8 @@ abstract class TestCase extends FoundationTestCase
 
             throw $e;
         } finally {
+            $this->logConsoleFor($browsers);
+
             static::$browsers = $this->closeAllButPrimary($browsers);
         }
     }
@@ -152,6 +156,19 @@ abstract class TestCase extends FoundationTestCase
     {
         $browsers->each(function ($browser, $key) {
             $browser->screenshot('failure-'.$this->getName().'-'.$key);
+        });
+    }
+
+    /**
+     * Log the console output for each browser.
+     *
+     * @param  \Illuminate\Support\Collection  $browsers
+     * @return void
+     */
+    protected function logConsoleFor($browsers)
+    {
+        $browsers->each(function ($browser, $key) {
+            $browser->logConsole($this->getName().'-'.$key);
         });
     }
 


### PR DESCRIPTION
This PR adds the functionality of storing the browser console content into files for further inspection. Upon installation a `Browser/console` directory will be created to store the log files of each test.

An example log file looks like:

```
[
    {
        "level": "SEVERE",
        "message": "http:\/\/duskproject.dev\/ 18:28 Uncaught TypeError: Cannot read property 'undefined' of null",
        "source": "javascript",
        "timestamp": 1487615364745
    }
]
```