### PR TITLE
Rename "$browser->with(" to "$browser->within("

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "2.0-dev"
         }
     },
     "minimum-stability": "dev"

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "php": ">=5.6.4",
         "facebook/webdriver": "~1.0",
         "nesbot/carbon": "~1.20",
-        "illuminate/console": "~5.4",
-        "illuminate/support": "~5.4",
+        "illuminate/console": "~5.5",
+        "illuminate/support": "~5.5",
         "symfony/console": "~3.2",
         "symfony/process": "~3.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,11 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Laravel\\Dusk\\DuskServiceProvider"
+            ]
         }
     },
     "minimum-stability": "dev"

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -248,7 +248,7 @@ class Browser
      * @param  \Closure  $callback
      * @return $this
      */
-    public function with($selector, Closure $callback)
+    public function within($selector, Closure $callback)
     {
         $browser = new static(
             $this->driver, new ElementResolver($this->driver, $this->resolver->format($selector))

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -148,7 +148,7 @@ class Browser
         $this->resolver->pageElements(array_merge(
             $page::siteElements(), $page->elements()
         ));
-        
+
         $page->assert($this);
 
         return $this;
@@ -177,7 +177,7 @@ class Browser
 
         return $this;
     }
-    
+
     /**
      * Maximize the browser window.
      *
@@ -328,12 +328,12 @@ class Browser
      */
     public function tinker()
     {
-        $browser = $this;
-        $driver = $this->driver;
-        $resolver = $this->resolver;
-        $page = $this->page;
-
-        \Psy\Shell::debug(compact('browser', 'driver', 'resolver', 'page'), $this);
+        \Psy\Shell::debug([
+            'browser' => $this,
+            'driver' => $this->driver,
+            'resolver' => $this->resolver,
+            'page' => $this->page,
+        ], $this);
 
         return $this;
     }

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -322,6 +322,18 @@ class Browser
     }
 
     /**
+     * Pause execution of test and open Laravel Tinker (PsySH) REPL.
+     *
+     * @return $this
+     */
+    public function tinker()
+    {
+        eval(\Psy\sh());
+
+        return $this;
+    }
+
+    /**
      * Stop running tests but leave the browser open.
      *
      * @return void

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -328,7 +328,12 @@ class Browser
      */
     public function tinker()
     {
-        eval(\Psy\sh());
+        $browser = $this;
+        $driver = $this->driver;
+        $resolver = $this->resolver;
+        $page = $this->page;
+
+        \Psy\Shell::debug(compact('browser', 'driver', 'resolver', 'page'), $this);
 
         return $this;
     }

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -142,14 +142,14 @@ class Browser
     {
         $this->page = $page;
 
-        $page->assert($this);
-
         // Here we will set the page elements on the resolver instance, which will allow
         // the developer to access short-cuts for CSS selectors on the page which can
         // allow for more expressive navigation and interaction with all the pages.
         $this->resolver->pageElements(array_merge(
             $page::siteElements(), $page->elements()
         ));
+        
+        $page->assert($this);
 
         return $this;
     }

--- a/src/Concerns/InteractsWithAuthentication.php
+++ b/src/Concerns/InteractsWithAuthentication.php
@@ -3,7 +3,7 @@
 namespace Laravel\Dusk\Concerns;
 
 use Laravel\Dusk\Browser;
