### PR TITLE
Preview mid test

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -338,6 +338,21 @@ class Browser
         return $this;
     }
 
+    public function preview($interval = 1000)
+    {
+        $time = time();
+
+        $name = sprintf('%s/%s.png', rtrim(static::$storeScreenshotsAt, '/'), $time);
+        $command = sprintf('/usr/bin/qlmanage -p %s > /dev/null 2> /dev/null', $name);
+
+        $this->pause($interval)->screenshot($time);
+
+        exec($command);
+        unlink($name);
+
+        return $this;
+    }
+
     /**
      * Stop running tests but leave the browser open.
      *


### PR DESCRIPTION
This change adds the ability to preview the screen state mid-test. It obviously needs docs still, but I thought the code would illustrate it well enough to decide whether the additional polish was warranted...

Edit 1: it only works on macOS. I'm sure it should be possible to cater for windows and linux (Ubuntu at least) but I don't have those on hand to write the code for...

Edit 2: This is obviously less useful if you're not running headless.