### PR TITLE
Assert Page after resolving elements

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -142,14 +142,14 @@ class Browser
     {
         $this->page = $page;
 
-        $page->assert($this);
-
         // Here we will set the page elements on the resolver instance, which will allow
         // the developer to access short-cuts for CSS selectors on the page which can
         // allow for more expressive navigation and interaction with all the pages.
         $this->resolver->pageElements(array_merge(
             $page::siteElements(), $page->elements()
         ));
+        
+        $page->assert($this);
 
         return $this;
     }


### PR DESCRIPTION
This allow the use of elements inside the insert method of a page, exemple:

```php
class LoginPage extends Page
{
    public function assert(Browser $browser)
    {
        $browser->assertInputValue('@login', '')
    }

    public function elements()
    {
        return [
            '@login' => 'input[name=login]',
        ];
    }
}
```