### PR TITLE
Assure the environment running dusk matches the web server environment

### DIFF
--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -29,6 +29,13 @@ class DuskServiceProvider extends ServiceProvider
             'middleware' => 'web',
             'uses' => 'Laravel\Dusk\Http\Controllers\UserController@user',
         ]);
+
+        Route::get('/_dusk/env', [
+            'middleware' => 'web',
+            'uses' => function () {
+                return getenv('APP_ENV');
+            }
+        ]);
     }
 
     /**

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -122,6 +122,8 @@ abstract class TestCase extends FoundationTestCase
             static::$browsers->push($this->newBrowser($this->createWebDriver()));
         }
 
+        $this->validateBrowserEnvironment(static::$browsers->first());
+
         return static::$browsers;
     }
 
@@ -241,5 +243,20 @@ abstract class TestCase extends FoundationTestCase
     protected function user()
     {
         throw new Exception("User resolver has not been set.");
+    }
+
+    /**
+     * Verify that dusk environment matches the web environment.
+     *
+     * @param Browser $browser
+     * @throws Exception
+     */
+    protected function validateBrowserEnvironment(Browser $browser)
+    {
+        $dusk = $browser->visit('/_dusk/env')->element('')->getText();
+        $web = getenv('APP_ENV');
+        if ($dusk != $web) {
+            throw new Exception("Dusk environment [{$dusk}] diverge from web environment [{$web}]");
+        }
     }
 }


### PR DESCRIPTION
Dusk tries to enforce environment compatibility between itself and the environment the browser will access by swapping the `.env` file, which will be used by the Web Server. Doing this allows cool things like `assertDatabaseHas` to work properly. However, if you don't have compatible setup, things might not work correctly.

One way to get stuck is to combine `dusk` with `serve`, because `php artisan serve` will use `.env` before dusk had a chance to swap it. This PR makes it easier for the developer not to mess with the local environment by running dusk on it as well as making it easy to identify which environment dusk was running and which environment the webserver was providing.