### PR TITLE
Allow falsy values in InteractsWithElements::value

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -86,7 +86,7 @@ trait InteractsWithElements
      */
     public function value($selector, $value = null)
     {
-        if (! $value) {
+        if (is_null($value)) {
             return $this->resolver->findOrFail($selector)->getAttribute('value');
         }
 


### PR DESCRIPTION
Fixes #131

In a scenario described in #131 if a user passes a falsy `$value`, Dusk thinks he's asking to retrieve the value, not set it, making it impossible to set an element value to eg. 0.
