### PR TITLE
add case sensitive option to assertions

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\Dusk\Concerns;
 
+use Facebook\WebDriver\Exception\NoSuchElementException;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\Assert as PHPUnit;
-use Facebook\WebDriver\Exception\NoSuchElementException;
 
 trait MakesAssertions
 {
@@ -203,22 +203,24 @@ trait MakesAssertions
      * Assert that the given text appears on the page.
      *
      * @param  string  $text
+     * @param  bool    $caseSensitive
      * @return $this
      */
-    public function assertSee($text)
+    public function assertSee($text, $caseSensitive = true)
     {
-        return $this->assertSeeIn('', $text);
+        return $this->assertSeeIn('', $text, $caseSensitive);
     }
 
     /**
      * Assert that the given text does not appear on the page.
      *
      * @param  string  $text
+     * @param  bool    $caseSensitive
      * @return $this
      */
-    public function assertDontSee($text)
+    public function assertDontSee($text, $caseSensitive = true)
     {
-        return $this->assertDontSeeIn('', $text);
+        return $this->assertDontSeeIn('', $text, $caseSensitive);
     }
 
     /**
@@ -226,16 +228,24 @@ trait MakesAssertions
      *
      * @param  string  $selector
      * @param  string  $text
+     * @param  bool    $caseSensitive
      * @return $this
      */
-    public function assertSeeIn($selector, $text)
+    public function assertSeeIn($selector, $text, $caseSensitive = true)
     {
         $fullSelector = $this->resolver->format($selector);
 
         $element = $this->resolver->findOrFail($selector);
 
+        $actualText = $element->getText();
+
+        if (!$caseSensitive) {
+            $actualText = Str::lower($actualText);
+            $text = Str::lower($text);
+        }
+
         PHPUnit::assertTrue(
-            Str::contains($element->getText(), $text),
+            Str::contains($actualText, $text),
             "Did not see expected text [{$text}] within element [{$fullSelector}]."
         );
 
@@ -247,16 +257,24 @@ trait MakesAssertions
      *
      * @param  string  $selector
      * @param  string  $text
+     * @param  bool    $caseSensitive
      * @return $this
      */
-    public function assertDontSeeIn($selector, $text)
+    public function assertDontSeeIn($selector, $text, $caseSensitive = true)
     {
         $fullSelector = $this->resolver->format($selector);
 
         $element = $this->resolver->findOrFail($selector);
 
+        $actualText = $element->getText();
+
+        if (!$caseSensitive) {
+            $actualText = Str::lower($actualText);
+            $text = Str::lower($text);
+        }
+
         PHPUnit::assertFalse(
-            Str::contains($element->getText(), $text),
+            Str::contains($actualText, $text),
             "Saw unexpected text [{$text}] within element [{$fullSelector}]."
         );
 

--- a/tests/MakesAssertionTest.php
+++ b/tests/MakesAssertionTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use Facebook\WebDriver\Remote\RemoteWebElement;
+use Laravel\Dusk\Concerns\MakesAssertions;
+use Laravel\Dusk\ElementResolver;
+
+class MakesAssertionTest extends PHPUnit_Framework_TestCase
+{
+    public function test_assert_see()
+    {
+        $mock = Mockery::mock(DuskTest::class)->makePartial();
+
+        $resolver = Mockery::mock(ElementResolver::class);
+
+        $mock->resolver = $resolver;
+
+        $element = Mockery::mock(RemoteWebElement::class);
+        $element->shouldReceive('getText')->once()->andReturn('The Case Sensitive expected value.');
+        $resolver->shouldReceive('format')->once()->andReturn(null);
+        $resolver->shouldReceive('findOrFail')->once()->andReturn($element);
+
+        $mock->assertSee('Case Sensitive');
+    }
+
+    public function test_assert_see_case_insensitive()
+    {
+        $mock = Mockery::mock(DuskTest::class)->makePartial();
+
+        $resolver = Mockery::mock(ElementResolver::class);
+
+        $mock->resolver = $resolver;
+
+        $element = Mockery::mock(RemoteWebElement::class);
+        $element->shouldReceive('getText')->once()->andReturn('The case insensitive expected value.');
+        $resolver->shouldReceive('format')->once()->andReturn(null);
+        $resolver->shouldReceive('findOrFail')->once()->andReturn($element);
+
+        $mock->assertSee('Case Insensitive', false);
+    }
+
+    public function test_assert_see_failure()
+    {
+        $this->expectException(PHPUnit_Framework_AssertionFailedError::class);
+
+        $mock = Mockery::mock(DuskTest::class)->makePartial();
+
+        $resolver = Mockery::mock(ElementResolver::class);
+
+        $mock->resolver = $resolver;
+
+        $element = Mockery::mock(RemoteWebElement::class);
+        $element->shouldReceive('getText')->once()->andReturn('The expected value.');
+        $resolver->shouldReceive('format')->once()->andReturn(null);
+        $resolver->shouldReceive('findOrFail')->once()->andReturn($element);
+
+        $mock->assertSee('actual value');
+    }
+
+    public function test_assert_see_failure_because_of_case_sensitivity()
+    {
+        $this->expectException(PHPUnit_Framework_AssertionFailedError::class);
+
+        $mock = Mockery::mock(DuskTest::class)->makePartial();
+
+        $resolver = Mockery::mock(ElementResolver::class);
+
+        $mock->resolver = $resolver;
+
+        $element = Mockery::mock(RemoteWebElement::class);
+        $element->shouldReceive('getText')->once()->andReturn('The case sensitive expected value.');
+        $resolver->shouldReceive('format')->once()->andReturn(null);
+        $resolver->shouldReceive('findOrFail')->once()->andReturn($element);
+
+        $mock->assertSee('Case Sensitive');
+    }
+}
+
+class DuskTest
+{
+    use MakesAssertions;
+}


### PR DESCRIPTION
if the user wants the test to be case insensitive we will just lower-case everything.  by default assertions remain case-sensitive by default to maintain BC.

also add some tests.

I am not the world's most experienced unit tester, so suggestions are welcome.