### PR TITLE
Delete all the cookies to logout the authenticated user

### DIFF
--- a/src/Concerns/InteractsWithCookies.php
+++ b/src/Concerns/InteractsWithCookies.php
@@ -85,4 +85,14 @@ trait InteractsWithCookies
 
         return $this;
     }
+
+    /**
+     * Delete all the cookies.
+     *
+     * @return $this
+     */
+    public function deleteAllCookies()
+    {
+        $this->driver->manage()->deleteAllCookies();
+    }
 }

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -96,6 +96,8 @@ abstract class TestCase extends FoundationTestCase
             throw $e;
         } finally {
             static::$browsers = $this->closeAllButPrimary($browsers);
+
+            static::$browsers->first()->deleteAllCookies();
         }
     }
 


### PR DESCRIPTION
Another possible and simpler solution to this issue: https://github.com/laravel/dusk/issues/142 

Also described here: https://github.com/laravel/dusk/pull/128

The idea is to delete all the cookies so the session is reset and the next test begins with a clean state (no auth user, etc.)