### PR TITLE
Update access level for TestCase::setUp()

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -34,7 +34,7 @@ abstract class TestCase extends FoundationTestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 


### PR DESCRIPTION
The access level for `setUp` in phpunit is `protected.`

`setup` builds fixture before tests are conducted, which should NOT be visible to outside classes.