### PR TITLE
Add user info to the response

### DIFF
--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -2,8 +2,9 @@
 
 namespace Laravel\Dusk;
 
-use Illuminate\Support\Facades\Route;
+use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Dusk\Http\Middleware\AddUserInfo;
 
 class DuskServiceProvider extends ServiceProvider
 {
@@ -12,21 +13,18 @@ class DuskServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(Router $router)
     {
-        Route::get('/_dusk/login/{userId}', [
+        $router->pushMiddlewareToGroup('web', AddUserInfo::class);
+
+        $router->get('/_dusk/login/{userId}', [
             'middleware' => 'web',
             'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
         ]);
 
-        Route::get('/_dusk/logout', [
+        $router->get('/_dusk/logout', [
             'middleware' => 'web',
             'uses' => 'Laravel\Dusk\Http\Controllers\UserController@logout',
-        ]);
-
-        Route::get('/_dusk/user/{guard?}', [
-            'middleware' => 'web',
-            'uses' => 'Laravel\Dusk\Http\Controllers\UserController@user',
         ]);
     }
 

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -7,26 +7,6 @@ use Illuminate\Support\Facades\Auth;
 class UserController
 {
     /**
-     * Retrieve the authenticated user identifier and class name.
-     *
-     * @param  string|null  $guard
-     * @return array
-     */
-    public function user($guard = null)
-    {
-        $user = Auth::guard($guard)->user();
-
-        if (! $user) {
-            return [];
-        }
-
-        return [
-            'id' => $user->getAuthIdentifier(),
-            'className' => get_class($user),
-        ];
-    }
-
-    /**
      * Login using the given user ID / email.
      *
      * @param  string  $userId

--- a/src/Http/Middleware/AddUserInfo.php
+++ b/src/Http/Middleware/AddUserInfo.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Laravel\Dusk\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class AddUserInfo
+{
+    /**
+     * Add the current user ID and class name to the response header.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string|null  $guard
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        if (Auth::check()) {
+            $this->appendUserInfo($response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Append the info of the authenticated user to the response body.
+     *
+     * @param  \Illuminate\Http\Response  $response
+     *
+     * @return void
+     */
+    protected function appendUserInfo($response)
+    {
+        $user = Auth::user();
+
+        $content = get_class($user).':'.$user->getAuthIdentifier();
+
+        $html = "<script id='dusk_user_info' data-content='{$content}'></script></body>";
+
+        $response->setContent(
+            str_replace_last('</body>', $html, $response->getContent())
+        );
+    }
+}


### PR DESCRIPTION
I was trying to find a way to get the user info (and possibly other useful data) from the response itself, in that way `assertAuthenticated*` methods won't need to send another request and the page is not changed, i.e. this is now possible: 

```
    $browser->visit($token->url)
        ->assertAuthenticatedAs($user) // the page is not changed, if this fails the proper screenshot will be captured
        ->assertPathIs('/'); // and also you can continue calling the assert* methods
```

This is probably not the best solution but I'll leave the PR here just in case :) 