### PR TITLE
Add stop() to stop the PHPunit process but keep the browser open

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -283,7 +283,7 @@ class Browser
     }
 
     /**
-     * Stop the script but keep the browser open.
+     * Stop running tests but leave the browser open.
      *
      * @return void
      */

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -283,6 +283,16 @@ class Browser
     }
 
     /**
+     * Stop the script but keep the browser open.
+     *
+     * @return void
+     */
+    public function stop()
+    {
+        exit();
+    }
+
+    /**
      * Dynamically call a method on the browser.
      *
      * @param  string  $method


### PR DESCRIPTION
Using `stop()` will exit the process that's running PHPUnit but will not attempt to close the currently open browser since the `afterClass` is not called.

This is useful for debugging when you want to keep the browser open and tinker with elements at a given state.