### PR TITLE
Compatibility with PHPUnit ~6.0

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -32,11 +32,12 @@ abstract class TestCase extends FoundationTestCase
     /**
      * Register the base URL with Dusk.
      *
-     * @before
      * @return void
      */
-    public function propagateScaffoldingToBrowser()
+    public function setUp()
     {
+        parent::setUp();
+
         Browser::$baseUrl = $this->baseUrl();
 
         Browser::$storeScreenshotsAt = base_path('tests/Browser/screenshots');


### PR DESCRIPTION
This closes #99. Although it looks a breaking change, it actually isn't. If someone is overriding the `setUp` method, they're already calling the `parent` from within it otherwise the application doesn't work. This change only adds one more step to the `setUp`.

```
[dusk@php7 dusk-with-unit]$ php artisan serve &
[1] 2538
[dusk@php7 dusk-with-unit]$ Laravel development server started: <http://127.0.0.1:8000>

[dusk@php7 dusk-with-unit]$
[dusk@php7 dusk-with-unit]$ php artisan dusk
PHPUnit 6.1.0 by Sebastian Bergmann and contributors.

[Tue Apr 18 14:43:08 2017] 127.0.0.1:51566 [200]: /favicon.ico
.                                                                   1 / 1 (100%)

Time: 2.03 seconds, Memory: 10.00MB

OK (1 test, 1 assertion)
```