### PR TITLE
Allow assertion of available options on a given select element

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -513,6 +513,70 @@ JS;
     }
 
     /**
+     * Assert that the given array of values are available to be selected on the given field.
+     *
+     * @param string  $field
+     * @param array  $values
+     * @return $this
+     */
+    public function assertOptionsAvailable($field, array $values)
+    {
+        PHPUnit::assertCount(
+            count($values),
+            $this->resolver->resolveSelectOptions($field, $values),
+            "Expected options [".implode(',', $values)."] for select [{$field}] to be available, but it wasn't."
+        );
+
+        return $this;
+    }
+    
+    /**
+     * Assert that the given array of values are not available to be selected on the given field.
+     *
+     * @param string  $field
+     * @param array  $values
+     * @return $this
+     */
+    public function assertOptionsNotAvailable($field, array $values)
+    {
+        PHPUnit::assertCount(
+            0,
+            $this->resolver->resolveSelectOptions($field, $values),
+            "Unexpected available options [".implode(',', $values)."] for select [{$field}]."
+        );
+
+        return $this;
+    }
+    
+    /**
+     * Assert that the given value is available to be selected on the given field.
+     *
+     * @param string  $field
+     * @param string  $value
+     * @return $this
+     */
+    public function assertOptionAvailable($field, $value)
+    {
+        $value = [$value];
+
+        return $this->assertOptionsAvailable($field, $value);
+    }
+    
+    /**
+     * Assert that the given value is not available to be selected on the given field.
+     *
+     * @param string  $field
+     * @param string  $value
+     * @return $this
+     */
+    public function assertOptionNotAvailable($field, $value)
+    {
+        $value = [$value];
+
+        return $this->assertOptionsNotAvailable($field, $value);
+    }
+
+    /**
      * Determine if the given value is selected for the given select field.
      *
      * @param  string  $field

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -557,9 +557,7 @@ JS;
      */
     public function assertOptionAvailable($field, $value)
     {
-        $value = [$value];
-
-        return $this->assertOptionsAvailable($field, $value);
+        return $this->assertOptionsAvailable($field, [$value]);
     }
     
     /**
@@ -571,9 +569,7 @@ JS;
      */
     public function assertOptionNotAvailable($field, $value)
     {
-        $value = [$value];
-
-        return $this->assertOptionsNotAvailable($field, $value);
+        return $this->assertOptionsNotAvailable($field, [$value]);
     }
 
     /**

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -115,20 +115,17 @@ class ElementResolver
      */
     public function resolveSelectOptions($field, array $values)
     {
-        $select = $this->resolveForSelection($field);
-        $options = $select->findElements(WebDriverBy::tagName('option'));
-        
+        $options = $this->resolveForSelection($field)
+            ->findElements(WebDriverBy::tagName('option'));
+
         if (empty($options))
             return [];
-        
-        $available = [];
-        foreach ($options as $option)
-            if (in_array($option->getAttribute('value'), $values))
-                $available[] = $option;
-        
-        return $available;
+
+        return array_filter($options, function($option) use ($values) {
+            return in_array($option->getAttribute('value'), $values);
+        });
     }
-    
+
     /**
      * Resolve the element for a given radio "field" / value.
      *

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -107,6 +107,29 @@ class ElementResolver
     }
 
     /**
+     * Resolve all the options with the given value on the select field.
+     *
+     * @param string  $field
+     * @param array  $values
+     * @return array
+     */
+    public function resolveSelectOptions($field, array $values)
+    {
+        $select = $this->resolveForSelection($field);
+        $options = $select->findElements(WebDriverBy::tagName('option'));
+        
+        if (empty($options))
+            return [];
+        
+        $available = [];
+        foreach ($options as $option)
+            if (in_array($option->getAttribute('value'), $values))
+                $available[] = $option;
+        
+        return $available;
+    }
+    
+    /**
      * Resolve the element for a given radio "field" / value.
      *
      * @param  string  $field


### PR DESCRIPTION
Closes #65.

This PR will allow assertions as follows: 

```
$this->browse(function (Browser $browser) {
    $browser->visit(new HomePage)
        ->assertOptionAvailable('laravel-dusk', '1')
        ->assertOptionsAvailable('laravel-dusk', ['1', ''])
        ->assertOptionNotAvailable('laravel-dusk', '10')
        ->assertOptionsNotAvailable('laravel-dusk', ['10', 'unavailable']);
    });
```

On a select like this: 

```
<select name="laravel-dusk">
    <option value="1">First</option>
    <option value="">Empty</option>
</select>
```

