### PR TITLE
Use namespace when including PHPUnit

### DIFF
--- a/src/Concerns/InteractsWithAuthentication.php
+++ b/src/Concerns/InteractsWithAuthentication.php
@@ -3,7 +3,7 @@
 namespace Laravel\Dusk\Concerns;
 
 use Laravel\Dusk\Browser;
-use PHPUnit_Framework_Assert as PHPUnit;
+use PHPUnit\Framework\Assert as PHPUnit;
 
 trait InteractsWithAuthentication
 {


### PR DESCRIPTION
Use PHPUnit with namespace syntax (`use PHPUnit\Framework\Assert as PHPUnit;`) in `InteractsWithAuthentication.php` to allow for PHPUnit 6.
Which also follows how it is in the other files, ex `MakesAssertions.php`