### PR TITLE
Adds back PHP_BINARY to phpunit process

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -78,11 +78,11 @@ class DuskCommand extends Command
     /**
      * Get the PHP binary to execute.
      *
-     * @return string
+     * @return string|array
      */
     protected function binary()
     {
-        return PHP_OS === 'WINNT' ? base_path('vendor\bin\phpunit.bat') : 'vendor/bin/phpunit';
+        return PHP_OS === 'WINNT' ? base_path('vendor\bin\phpunit.bat') : [PHP_BINARY, 'vendor/bin/phpunit'];
     }
 
     /**


### PR DESCRIPTION
Disclaimer: Not sure of the implications of this on windows, as I can't test it...

A while back a [pull request](https://github.com/laravel/dusk/pull/51/files) was accepted that ensured PHP_BINARY was used for phpunit. Almost immediately after, that change was reverted in a refactor. This brings that fix back.