### PR TITLE
Click using a jQuery selector

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -61,6 +61,22 @@ trait InteractsWithElements
     }
 
     /**
+     * Click the given jQuery selector.
+     *
+     * @param  string  $selector
+     * @param  int  $index
+     * @return $this
+     */
+    public function clickJQuery($selector, $index = 0)
+    {
+        $this->ensurejQueryIsAvailable();
+
+        $this->driver->executeScript("jQuery.find(\"{$selector}\")[{$index}].click();");
+
+        return $this;
+    }
+    
+    /**
      * Click the link with the given text.
      *
      * @param  string  $link


### PR DESCRIPTION
Similar to the `clickLink` method but to click any kind of element using a more complex selector.

Allow the use of things like: `input[name=email]:first + span`