### PR TITLE
Added new interaction to type without clearing

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -178,7 +178,7 @@ trait InteractsWithElements
      * @param  string  $value
      * @return $this
      */
-    public function typeWithoutClearing($field, $value)
+    public function append($field, $value)
     {
         $this->resolver->resolveForTyping($field)->sendKeys($value);
 

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -172,6 +172,20 @@ trait InteractsWithElements
     }
 
     /**
+     * Type the given value in the given field without clearing it.
+     *
+     * @param  string  $field
+     * @param  string  $value
+     * @return $this
+     */
+    public function typeWithoutClearing($field, $value)
+    {
+        $this->resolver->resolveForTyping($field)->sendKeys($value);
+
+        return $this;
+    }
+
+    /**
      * Clear the given field.
      *
      * @param  string  $field


### PR DESCRIPTION
In certain situations, appending onto already typed values is useful, particularly when continuing to retry inline validation and assert the result.

Or, just a more elegant way to type after line breaks have been added using `keys`.

```php
->type('@body', 'Test message')
->keys('@body', '{shift}', '{enter}')
->append('@body', 'New line')
```