### PR TITLE
Supress Symphony exception when TTY is not available

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -64,7 +64,7 @@ class DuskCommand extends Command
                 ->getProcess();
 
             try {
-                $process->setTty(PHP_OS !== 'WINNT');
+                $process->setTty(true);
             } catch (RuntimeException $e) {
                 $this->output->writeln('Warning: ' . $e->getMessage());
             }

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -5,8 +5,8 @@ namespace Laravel\Dusk\Console;
 use Dotenv\Dotenv;
 use Illuminate\Console\Command;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Exception\RuntimeException;
 
 class DuskCommand extends Command
 {
@@ -66,7 +66,7 @@ class DuskCommand extends Command
             try {
                 $process->setTty(true);
             } catch (RuntimeException $e) {
-                $this->output->writeln('Warning: ' . $e->getMessage());
+                $this->output->writeln('Warning: '.$e->getMessage());
             }
 
             return $process->run(function ($type, $line) {


### PR DESCRIPTION
Instead of trying to figure out whether TTY is available or not, let Symphony come up with the answer for this (no need to reinvent the wheel). If they tell us it's not available (throw exception), simply ignore it. The side effect is basically no colors on your tests, which people running on CI might not care and/or the CI itself might implement colors themselves.

Without TTY:
![Without TTY](https://puu.sh/voerq/2b85469e47.png)

With TTY:
![With TTY](https://puu.sh/voepW/a948866d65.png)

Should be enough to close #202 and provide liable solution for people supporting #136 