### PR TITLE
Use Process instead of ProcessBuilder to stop chromedriver afterwards

### DIFF
--- a/src/SupportsChrome.php
+++ b/src/SupportsChrome.php
@@ -4,7 +4,6 @@ namespace Laravel\Dusk;
 
 use RuntimeException;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessBuilder;
 
 trait SupportsChrome
 {
@@ -68,10 +67,7 @@ trait SupportsChrome
             throw new RuntimeException("Invalid path to Chromedriver [{$driver}].");
         }
 
-        return (new ProcessBuilder())
-                ->setPrefix(realpath($driver))
-                ->getProcess()
-                ->setEnv(static::chromeEnvironment());
+        return (new Process([realpath($driver)], null, static::chromeEnvironment()));
     }
 
     /**


### PR DESCRIPTION
For backwards compatibilty reasons simfony's ProcessBuilder doesn't prepend
the exec command to the commandline. So only the PID of the wrapping
shell gets stored, but not the one of the chromedriver.

A solution is to use Process directly.

See https://github.com/symfony/symfony/issues/5759 for background
information.

Closes laravel/dusk#341