### PR TITLE
Revert "Adds back PHP_BINARY to phpunit process"

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -78,11 +78,11 @@ class DuskCommand extends Command
     /**
      * Get the PHP binary to execute.
      *
-     * @return string|array
+     * @return string
      */
     protected function binary()
     {
-        return PHP_OS === 'WINNT' ? base_path('vendor\bin\phpunit.bat') : [PHP_BINARY, 'vendor/bin/phpunit'];
+        return PHP_OS === 'WINNT' ? base_path('vendor\bin\phpunit.bat') : 'vendor/bin/phpunit';
     }
 
     /**


### PR DESCRIPTION
Reverts laravel/dusk#240

This breaks Dusk on Virtual Machines with Windows Hosts. After updating to `1.0.13`, this is the result: 

```
[dusk@php7 linus-laravel]$ php artisan dusk --group=f

dir=$(d=${0%[/\\]*}; cd "$d"; cd '../phpunit/phpunit' && pwd)

# See if we are running in Cygwin by checking for cygpath program
if command -v 'cygpath' >/dev/null 2>&1; then
        # Cygwin paths start with /cygdrive/ which will break windows PHP,
        # so we need to translate the dir path to windows format. However
        # we could be using cygwin PHP which does not require this, so we
        # test if the path to PHP starts with /cygdrive/ rather than /usr/bin
        if [[ $(which php) == /cygdrive/* ]]; then
                dir=$(cygpath -m "$dir");
        fi
fi

dir=$(echo $dir | sed 's/ /\ /g')
"${dir}/phpunit" "$@"
[dusk@php7 linus-laravel]$
```

By erasing the `PHP_BINARY` from the array, I was able to run my tests normally again.

@jhoff any reason why you need this change?