### PR TITLE
Allow authentication actions for specific guards

### DIFF
--- a/src/Concerns/InteractsWithAuthentication.php
+++ b/src/Concerns/InteractsWithAuthentication.php
@@ -21,23 +21,25 @@ trait InteractsWithAuthentication
      * Log into the application using a given user ID or email.
      *
      * @param  object|string  $userId
+     * @param  string         $guard
      * @return $this
      */
-    public function loginAs($userId)
+    public function loginAs($userId, $guard = null)
     {
         $userId = method_exists($userId, 'getKey') ? $userId->getKey() : $userId;
 
-        return $this->visit('/_dusk/login/'.$userId);
+        return $this->visit('/_dusk/login/'.$userId.'/'.$guard);
     }
 
     /**
      * Log out of the application.
      *
+     * @param  string  $guard
      * @return $this
      */
-    public function logout()
+    public function logout($guard = null)
     {
-        return $this->visit('/_dusk/logout/');
+        return $this->visit('/_dusk/logout/'.$guard);
     }
 
     /**

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -14,12 +14,12 @@ class DuskServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Route::get('/_dusk/login/{userId}', [
+        Route::get('/_dusk/login/{userId}/{guard?}', [
             'middleware' => 'web',
             'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
         ]);
 
-        Route::get('/_dusk/logout', [
+        Route::get('/_dusk/logout/{guard?}', [
             'middleware' => 'web',
             'uses' => 'Laravel\Dusk\Http\Controllers\UserController@logout',
         ]);

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -30,11 +30,14 @@ class UserController
      * Login using the given user ID / email.
      *
      * @param  string  $userId
+     * @param  string  $guard
      * @return Response
      */
-    public function login($userId)
+    public function login($userId, $guard = null)
     {
-        $model = config('auth.providers.users.model');
+        $guard    = $guard ?: config('auth.defaults.guard');
+        $provider = config("auth.guards.{$guard}.provider");
+        $model    = config("auth.providers.{$provider}.model");
 
         if (str_contains($userId, '@')) {
             $user = (new $model)->where('email', $userId)->first();
@@ -42,16 +45,17 @@ class UserController
             $user = (new $model)->find($userId);
         }
 
-        Auth::login($user);
+        Auth::guard($guard)->login($user);
     }
 
     /**
      * Log the user out of the application.
      *
+     * @param  string  $guard
      * @return Response
      */
-    public function logout()
+    public function logout($guard = null)
     {
-        Auth::logout();
+        Auth::guard($guard ?: config('auth.defaults.guard'))->logout();
     }
 }


### PR DESCRIPTION
Allows optional passing of a specific guard to the loginAs and logout methods.

Additionally, it removes the hardcoding of the `users` auth provider - now using whatever guard is specified (defaulting to the default)

Apologies for going straight for the PR, and not running it by an issue first - I'd already coded it to fix something in my tests, and it's half-fix, half-feature.

Comments welcome.