### PR TITLE
Add tinker method to pause and open Laravel Tinker

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -322,6 +322,18 @@ class Browser
     }
 
     /**
+     * Pause execution of test and open Laravel Tinker (PsySH) REPL.
+     *
+     * @return $this
+     */
+    public function tinker()
+    {
+        eval(\Psy\sh());
+
+        return $this;
+    }
+
+    /**
      * Stop running tests but leave the browser open.
      *
      * @return void


### PR DESCRIPTION
I recently stumbled on a cool trick that has made writing Dusk tests SOOO much nicer for me.

Take a look at the following code:
```
$browser->visitRoute('route');

// special snippet that pauses execution and opens Tinker
eval(\Psy\sh());

@browser->assertSee(...
```
You can see it in action here:
![](https://blog.tighten.co/assets/img/tinker_dusk.gif)
I also wrote about [here](https://blog.tighten.co/supercharge-your-laravel-tinker-workflow)

I would love to have this functionality inline like so:
```
$browser->visitRoute('route')
    ->tinker()
    ->assertSee(...
```

I'm guessing there are some problems with my implementation, like it wouldn't work if someone used Dusk outside the Laravel App context, or if someone chose to not include the Laravel tinker package. Let me know if you have any thoughts on this and we can work towards a better solution, unless what I have is good enough!

As always, thanks for all the hard work! Dusk is AWESOME :)

- Caleb
