### PR TITLE
Attempt to solve TTY issue

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -61,7 +61,7 @@ class DuskCommand extends Command
                 ->setPrefix($this->binary())
                 ->setArguments($this->phpunitArguments($options))
                 ->getProcess()
-                ->setTty(PHP_OS !== 'WINNT')
+                ->setTty(PHP_OS !== 'WINNT' && is_writable('/dev/tty'))
                 ->run(function ($type, $line) {
                     $this->output->write($line);
                 });


### PR DESCRIPTION
Following up on #136, `is_writable` seems A LOT less harmless and simpler to check before attempting to enable TTY. However, I would need somebody actually suffering from the issue to check if this actually resolves the problem.

The only other solution would be to break the chain and catch the RuntimeException thrown by Symphony, in my opinion.