### PR TITLE
Add dusk:serve command

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -41,6 +41,10 @@ class DuskCommand extends Command
         parent::__construct();
 
         $this->ignoreValidationErrors();
+
+        $this->purgeScreenshots();
+
+        $this->purgeConsoleLogs();
     }
 
     /**
@@ -50,28 +54,32 @@ class DuskCommand extends Command
      */
     public function handle()
     {
-        $this->purgeScreenshots();
+        return $this->withDuskEnvironment([$this, 'runPhpunit']);
+    }
 
-        $this->purgeConsoleLogs();
-
+    /**
+     * Build and run PHPUnit process
+     *
+     * @return int
+     */
+    protected function runPhpunit()
+    {
         $options = array_slice($_SERVER['argv'], 2);
 
-        return $this->withDuskEnvironment(function () use ($options) {
-            $process = (new ProcessBuilder())
-                ->setTimeout(null)
-                ->setPrefix($this->binary())
-                ->setArguments($this->phpunitArguments($options))
-                ->getProcess();
+        $process = (new ProcessBuilder())
+            ->setTimeout(null)
+            ->setPrefix($this->binary())
+            ->setArguments($this->phpunitArguments($options))
+            ->getProcess();
 
-            try {
-                $process->setTty(true);
-            } catch (RuntimeException $e) {
-                $this->output->writeln('Warning: '.$e->getMessage());
-            }
+        try {
+            $process->setTty(true);
+        } catch (RuntimeException $e) {
+            $this->output->writeln('Warning: '.$e->getMessage());
+        }
 
-            return $process->run(function ($type, $line) {
-                $this->output->write($line);
-            });
+        return $process->run(function ($type, $line) {
+            $this->output->write($line);
         });
     }
 

--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Laravel\Dusk\Console;
+
+use Laravel\Dusk\Console\DuskCommand as BaseCommand;
+use Symfony\Component\Process\ProcessBuilder;
+
+class ServeCommand extends BaseCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dusk:serve';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Serve the application and run Dusk tests';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->withDuskEnvironment(function () {
+            $exec = PHP_OS != 'WINNT' ? ['exec'] : [];
+            $arguments = array_merge($exec, [PHP_BINARY, 'artisan', 'serve']);
+
+            $serve = (new ProcessBuilder($arguments))
+                ->setTimeout(null)
+                ->getProcess();
+
+            $serve->start();
+
+            return tap(parent::runPhpunit(), function () use ($serve) {
+                $serve->stop();
+            });
+        });
+    }
+}

--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -2,10 +2,9 @@
 
 namespace Laravel\Dusk\Console;
 
-use Laravel\Dusk\Console\DuskCommand as BaseCommand;
 use Symfony\Component\Process\ProcessBuilder;
 
-class ServeCommand extends BaseCommand
+class ServeCommand extends DuskCommand
 {
     /**
      * The name and signature of the console command.


### PR DESCRIPTION
While keeping `php artisan dusk` unaltered, this PR will add `php artisan dusk:serve` to the list of available commands to achieve an automatic behavior of serving the application.

- Swap `.env` files;
- Build and run `php artisan serve`
- Build and run Phpunit (inheriting `DuskCommand`)

Not only solves the tedious task of having to turn on a server to run dusk everytime, it will never `serve` an `env` that doesn't match dusk's because of the order of processing.

Special thanks to @SebastianS90 for the `php artisan serve` builder posted on #162 

It even works on `cmd.exe` (which I don't really find important, but hey).

![cmd.exe](https://puu.sh/vw7wX/df5fb5d85a.png)