### PR TITLE
Rename '$browser->with()' to '$browser->within()'

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -248,7 +248,7 @@ class Browser
      * @param  \Closure  $callback
      * @return $this
      */
-    public function with($selector, Closure $callback)
+    public function within($selector, Closure $callback)
     {
         $browser = new static(
             $this->driver, new ElementResolver($this->driver, $this->resolver->format($selector))

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -21,7 +21,7 @@ trait WaitsForElements
      */
     public function whenAvailable($selector, Closure $callback, $seconds = 5)
     {
-        return $this->waitFor($selector, $seconds)->with($selector, $callback);
+        return $this->waitFor($selector, $seconds)->within($selector, $callback);
     }
 
     /**

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -57,7 +57,7 @@ class BrowserTest extends TestCase
         $driver = Mockery::mock(StdClass::class);
         $browser = new Browser($driver);
 
-        $browser->with('prefix', function ($browser) {
+        $browser->within('prefix', function ($browser) {
             $this->assertInstanceof(Browser::class, $browser);
             $this->assertEquals('body prefix', $browser->resolver->prefix);
         });
@@ -72,7 +72,7 @@ class BrowserTest extends TestCase
 
         $browser->visit($page = new BrowserTestPage);
 
-        $browser->with('prefix', function ($browser) use ($page) {
+        $browser->within('prefix', function ($browser) use ($page) {
             $this->assertInstanceof(Browser::class, $browser);
             $this->assertEquals('body prefix', $browser->resolver->prefix);
             $this->assertEquals($page, $browser->page);

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -52,7 +52,7 @@ class BrowserTest extends TestCase
         $browser->refresh();
     }
 
-    public function test_with_method()
+    public function test_within_method()
     {
         $driver = Mockery::mock(StdClass::class);
         $browser = new Browser($driver);
@@ -63,7 +63,7 @@ class BrowserTest extends TestCase
         });
     }
 
-    public function test_with_method_with_page()
+    public function test_within_method_with_page()
     {
         $driver = Mockery::mock(StdClass::class);
         $driver->shouldReceive('navigate->to')->with('http://laravel.dev/login');


### PR DESCRIPTION
```php
// current method
$browser->with('selector', ...

// more appropriate IMO
$browser->within('select', ...
```

Personally "within" is self explanatory. "with" doesn't seem intuitive to me and I believe the same for new-comers.

Also, I've been using "Pages" for reusable components and parts of a page. I'd eventially like to pull request the concept of "Components" or modify the way "Pages" behave to accommodate this. Using Page objects for UI flows and re-usable page components is common: see Ben Orenstiens video [here](https://www.youtube.com/watch?v=u6grFClqt6E&feature=youtu.be&__s=3zqnnsygjob5sobbuxzm)

```php
$browser->on(new Homepage)
    ->within(new Navbar, function ($browser) {
        $browser->click('@profile-dropdown'...
...
``` 

I understand this is a pretty big change to Dusk's API, but I think it's worth it in the long run for being added to 2.0.

Thanks!
Caleb