### PR TITLE
Define connection and request timeouts on RemoteWebDriver creation

### DIFF
--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -29,7 +29,7 @@ abstract class DuskTestCase extends BaseTestCase
     protected function driver()
     {
         return RemoteWebDriver::create(
-            'http://localhost:9515', DesiredCapabilities::chrome()
+            'http://localhost:9515', DesiredCapabilities::chrome(), 2000, 7000
         );
     }
 }

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -29,7 +29,7 @@ abstract class DuskTestCase extends BaseTestCase
     protected function driver()
     {
         return RemoteWebDriver::create(
-            'http://localhost:9515', DesiredCapabilities::chrome(), 2000, 7000
+            'http://localhost:9515', DesiredCapabilities::chrome(), 5000, 10000
         );
     }
 }


### PR DESCRIPTION
These default timeouts would help a lot. Instead of having a hanging process (for whatever reason), we would get an exception describing what happened.