### PR TITLE
[1.0.13] Let jQuery handle string selector

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -70,7 +70,7 @@ trait InteractsWithElements
     {
         $this->ensurejQueryIsAvailable();
 
-        $selector = trim($this->resolver->format("a:contains('{$link}')"));
+        $selector = trim($this->resolver->format("a:contains({$link})"));
 
         $this->driver->executeScript("jQuery.find(\"{$selector}\")[0].click();");
 


### PR DESCRIPTION
Closes #56 

```
    public function testBasicExample() {
        $this->browse(function (Browser $browser) {
            $browser->visit('/')
                ->assertSee('Laravel')
                ->clickLink('Laravel\'s Documentation');
        });
    }
```