### PR TITLE
Screenshot captured event + symlink screenshots to storage/screenshots

### DIFF
--- a/src/Console/Link.php
+++ b/src/Console/Link.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Laravel\Dusk\Console;
+
+use Illuminate\Console\Command;
+
+class Link extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'dusk:link';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a symbolic link from "tests/Browser/screenshots" to "storage/app/public/screenshots"';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        if (file_exists(storage_path('app/public/screenshots'))) {
+            return $this->error('The "app/public/screenshots" directory already exists.');
+        }
+
+        $this->laravel->make('files')->link(
+            base_path('tests/Browser/screenshots'), storage_path('app/public/screenshots')
+        );
+
+        $this->info('The [app/public/screenshots] directory has been linked.');
+    }
+}

--- a/src/Console/LinkCommand.php
+++ b/src/Console/LinkCommand.php
@@ -4,7 +4,7 @@ namespace Laravel\Dusk\Console;
 
 use Illuminate\Console\Command;
 
-class Link extends Command
+class LinkCommand extends Command
 {
     /**
      * The console command signature.

--- a/src/Events/ScreenshotCaptured.php
+++ b/src/Events/ScreenshotCaptured.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Dusk\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class ScreenshotCaptured
+{
+    use Dispatchable;
+
+    protected $filename;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param $filename
+     */
+    public function __construct($filename)
+    {
+        $this->filename = $filename;
+    }
+
+}

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Throwable;
 use ReflectionFunction;
+use Laravel\Dusk\Events\ScreenshotCaptured;
 use Illuminate\Support\Collection;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
@@ -156,6 +157,7 @@ abstract class TestCase extends FoundationTestCase
     {
         $browsers->each(function ($browser, $key) {
             $browser->screenshot('failure-'.$this->getName().'-'.$key);
+            event(new ScreenshotCaptured('failure-'.$this->getName().'-'.$key));
         });
     }
 


### PR DESCRIPTION
Hi there,

This pull request has a couple of things:

- ```php artisan dusk:link``` command
- ScreenshotCaptured event
- TestCase failed screenshot loop fires the ScreenshotCaptured event

I wanted to have a Slack notification when Dusk failed and a screenshot was made.

Therefore I created a symlink command which links the ```tests/Browser/screenshots``` folder
to ```storage/screenshots``` folder.

The symlink is great when being used with Laravel's ```php artisan storage:link```. 
Now it is possible to link to the image, 
fe:  ```https://dusk.dev/screenshots/failure-a_user_can_login-0.png```

