### PR TITLE
fix id selector matching

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -255,7 +255,7 @@ class ElementResolver
      */
     protected function findById($selector)
     {
-        if (Str::startsWith($selector, '#')) {
+        if (preg_match('/^#[\w\-]+$/', $selector)) {
             return $this->driver->findElement(WebDriverBy::id(substr($selector, 1)));
         }
     }


### PR DESCRIPTION
This change should fix the following issue: Cannot make selections like '#id > .class' #161 

The regex will match #element, #element-id, and #element_id 

Many uncommon patterns included in the W3C recommandations won't match.
https://www.w3.org/TR/html5/dom.html#the-id-attribute