### PR TITLE
Ensure findOrFail() recgonises ID selectors

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -302,6 +302,10 @@ class ElementResolver
      */
     public function findOrFail($selector)
     {
+        if (! is_null($element = $this->findById($selector))) {
+            return $element;
+        }
+
         return $this->driver->findElement(
             WebDriverBy::cssSelector($this->format($selector))
         );


### PR DESCRIPTION
I was getting an error from webdriver ("An invalid or illegal selector was specified") when I stepped through the code I found that:
```php
$browser->click("#frmLogin:btnLogin2");
```
currently generates the following:
```
Array
(
    [using] => css selector
    [value] => body #frmLogin:btnLogin2
)
```
this pr ensures that selectors using the ID are picked up:
```
Array
(
    [using] => id
    [value] => frmLogin:btnLogin2
)
```