### PR TITLE
[1.0.13] Better approach for environment exception

### DIFF
--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -8,6 +8,14 @@ use Illuminate\Support\ServiceProvider;
 
 class DuskServiceProvider extends ServiceProvider
 {
+
+    /**
+     * Environments prohibited to register dusk
+     *
+     * @var array
+     */
+    protected $blacklist = ['production'];
+
     /**
      * Bootstrap any package services.
      *
@@ -39,7 +47,7 @@ class DuskServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if ($this->app->environment('production')) {
+        if ($this->app->environment($this->blacklist)) {
             throw new Exception('It is unsafe to run Dusk in production.');
         }
 

--- a/tests/DuskServiceProviderTest.php
+++ b/tests/DuskServiceProviderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Laravel\Dusk\DuskServiceProvider;
+
+class DuskServiceProviderTest extends TestCase {
+
+    /**
+     * @expectedException Exception
+     */
+    public function test_production_is_disallowed() {
+        $app = Mockery::mock(StdClass::class);
+        $app->shouldReceive('environment')->with(['production'])->andReturn(true);
+        $dusk = new DuskServiceProvider($app);
+        $dusk->register();
+    }
+
+    public function test_blacklist_override() {
+        $app = Mockery::mock(StdClass::class);
+        $app->shouldReceive('environment')->with([])->andReturn(false);
+        $app->shouldReceive('runningInConsole')->andReturn(true);
+        $dusk = new ExtendedDuskServiceProvider($app);
+        $dusk->register();
+    }
+
+}
+
+class ExtendedDuskServiceProvider extends DuskServiceProvider {
+    protected $blacklist = [];
+
+    public function commands($commands) {
+
+    }
+}


### PR DESCRIPTION
Extract environment to class attribute. If somebody wants to override the class and explicitly register Dusk on production, it won't juts be an accident.

Also added tests for this.