### PR TITLE
Tiny Fix, duplicate backslash

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -50,7 +50,7 @@ trait MakesAssertions
             $urlPath = '/' . ltrim($urlPath, '/');
         }
         
-        PHPUnit::assertEquals($path, $configPath);
+        PHPUnit::assertEquals($path, $urlPath);
         
         return $this;
     }

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -44,14 +44,14 @@ trait MakesAssertions
      */
     public function assertPathIs($path)
     {
-        $configPath = parse_url($this->driver->getCurrentURL())['path'];
+        $urlPath = parse_url($this->driver->getCurrentURL())['path'];
         
-        if(strpos($configPath, '/', 1)) {
-            $configPath = '/' . ltrim($configPath, '/');
+        if(strpos($urlPath, '/', 1)) {
+            $urlPath = '/' . ltrim($urlPath, '/');
         }
         
         PHPUnit::assertEquals($path, $configPath);
-
+        
         return $this;
     }
 

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -44,9 +44,13 @@ trait MakesAssertions
      */
     public function assertPathIs($path)
     {
-        PHPUnit::assertEquals($path, parse_url(
-            $this->driver->getCurrentURL()
-        )['path']);
+        $configPath = parse_url($this->driver->getCurrentURL())['path'];
+        
+        if(strpos($configPath, '/', 1)) {
+            $configPath = '/' . ltrim($configPath, '/');
+        }
+        
+        PHPUnit::assertEquals($path, $configPath);
 
         return $this;
     }


### PR DESCRIPTION
After a while it took me time to figure out why I always get Failed asserting that two strings are equal //contact equals /contact

![failed](https://cloud.githubusercontent.com/assets/16985712/23536210/b62f4970-ffc3-11e6-8c36-9ff46bedd5ab.jpg)

It appears that from where it pulls the configuration(.env file APP_URL) if you have backslash at the end you always get different strings with assertEquals:

![env](https://cloud.githubusercontent.com/assets/16985712/23536261/05230c88-ffc4-11e6-8c91-cf62ac35c6b8.jpg)

when I remove that backslash at the end of the file manually the test is passeding.

so in order to make this small fix I suggest to force it to have only one backslash even if the someone adds backslash at the end in the .env file on the APP_URL variable.

now both cases passing..

![success](https://cloud.githubusercontent.com/assets/16985712/23536330/714c86c8-ffc4-11e6-9226-1cf000cbe643.jpg)


 