### PR TITLE
Make assertPathIs match a given pattern to allow for ids in urls

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -37,14 +37,18 @@ trait MakesAssertions
     }
 
     /**
-     * Assert that the current URL path matches the given path.
+     * Assert that the current URL path matches the given pattern.
      *
      * @param  string  $path
      * @return $this
      */
     public function assertPathIs($path)
     {
-        PHPUnit::assertEquals($path, parse_url(
+        $pattern = preg_quote($path, '/');
+
+        $pattern = str_replace('\*', '.*', $pattern);
+
+        PHPUnit::assertRegExp('/^'.$pattern.'/u', parse_url(
             $this->driver->getCurrentURL()
         )['path']);
 

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Laravel\Dusk\Browser;
+use PHPUnit\Framework\TestCase;
+
+class MakesAssertionsTest extends TestCase
+{
+    public function test_assert_path_is()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('getCurrentURL')->once()->andReturn(
+            '/foo',
+            'foo/bar',
+            'foo/1/bar',
+            'foo/1/bar/1'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertPathIs('/foo');
+        $browser->assertPathIs('foo/bar');
+        $browser->assertPathIs('foo/*/bar');
+        $browser->assertPathIs('foo/*/bar/*');
+        $browser->assertPathIs('foo/1/bar/1');
+    }
+}


### PR DESCRIPTION
The path assertions provided by `Browser.php` make it difficult to assert a user is on a route with an `id` in the path like: `user/1/post`
```
// this PR allows wildcards in the url ("*")
class TestPage extends BasePage
{
    public function url()
    {
        return '/campaign/*/bid';
    }

    public function assert(Browser $browser)
    {
        $browser->assertPathIs($this->url());
    }
```

I drew heavy inspiration from `Request::is()`. Rather than adding another method like: `$browser->assertPathMatches`, I think people are familiar enough with `Request::is()` that they would expect this capability out of an `is` method.

To me this is invaluable, I love Page assertions but can't often use them because there are id's in the path. 

Hopefully you feel the same way
- Thanks Taylor