### PR TITLE
Support auto-discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,11 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Laravel\\Dusk\\DuskServiceProvider"
+            ]
         }
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
Support package autodiscovery coming in Laravel 5.5
This also removes the registering-only-in-local step, as it can be only required on require-dev