### PR TITLE
Don't store console log if there's nothing to be stored

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -217,10 +217,13 @@ class Browser
      */
     public function storeConsoleLog($name)
     {
-        file_put_contents(
-            sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name)
-            , json_encode($this->driver->manage()->getLog('browser'), JSON_PRETTY_PRINT)
-        );
+        $console = $this->driver->manage()->getLog('browser');
+        if (!empty($console)) {
+            file_put_contents(
+                sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name)
+                , json_encode($this->driver->manage()->getLog('browser'), JSON_PRETTY_PRINT)
+            );
+        }
 
         return $this;
     }

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -221,7 +221,7 @@ class Browser
         if (!empty($console)) {
             file_put_contents(
                 sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name)
-                , json_encode($this->driver->manage()->getLog('browser'), JSON_PRETTY_PRINT)
+                , json_encode($console, JSON_PRETTY_PRINT)
             );
         }
 


### PR DESCRIPTION
Loved the new console feature, but for success tests, we might just skip `file_put_contents` to prevent the file from being created.