### PR TITLE
AssertSeeButton, AssertDontSeeButton fix

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -393,6 +393,8 @@ JS;
             $element = $this->resolver->resolveForButtonPress($button);
         } catch (InvalidArgumentException $exception) {
             $element = null;
+        } catch(NoSuchElementException $exception) {
+            $element = null;
         }
 
         PHPUnit::assertNotNull(
@@ -420,6 +422,8 @@ JS;
         try {
             $element = $this->resolver->resolveForButtonPress($button);
         } catch (InvalidArgumentException $exception) {
+            $element = null;
+        } catch(NoSuchElementException $exception) {
             $element = null;
         }
 

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -393,7 +393,7 @@ JS;
             $element = $this->resolver->resolveForButtonPress($button);
         } catch (InvalidArgumentException $exception) {
             $element = null;
-        } catch(NoSuchElementException $exception) {
+        } catch (NoSuchElementException $exception) {
             $element = null;
         }
 
@@ -423,7 +423,7 @@ JS;
             $element = $this->resolver->resolveForButtonPress($button);
         } catch (InvalidArgumentException $exception) {
             $element = null;
-        } catch(NoSuchElementException $exception) {
+        } catch (NoSuchElementException $exception) {
             $element = null;
         }
 


### PR DESCRIPTION
If the "$button" variable contains a selector (e.g. "#id_selector") and the resolver could not locate the button, it throws a "NoSuchElementException".