### PR TITLE
Stop supporting PHP 5.6 on Dusk 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
 


### PR DESCRIPTION
Due to the partial dependencies on Laravel 5.5, Dusk should also stop supporting PHP 5.6 on 2.0 release.