### PR TITLE
[1.0.13] Cast option value to string for testing

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -582,7 +582,7 @@ JS;
     {
         $element = $this->resolver->resolveForSelection($field);
 
-        return $element->getAttribute('value') === $value;
+        return (string) $element->getAttribute('value') === (string) $value;
     }
 
     /**


### PR DESCRIPTION
Replicates the solution of #178 and closes #238. Basically the tests fails because we're usually testing for numbers on `selected` and the `resolver` will always return a `string` or `null`.