### PR TITLE
[1.0.13] Include custom browser with scaffolding to encourage custom assertion

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -54,6 +54,7 @@ class InstallCommand extends Command
             'HomePage.stub' => base_path('tests/Browser/Pages/HomePage.php'),
             'DuskTestCase.stub' => base_path('tests/DuskTestCase.php'),
             'Page.stub' => base_path('tests/Browser/Pages/Page.php'),
+            'Browser.stub' => base_path('tests/Browser/Browser.php'),
         ];
 
         foreach ($subs as $stub => $file) {

--- a/src/Console/stubs/test.stub
+++ b/src/Console/stubs/test.stub
@@ -3,7 +3,7 @@
 namespace DummyNamespace;
 
 use Tests\DuskTestCase;
-use Laravel\Dusk\Browser;
+use Tests\Browser\Browser;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class DummyClass extends DuskTestCase

--- a/stubs/Browser.stub
+++ b/stubs/Browser.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Browser;
+
+use Laravel\Dusk\Browser as DuskBrowser;
+
+class Browser extends DuskBrowser
+{
+
+    /**
+     * Make your custom assertion
+     *
+     * @return $this
+     */
+    public function assertLaravelIsAwesome() {
+        // Make your assertion
+
+        return $this;
+    }
+}

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Tests\Browser\Browser;
 use Laravel\Dusk\TestCase as BaseTestCase;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
@@ -19,6 +20,17 @@ abstract class DuskTestCase extends BaseTestCase
     public static function prepare()
     {
         static::startChromeDriver();
+    }
+
+    /**
+     * Instantiate object to manipulate the browser
+     *
+     * @param RemoteWebDriver $driver
+     * @return Browser
+     */
+    protected function newBrowser($driver)
+    {
+        return new Browser($driver);
     }
 
     /**

--- a/stubs/ExampleTest.stub
+++ b/stubs/ExampleTest.stub
@@ -17,7 +17,8 @@ class ExampleTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->visit('/')
-                    ->assertSee('Laravel');
+                    ->assertSee('Laravel')
+                    ->assertLaravelIsAwesome();
         });
     }
 }

--- a/stubs/HomePage.stub
+++ b/stubs/HomePage.stub
@@ -2,7 +2,7 @@
 
 namespace Tests\Browser\Pages;
 
-use Laravel\Dusk\Browser;
+use Tests\Browser\Browser;
 
 class HomePage extends Page
 {


### PR DESCRIPTION
We always want more assertion than the framework offers. This is a way of making it easy for everyone to understand how easy it is to build your custom assertion.

#217 #209 #206 #189 all talks about other options of assertion.