### PR TITLE
Optionally clear cookies during tearDown()

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -344,6 +344,16 @@ class Browser
     }
 
     /**
+     * Clear all browser cookies.
+     *
+     * @return void
+     */
+    public function clearCookies()
+    {
+        $this->driver->manage()->deleteAllCookies();
+    }
+
+    /**
      * Dynamically call a method on the browser.
      *
      * @param  string  $method

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -57,7 +57,7 @@ abstract class TestCase extends FoundationTestCase
     }
 
     /**
-     * Optionally clear all cookies after a test has run
+     * Optionally clear all cookies after a test has run.
      *
      * @return void
      */
@@ -66,7 +66,7 @@ abstract class TestCase extends FoundationTestCase
         parent::tearDown();
 
         if ($this->clearCookiesBetweenTests) {
-            static::$browsers->each->clearCookies();
+            Collection::make(static::$browsers)->each->clearCookies();
         }
     }
 

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -100,7 +100,7 @@ abstract class TestCase extends FoundationTestCase
         } finally {
             $this->storeConsoleLogsFor($browsers);
 
-            static::$browsers = $this->closeAllButPrimary($browsers);
+            static::$browsers = $this->resetToFreshBrowser($browsers);
         }
     }
 
@@ -174,15 +174,16 @@ abstract class TestCase extends FoundationTestCase
     }
 
     /**
-     * Close all of the browsers except the primary (first) one.
+     * Reset to one fresh browser.
      *
      * @param  \Illuminate\Support\Collection  $browsers
      * @return \Illuminate\Support\Collection
      */
-    protected function closeAllButPrimary($browsers)
+    protected function resetToFreshBrowser($browsers)
     {
         $browsers->slice(1)->each->quit();
-
+        $browsers->first()->clearCookies();
+        
         return $browsers->take(1);
     }
 

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -30,6 +30,13 @@ abstract class TestCase extends FoundationTestCase
     protected static $afterClassCallbacks = [];
 
     /**
+     * Indicates whether cookies should be cleared between tests.
+     *
+     * @var bool
+     */
+    protected $clearCookiesBetweenTests = false;
+
+    /**
      * Register the base URL with Dusk.
      *
      * @return void
@@ -47,6 +54,20 @@ abstract class TestCase extends FoundationTestCase
         Browser::$userResolver = function () {
             return $this->user();
         };
+    }
+
+    /**
+     * Optionally clear all cookies after a test has run
+     *
+     * @return void
+     */
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        if ($this->clearCookiesBetweenTests) {
+            static::$browsers->each->clearCookies();
+        }
     }
 
     /**
@@ -100,7 +121,7 @@ abstract class TestCase extends FoundationTestCase
         } finally {
             $this->storeConsoleLogsFor($browsers);
 
-            static::$browsers = $this->resetToFreshBrowser($browsers);
+            static::$browsers = $this->closeAllButPrimary($browsers);
         }
     }
 
@@ -174,16 +195,15 @@ abstract class TestCase extends FoundationTestCase
     }
 
     /**
-     * Reset to one fresh browser.
+     * Close all of the browsers except the primary (first) one.
      *
      * @param  \Illuminate\Support\Collection  $browsers
      * @return \Illuminate\Support\Collection
      */
-    protected function resetToFreshBrowser($browsers)
+    protected function closeAllButPrimary($browsers)
     {
         $browsers->slice(1)->each->quit();
-        $browsers->first()->clearCookies();
-        
+
         return $browsers->take(1);
     }
 

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -91,6 +91,14 @@ class BrowserTest extends TestCase
 
         $this->assertTrue($browser->page->macroed);
     }
+
+    public function test_clear_cookies()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('manage->deleteAllCookies');
+        $browser = new Browser($driver);
+        $browser->clearCookies();
+    }
 }
 
 


### PR DESCRIPTION
_This is an alternate version of #268_

Right now, an entire test class shares the same primary `Browser` instance (secondary instances are destroyed after a test, but the primary instance is only cleared after the entire test class has finished running). This means that separate tests that open sessions or set other cookies can influence each other.

This PR adds a `clearCookies()` method the `Browser` class, and adds a `$clearCookiesBetweenTests` property (defaulted to `false`) to `Laravel\Dusk\TestCase` that lets you configure dusk to clear cookies between tests.

This means that if you want your tests to run in a more isolated way, you can just set:

```php
class ExampleTest extends DuskTestCase
{
    protected $clearCookiesBetweenTests = true;

    // ...
}
```

This should resolve issue #100.