### PR TITLE
Reset cookies after browse closure completes

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -344,6 +344,16 @@ class Browser
     }
 
     /**
+     * Clear all browser cookies.
+     *
+     * @return void
+     */
+    public function clearCookies()
+    {
+        $this->driver->manage()->deleteAllCookies();
+    }
+
+    /**
      * Dynamically call a method on the browser.
      *
      * @param  string  $method

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -100,7 +100,7 @@ abstract class TestCase extends FoundationTestCase
         } finally {
             $this->storeConsoleLogsFor($browsers);
 
-            static::$browsers = $this->closeAllButPrimary($browsers);
+            static::$browsers = $this->resetToFreshBrowser($browsers);
         }
     }
 
@@ -174,15 +174,16 @@ abstract class TestCase extends FoundationTestCase
     }
 
     /**
-     * Close all of the browsers except the primary (first) one.
+     * Reset to one fresh browser.
      *
      * @param  \Illuminate\Support\Collection  $browsers
      * @return \Illuminate\Support\Collection
      */
-    protected function closeAllButPrimary($browsers)
+    protected function resetToFreshBrowser($browsers)
     {
         $browsers->slice(1)->each->quit();
-
+        $browsers->first()->clearCookies();
+        
         return $browsers->take(1);
     }
 

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -91,6 +91,14 @@ class BrowserTest extends TestCase
 
         $this->assertTrue($browser->page->macroed);
     }
+
+    public function test_clear_cookies()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('manage->deleteAllCookies');
+        $browser = new Browser($driver);
+        $browser->clearCookies();
+    }
 }
 
 


### PR DESCRIPTION
Right now, each call to `browse()` shares the same `Browser` instance, which means that tests that open sessions or set other cookies can influence each other. This adds a `clearCookies()` method the `Browser` class, and automatically calls it after the `browse()` closure completes. That way each test starts fresh. This should resolve issue #100.