### PR TITLE
Added method WaitsForElements::waitForLocation()

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -95,7 +95,7 @@ trait WaitsForElements
      */
     public function waitForLocation($path, $seconds = 5)
     {
-        return $this->waitUntil("window.location.pathname == '$path'", $seconds);
+        return $this->waitUntil("window.location.pathname == '{$path}'", $seconds);
     }
 
     /**

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -87,6 +87,18 @@ trait WaitsForElements
     }
 
     /**
+     * Wait for the given location.
+     *
+     * @param  string  $path
+     * @param  int  $seconds
+     * @return $this
+     */
+    public function waitForLocation($path, $seconds = 5)
+    {
+        return $this->waitUntil("window.location.pathname == '$path'", $seconds);
+    }
+
+    /**
      * Wait until the given script returns true.
      *
      * @param  string  $script


### PR DESCRIPTION
Method assertPathIs() sometimes fails if your script are redirecting the user to another location after an AJAX call is completed, for example when building a SPA using Vue Router.

This method waitForLocation() solves this issue actually waiting for the window.location.pathname to change.