### PR TITLE
Save the failed HTML source code

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -36,6 +36,13 @@ class Browser
     public static $storeScreenshotsAt;
 
     /**
+     * The directory that will contain any page sources.
+     *
+     * @var string
+     */
+    public static $storeSourcesAt;
+
+    /**
      * The directory that will contain any console logs.
      *
      * @var string
@@ -216,6 +223,22 @@ class Browser
     {
         $this->driver->takeScreenshot(
             sprintf('%s/%s.png', rtrim(static::$storeScreenshotsAt, '/'), $name)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Store the source code with the given name.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function source($name)
+    {
+        file_put_contents(
+            sprintf('%s/%s.html', rtrim(static::$storeSourcesAt, '/'), $name),
+            $this->driver->getPageSource()
         );
 
         return $this;

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -52,6 +52,8 @@ class DuskCommand extends Command
     {
         $this->purgeScreenshots();
 
+        $this->purgeSources();
+
         $this->purgeConsoleLogs();
 
         $options = array_slice($_SERVER['argv'], 2);
@@ -95,6 +97,15 @@ class DuskCommand extends Command
         return array_merge(['-c', base_path('phpunit.dusk.xml')], $options);
     }
 
+    protected function purgeFiles($path, $name)
+    {
+        $files = Finder::create()->files()->in($path)->name($name);
+
+        foreach ($files as $file) {
+            @unlink($file->getRealPath());
+        }
+    }
+
     /**
      * Purge the failure screenshots
      *
@@ -102,13 +113,17 @@ class DuskCommand extends Command
      */
     protected function purgeScreenshots()
     {
-        $files = Finder::create()->files()
-                        ->in(base_path('tests/Browser/screenshots'))
-                        ->name('failure-*');
+        $this->purgeFiles(base_path('tests/Browser/screenshots'), 'failure-*');
+    }
 
-        foreach ($files as $file) {
-            @unlink($file->getRealPath());
-        }
+    /**
+     * Purge the failure sources
+     *
+     * @return void
+     */
+    protected function purgeSources()
+    {
+        $this->purgeFiles(base_path('tests/Browser/sources'), 'failure-*');
     }
 
     /**
@@ -118,13 +133,7 @@ class DuskCommand extends Command
      */
     protected function purgeConsoleLogs()
     {
-        $files = Finder::create()->files()
-            ->in(base_path('tests/Browser/console'))
-            ->name('*.log');
-
-        foreach ($files as $file) {
-            @unlink($file->getRealPath());
-        }
+        $this->purgeFiles(base_path('tests/Browser/console'), '*.log');
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -45,6 +45,10 @@ class InstallCommand extends Command
             $this->createScreenshotsDirectory();
         }
 
+        if (! is_dir(base_path('tests/Browser/sources'))) {
+            $this->createSourcesDirectory();
+        }
+
         if (! is_dir(base_path('tests/Browser/console'))) {
             $this->createConsoleDirectory();
         }
@@ -89,6 +93,20 @@ class InstallCommand extends Command
         mkdir(base_path('tests/Browser/console'), 0755, true);
 
         file_put_contents(base_path('tests/Browser/console/.gitignore'), '*
+!.gitignore
+');
+    }
+
+    /**
+     * Create the screenshots directory.
+     *
+     * @return void
+     */
+    protected function createSourcesDirectory()
+    {
+        mkdir(base_path('tests/Browser/sources'), 0755, true);
+
+        file_put_contents(base_path('tests/Browser/sources/.gitignore'), '*
 !.gitignore
 ');
     }

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -42,6 +42,8 @@ abstract class TestCase extends FoundationTestCase
 
         Browser::$storeScreenshotsAt = base_path('tests/Browser/screenshots');
 
+        Browser::$storeSourcesAt = base_path('tests/Browser/sources');
+
         Browser::$storeConsoleLogAt = base_path('tests/Browser/console');
 
         Browser::$userResolver = function () {
@@ -157,6 +159,8 @@ abstract class TestCase extends FoundationTestCase
     {
         $browsers->each(function ($browser, $key) {
             $browser->screenshot('failure-'.$this->getName().'-'.$key);
+
+            $browser->source('failure-'.$this->getName().'-'.$key);
         });
     }
 


### PR DESCRIPTION
Having the screenshot it's nice, but sometimes, to debug your tests, it's not enough, so the generated HTML may help.