### PR TITLE
Return the browser object to allow chaining after a call to ->script.

### DIFF
--- a/src/Concerns/InteractsWithJavascript.php
+++ b/src/Concerns/InteractsWithJavascript.php
@@ -12,8 +12,10 @@ trait InteractsWithJavascript
      */
     public function script($scripts)
     {
-        return collect((array) $scripts)->map(function ($script) {
+        collect((array) $scripts)->map(function ($script) {
             return $this->driver->executeScript($script);
         })->all();
+
+        return $this;
     }
 }


### PR DESCRIPTION
Returning the browser object allows us to execute a script (or scripts) and then continue chaining test methods.

Example use case is simulating a user scrolling to the bottom of the page (to make a button visible) and then pressing it.

We could split this to a different method if there is a need to continue returning the collection of javascript execution results as it works now.