-use PHPUnit_Framework_Assert as PHPUnit;
+use PHPUnit\Framework\Assert as PHPUnit;
 
 trait InteractsWithAuthentication
 {

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -131,7 +131,7 @@ trait WaitsForElements
     {
         $token = str_random();
 
-        $this->executeScript("window['{$token}'] = \{\};");
+        $this->driver->executeScript("window['{$token}'] = {};");
 
         if ($callback) {
             $callback($this);

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -21,7 +21,7 @@ trait WaitsForElements
      */
     public function whenAvailable($selector, Closure $callback, $seconds = 5)
     {
-        return $this->waitFor($selector, $seconds)->with($selector, $callback);
+        return $this->waitFor($selector, $seconds)->within($selector, $callback);
     }
 
     /**

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -233,6 +233,7 @@ class ElementResolver
     protected function findButtonByName($button)
     {
         if (! is_null($element = $this->find("input[type=submit][name='{$button}']")) ||
+            ! is_null($element = $this->find("input[type=button][value='{$button}']")) ||
             ! is_null($element = $this->find("button[name='{$button}']"))) {
             return $element;
         }

--- a/src/SupportsChrome.php
+++ b/src/SupportsChrome.php
@@ -82,7 +82,7 @@ trait SupportsChrome
      */
     public static function useChromedriver($path)
     {
-        static::$chomeDriver = $path;
+        static::$chromeDriver = $path;
     }
 
     /**

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -34,7 +34,7 @@ abstract class TestCase extends FoundationTestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -29,7 +29,7 @@ abstract class DuskTestCase extends BaseTestCase
     protected function driver()
     {
         return RemoteWebDriver::create(
-            'http://localhost:9515', DesiredCapabilities::chrome()
+            'http://localhost:9515', DesiredCapabilities::chrome(), 5000, 10000
         );
     }
 }

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Laravel\Dusk\TestCase as BaseTestCase;
+use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 
@@ -28,8 +29,12 @@ abstract class DuskTestCase extends BaseTestCase
      */
     protected function driver()
     {
+        $options = (new ChromeOptions)->addArguments(['--headless']);
+
         return RemoteWebDriver::create(
-            'http://localhost:9515', DesiredCapabilities::chrome(), 5000, 10000
+            'http://localhost:9515', DesiredCapabilities::chrome()->setCapability(
+                ChromeOptions::CAPABILITY, $options
+            )
         );
     }
 }

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -29,7 +29,10 @@ abstract class DuskTestCase extends BaseTestCase
      */
     protected function driver()
     {
-        $options = (new ChromeOptions)->addArguments(['--headless']);
+        $options = (new ChromeOptions)->addArguments([
+            '--disable-gpu',
+            '--headless'
+        ]);
 
         return RemoteWebDriver::create(
             'http://localhost:9515', DesiredCapabilities::chrome()->setCapability(

--- a/stubs/phpunit.xml
+++ b/stubs/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="bootstrap/autoload.php"
+         bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -57,7 +57,7 @@ class BrowserTest extends TestCase
         $driver = Mockery::mock(StdClass::class);
         $browser = new Browser($driver);
 
-        $browser->with('prefix', function ($browser) {
+        $browser->within('prefix', function ($browser) {
             $this->assertInstanceof(Browser::class, $browser);
             $this->assertEquals('body prefix', $browser->resolver->prefix);
         });
@@ -72,7 +72,7 @@ class BrowserTest extends TestCase
 
         $browser->visit($page = new BrowserTestPage);
 
-        $browser->with('prefix', function ($browser) use ($page) {
+        $browser->within('prefix', function ($browser) use ($page) {
             $this->assertInstanceof(Browser::class, $browser);
             $this->assertEquals('body prefix', $browser->resolver->prefix);
             $this->assertEquals($page, $browser->page);


### PR DESCRIPTION
```php
// current method
$browser->with('selector', ...

// more appropriate IMO
$browser->within('select', ...
```

Personally "within" is self explanatory. "with" doesn't seem intuitive to me and I believe the same for new-comers.

Also, I've been using "Pages" for reusable components and parts of a page. I'd eventially like to pull request the concept of "Components" or modify the way "Pages" behave to accommodate this. Using Page objects for UI flows and re-usable page components is common: see Ben Orenstiens video [here](https://www.youtube.com/watch?v=u6grFClqt6E&feature=youtu.be&__s=3zqnnsygjob5sobbuxzm)

```php
$browser->on(new Homepage)
    ->within(new Navbar, function ($browser) {
        $browser->click('@profile-dropdown'...
...
``` 

I understand this is a pretty big change to Dusk's API, but I think it's worth it in the long run for being added to 2.0.

Thanks!
Caleb