### PR TITLE
Fix calling invalid method

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -556,7 +556,7 @@ JS;
      */
     public function assertOptionAvailable($field, $value)
     {
-        return $this->assertOptionsAvailable($field, [$value]);
+        return $this->assertSelectHasOptions($field, [$value]);
     }
 
     /**
@@ -568,7 +568,7 @@ JS;
      */
     public function assertOptionNotAvailable($field, $value)
     {
-        return $this->assertOptionsNotAvailable($field, [$value]);
+        return $this->assertSelectMissingOptions($field, [$value]);
     }
 
     /**


### PR DESCRIPTION
I don't know if the naming convention of the singular methods was good or just forgotten, but the current state is failing because there are exposed assertions calling invalid methods.