### PR TITLE
Add 'within' method as alias for 'with' method

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -248,6 +248,18 @@ class Browser
      * @param  \Closure  $callback
      * @return $this
      */
+    public function within($selector, Closure $callback)
+    {
+        return $this->with($selector, $callback);
+    }
+
+    /**
+     * Execute a Closure with a scoped browser instance.
+     *
+     * @param  string  $selector
+     * @param  \Closure  $callback
+     * @return $this
+     */
     public function with($selector, Closure $callback)
     {
         $browser = new static(

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -79,6 +79,33 @@ class BrowserTest extends TestCase
         });
     }
 
+    public function test_within_method()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $browser = new Browser($driver);
+
+        $browser->within('prefix', function ($browser) {
+            $this->assertInstanceof(Browser::class, $browser);
+            $this->assertEquals('body prefix', $browser->resolver->prefix);
+        });
+    }
+
+    public function test_within_method_with_page()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('navigate->to')->with('http://laravel.dev/login');
+        $browser = new Browser($driver);
+        Browser::$baseUrl = 'http://laravel.dev';
+
+        $browser->visit($page = new BrowserTestPage);
+
+        $browser->within('prefix', function ($browser) use ($page) {
+            $this->assertInstanceof(Browser::class, $browser);
+            $this->assertEquals('body prefix', $browser->resolver->prefix);
+            $this->assertEquals($page, $browser->page);
+        });
+    }
+
     public function test_page_macros()
     {
         $driver = Mockery::mock(StdClass::class);


### PR DESCRIPTION
This PR adds `$browser->within()` as an alias for `$browser->with()`

Was originally submitted as a replacement, but now submitting as an alias per Taylor's suggestion: #339 