### PR TITLE
Require latest php-webdriver version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "facebook/webdriver": "~1.0",
+        "facebook/webdriver": "^1.4",
         "nesbot/carbon": "~1.20",
         "illuminate/support": "~5.3",
         "symfony/console": "~3.2",

--- a/src/Concerns/InteractsWithCookies.php
+++ b/src/Concerns/InteractsWithCookies.php
@@ -3,6 +3,7 @@
 namespace Laravel\Dusk\Concerns;
 
 use DateTimeInterface;
+use Facebook\WebDriver\Cookie;
 
 trait InteractsWithCookies
 {
@@ -22,7 +23,7 @@ trait InteractsWithCookies
         }
 
         if ($cookie = $this->driver->manage()->getCookieNamed($name)) {
-            return decrypt(rawurldecode($cookie['value']));
+            return decrypt(rawurldecode($cookie->getValue()));
         }
     }
 
@@ -42,7 +43,7 @@ trait InteractsWithCookies
         }
 
         if ($cookie = $this->driver->manage()->getCookieNamed($name)) {
-            return rawurldecode($cookie['value']);
+            return rawurldecode($cookie->getValue());
         }
     }
 
@@ -66,9 +67,9 @@ trait InteractsWithCookies
             $expiry = $expiry->getTimestamp();
         }
 
-        $this->driver->manage()->addCookie(
-            array_merge($options, compact('expiry', 'name', 'value'))
-        );
+        $cookie = Cookie::createFromArray(array_merge($options, compact('expiry', 'name', 'value')));
+
+        $this->driver->manage()->addCookie($cookie);
 
         return $this;
     }


### PR DESCRIPTION
There is a bunch of useful improvements and fixes in latest php-webdriver version, see [changelog](https://github.com/facebook/php-webdriver/blob/community/CHANGELOG.md).

IMHO there is no need to rely on the ~1.0 and the 1.4+ could be forced, or am I wrong? 