### PR TITLE
Add @dusk blade directive to render dusk hooks in markup

### DIFF
--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -29,6 +29,12 @@ class DuskServiceProvider extends ServiceProvider
             'middleware' => 'web',
             'uses' => 'Laravel\Dusk\Http\Controllers\UserController@user',
         ]);
+
+        Blade::directive('dusk', function ($expression) {
+            $selector = trim(preg_replace("/[\(\)\\\"\']/", '', $expression));
+
+            return "<?php echo 'dusk=\"{$selector}\"'; ?>";
+        });
     }
 
     /**

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Dusk;
 
 use Exception;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 


### PR DESCRIPTION
This PR adds a blade directive to render `dusk=""` attribute "hooks" in markup:

```
<div @dusk('foo')></div>
<div dusk="foo"></div> // compiles to
```

Note: because `DuskServiceProvider` isn't loaded in production, these directives will not be rendered in production, therefore leaving behind `@dusk('')` in rendered html. I will submit a PR to `laravel/framework` that compiles an empty string when `@dusk` is encountered in production.