### PR TITLE
add selectorPrefix to clickLink method

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -49,13 +49,14 @@ trait InteractsWithElements
      * Click the link with the given text.
      *
      * @param  string  $link
+     * @param  string  $selectorPrefix
      * @return $this
      */
-    public function clickLink($link)
+    public function clickLink($link, $selectorPrefix = '')
     {
         $this->ensurejQueryIsAvailable();
 
-        $selector = trim($this->resolver->format("a:contains('{$link}')"));
+        $selector = trim($this->resolver->format($selectorPrefix . " a:contains('{$link}')"));
 
         $this->driver->executeScript("jQuery.find(\"{$selector}\")[0].click();");
 


### PR DESCRIPTION
With clickLink it was possible to click the wrong link if multiple links exist with the same (or similar) content. $selectorPrefix allows user to target with stronger specificity.