### PR TITLE
Fix an invalid property name for the Chromedriver's path

### DIFF
--- a/src/SupportsChrome.php
+++ b/src/SupportsChrome.php
@@ -82,7 +82,7 @@ trait SupportsChrome
      */
     public static function useChromedriver($path)
     {
-        static::$chomeDriver = $path;
+        static::$chromeDriver = $path;
     }
 
     /**


### PR DESCRIPTION
Fixing a simple typo.

**Note:** I'm the one who wrote the original PR to add that driver path feature. I've provided [some tests](https://github.com/laravel/dusk/commit/90973b5f0a4cd8391bbf61107a65846e69a0c93c#diff-c6ca108ff86f360a346875f059c26f62) with the PR but [it seems like you got rid of them](https://github.com/laravel/dusk/commit/a0de2692ef4e5ec6aff4ccfcdec3519b11d28f5e#diff-c6ca108ff86f360a346875f059c26f62), is there any reason?