### PR TITLE
Add missing cookie assertion

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -187,6 +187,22 @@ trait MakesAssertions
     }
 
     /**
+     * Assert that the given cookie is not present.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function assertCookieMissing($name)
+    {
+        PHPUnit::assertTrue(
+            is_null($this->cookie($name)),
+            "Found unexpected cookie [{$name}]."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that an encrypted cookie has a given value.
      *
      * @param  string  $name


### PR DESCRIPTION
The same thing can be done currently using 

```php
$this->assertNull($browser->cookie('laravel_session'));
```

or

```php
$browser->assertCookieValue('laravel_session', null);
```

but `$browser->assertCookieMissing('laravel_session')` feels better.

