### PR TITLE
Restore support for IDs containing a colon

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -276,7 +276,7 @@ class ElementResolver
      */
     protected function findById($selector)
     {
-        if (preg_match('/^#[\w\-]+$/', $selector)) {
+        if (preg_match('/^#[\w\-:]+$/', $selector)) {
             return $this->driver->findElement(WebDriverBy::id(substr($selector, 1)));
         }
     }

--- a/tests/ElementResolverTest.php
+++ b/tests/ElementResolverTest.php
@@ -114,4 +114,18 @@ class ElementResolverTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('prefix #first', $resolver->format('@modal'));
         $this->assertEquals('prefix #second', $resolver->format('@modal-second'));
     }
+
+    public function test_find_by_id_with_colon()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement')->once()->andReturn('foo');
+        $resolver = new ElementResolver($driver);
+
+        $class = new \ReflectionClass($resolver);
+        $method = $class->getMethod('findById');
+        $method->setAccessible(true);
+        $result = $method->invoke($resolver, '#frmLogin:strCustomerLogin_userID');
+
+        $this->assertEquals('foo', $result);
+    }
 }


### PR DESCRIPTION
#163 broke support for IDs containing a colon, eg:
```html
<input type='text' id='#frmLogin:strCustomerLogin_userID'>
```
This pr restores it and adds a test