### PR TITLE
Add waitForReload method to wait for page reload to continue

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -121,6 +121,26 @@ trait WaitsForElements
     }
 
     /**
+     * Wait for the current page to reload.
+     *
+     * @param  Closure  $callback
+     * @param  int  $seconds
+     * @return $this
+     */
+    public function waitForReload($callback = null, $seconds = 5)
+    {
+        $reloadStateKey = str_random();
+
+        $this->executeScript("window['{$reloadStateKey}'] = \{\};");
+
+        $callback && $callback($this);
+
+        return $this->waitUsing($seconds, 100, function () use ($script) {
+            return $this->driver->executeScript("return typeof window['{$reloadStateKey}'] === 'undefined';");
+        });
+    }
+
+    /**
      * Wait for the given callback to be true.
      *
      * @param  int  $seconds


### PR DESCRIPTION
When writing Laravel & Vue.js I often call an endpoint in my app:
```
axios.get('/endpoint').then(response => {
    window.location.reload(); //or
    window.location.href = response.data.redirect_url;
});
```
This can be difficult to test because of reload timing.

The following is my solution:
```
$browser->waitForReload(function ($browser) {
    $browser->click('.some-action');
})->assertSee('something');

// or inline works too

$browser->click('.some-action')
    ->waitForReload()
    ->assertSee('something');
```

The implementation uses Javascript to set a variable and check that it no longer exists (after reload). It works for me, but I can see that some would feel iffy about this solution. Hopefully it lands well here and is pulled in.

Thanks for all the hard work as always!