### PR TITLE
Fix error when using double quotes in selector…

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -70,7 +70,7 @@ trait InteractsWithElements
     {
         $this->ensurejQueryIsAvailable();
 
-        $selector = trim($this->resolver->format("a:contains({$link})"));
+        $selector = addslashes(trim($this->resolver->format("a:contains({$link})")));
 
         $this->driver->executeScript("jQuery.find(\"{$selector}\")[0].click();");
 

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -364,7 +364,7 @@ trait MakesAssertions
     {
         $this->ensurejQueryIsAvailable();
 
-        $selector = trim($this->resolver->format("a:contains('{$link}')"));
+        $selector = addslashes(trim($this->resolver->format("a:contains('{$link}')")));
 
         $script = <<<JS
             var link = jQuery.find("{$selector}");


### PR DESCRIPTION
When using selectors like `[name="username"]`, the `->clickLink()` method fails because it doesn't escape the double quotes.

A failing test:
```
$browser->with('[name="username"]', function ($browser) {
    $browser->clickLink('test');
});
```

Because the error only exists when clicking elements via jQuery, the only affected methods are: `clickLink` and `seeLink`.