### PR TITLE
cast both operands to string

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -203,7 +203,7 @@ trait InteractsWithElements
 
         else {
             foreach ($options as $option) {
-                if ((string)$option->getAttribute('value') === (string)$value) {
+                if ((string) $option->getAttribute('value') === (string) $value) {
                     $option->click();
 
                     break;

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -203,7 +203,7 @@ trait InteractsWithElements
 
         else {
             foreach ($options as $option) {
-                if ($option->getAttribute('value') === $value) {
+                if ((string)$option->getAttribute('value') === (string)$value) {
                     $option->click();
 
                     break;


### PR DESCRIPTION
`getAttribute()` returns a `string` or `null`, so we cast the left
operand to a string to handle `null`.

since we are using a strict comparison, we also cast the right operand
to a string.

the most common issue this solves is when the user tries to `select` an
integer.

fixes #134