### PR TITLE
Add data-dusk DOM hooks (for less brittle tests)

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -368,9 +368,9 @@ class ElementResolver
             array_keys($sortedElements), array_values($sortedElements), $originalSelector = $selector
         );
 
-        // If a '@' element alias hasn't been defined, look for a data-dusk DOM hook.
+        // If a '@' element alias hasn't been defined, look for a dusk attribute hook.
         if (starts_with($selector, '@') && $selector === $originalSelector) {
-            $selector = '[data-dusk="'.explode('@', $selector)[1].'"]';
+            $selector = '[dusk="'.explode('@', $selector)[1].'"]';
         }
 
         return trim($this->prefix.' '.$selector);

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -365,8 +365,13 @@ class ElementResolver
         })->toArray();
 
         $selector = str_replace(
-            array_keys($sortedElements), array_values($sortedElements), $selector
+            array_keys($sortedElements), array_values($sortedElements), $originalSelector = $selector
         );
+
+        // If a '@' element alias hasn't been defined, look for a data-dusk DOM hook.
+        if (starts_with($selector, '@') && $selector === $originalSelector) {
+            $selector = '[data-dusk="'.explode('@', $selector)[1].'"]';
+        }
 
         return trim($this->prefix.' '.$selector);
     }

--- a/tests/ElementResolverTest.php
+++ b/tests/ElementResolverTest.php
@@ -115,7 +115,7 @@ class ElementResolverTest extends TestCase
         $this->assertEquals('prefix #first', $resolver->format('@modal'));
         $this->assertEquals('prefix #second', $resolver->format('@modal-second'));
         $this->assertEquals('prefix #first-third', $resolver->format('@modal-third'));
-        $this->assertEquals('prefix [data-dusk="missing-element"]', $resolver->format('@missing-element'));
+        $this->assertEquals('prefix [dusk="missing-element"]', $resolver->format('@missing-element'));
     }
 
     public function test_find_by_id_with_colon()

--- a/tests/ElementResolverTest.php
+++ b/tests/ElementResolverTest.php
@@ -114,6 +114,8 @@ class ElementResolverTest extends TestCase
         ]);
         $this->assertEquals('prefix #first', $resolver->format('@modal'));
         $this->assertEquals('prefix #second', $resolver->format('@modal-second'));
+        $this->assertEquals('prefix #first-third', $resolver->format('@modal-third'));
+        $this->assertEquals('prefix [data-dusk="missing-element"]', $resolver->format('@missing-element'));
     }
 
     public function test_find_by_id_with_colon()


### PR DESCRIPTION
TL;DR;
```php
// before
<div class="post-panel m-b-lg"><p>Some Post Title</p></div>
$browser->click('.post-panel.m-b-lg p');

// after
<div class="post-panel m-b-lg"><p data-dusk="post-title">Some Post Title</p></div>
$browser->click('@post-title');
```

Depending on prone-to-change ui classes in Dusk tests like `div div div.campaign-panel--large ul li` can make for really brittle acceptance tests.

There is a slightly better solution from the jquery days: `.js-campaign-title`

Something like `.dusk-campaign-title` would do the trick, but I personally don't like muddying up my class lists.

I've come up with a solution that I think is pretty BA: `<li class="active" data-dusk="campaign-title">...`

My selectors in dusk now look like: `$browser->click('[data-dusk="campaign-title"]')` - which works but makes me a little sad. I've used macros like `$browser->hook('campaign-title')` in the past, but things like that always feel hidden to me.

I propose leveraging the existing `'@campaign-title' => 'div div.campaign-panel...'` idiom in Dusk and creating a fallback for `data-dusk`

Now, anywhere in your DOM you can add `data-dusk="something"`, and it is immediately available via `$browser->click('@something')`

It's ballsy, I know - but people seem to really dig it. 