### PR TITLE
Fix overriding original backup upon previous failure

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -105,7 +105,9 @@ class DuskCommand extends Command
     protected function withDuskEnvironment($callback)
     {
         if (file_exists(base_path($this->duskFile()))) {
-            $this->backupEnvironment();
+            if (file_get_contents(base_path('.env')) !== file_get_contents(base_path($this->duskFile())) {
+                $this->backupEnvironment();
+            }
 
             $this->refreshEnvironment();
         }

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -117,7 +117,7 @@ class DuskCommand extends Command
         return tap($callback(), function () {
             $this->removeConfiguration();
 
-            if (file_exists(base_path($this->duskFile()))) {
+            if (file_exists(base_path($this->duskFile())) && file_exists(base_path('.env.backup')))) {
                 $this->restoreEnvironment();
             }
         });

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -117,7 +117,7 @@ class DuskCommand extends Command
         return tap($callback(), function () {
             $this->removeConfiguration();
 
-            if (file_exists(base_path($this->duskFile())) && file_exists(base_path('.env.backup')))) {
+            if (file_exists(base_path($this->duskFile())) && file_exists(base_path('.env.backup'))) {
                 $this->restoreEnvironment();
             }
         });


### PR DESCRIPTION
Only backup .env if it's not equal to the .env.dusk.[env]

This fixes issues when you ctrl+c the `php artisan dusk` command or it fails somehow without finishing the restore.