### PR TITLE
Changed inputValue assertions to check textarea element

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -397,7 +397,7 @@ JS;
     {
         $element = $this->resolver->resolveForTyping($field);
 
-        return $element->getTagName() == 'input'
+        return in_array($element->getTagName(), ['input', 'textarea'])
                         ? $element->getAttribute('value')
                         : $element->getText();
     }


### PR DESCRIPTION
The docblock suggests that a textarea element is examined as part of `assertInputValue` and `assertInputValueIsNot`. I ran into problems checking a textarea value earlier, so this fixes that.