### PR TITLE
[1.0.15] Invoke php script from phpunit folder directly

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -78,11 +78,11 @@ class DuskCommand extends Command
     /**
      * Get the PHP binary to execute.
      *
-     * @return string
+     * @return array
      */
     protected function binary()
     {
-        return PHP_OS === 'WINNT' ? base_path('vendor\bin\phpunit.bat') : 'vendor/bin/phpunit';
+        return [PHP_BINARY, 'vendor/phpunit/phpunit/phpunit'];
     }
 
     /**


### PR DESCRIPTION
Definitive solution for #240 and #243.

### The problem

Dusk runs the php version available on `path`, while people might want to do things like: `php-56 artisan dusk` or `php-71 artisan dusk` (where **php-56** and **php-71** are different binaries for php located in different places). The behavior expected would be that running dusk from a specific binary asserts that PHPUnit also runs from that specific binary.

### The difficulties

`DuskCommand` was using `vendor/bin` folder to quickly run phpunit. The problem with this approach are listed below: 

- On a Unix environment (Linux and probably Mac), `vendor/bin/phpunit` will be a `php` script provided by PHPUnit. [Source](https://github.com/sebastianbergmann/phpunit/blob/master/phpunit)
- On Windows, composer will make sure to translate the executable to a `bat` file. [Source](https://github.com/composer/composer/blob/14c77130e8f717ceb154720e1abefafe99124cb9/src/Composer/Installer/BinaryInstaller.php#L181-L184)
- On Linux Virtual Machine, provided by a Windows Host, composer will consider you need a Proxy script and translate accordingly. [Source](https://github.com/composer/composer/blob/14c77130e8f717ceb154720e1abefafe99124cb9/src/Composer/Installer/BinaryInstaller.php#L195-L212)

The main reason this is a difficulty is that if `vendor/bin/phpunit` is a php script, you can `php /bin/phpunit`, but if it's a `bat` or a proxy script, you can't invoke it from php.

### The solution

Understanding this makes us appreciate much more composer, but given Dusk's core goal is to just wrap `phpunit` (and PHPUnit is actually a PHP script instead of `bash`), we could just bypass this and go straight to `vendor/phpunit/phpunit/phpunit` file. The beauty of this solution is that not only solves the problem, but we can trust that `PHP_BINARY` will be executable regardless of the operating system (whether it's `/usr/bin/php` or `C:\php\php.exe`) and it will KNOW how to run phpunit's script file.

Special thanks to @jhoff to have brought it up. It gave me an amazing opportunity to improve my understanding of the ecosystem I use on a daily basis.


## Windows (cmd.exe)
![Windows](https://puu.sh/vtwdS/a8b4ea25cb.png)

## Linux Guest (Windows Host)
![Linux Guest](https://puu.sh/vtw1Q/81d333a3b2.png)

## Windows Bash (cygwin.exe)
![Windows Bash](https://puu.sh/vtwcq/faf7997c30.png)