### PR TITLE
Handle case where GET_LOG is not supported

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -44,9 +44,9 @@ class Browser
     public static $storeConsoleLogAt;
 
     /**
-     * Force retrieving of console logs even when not using Chrome.
+     * The browsers that support retrieving logs.
      *
-     * @var bool
+     * @var array
      */
     public static $supportsRemoteLogs = [
         WebDriverBrowserType::CHROME,

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -48,7 +48,11 @@ class Browser
      *
      * @var bool
      */
-    public static $alwaysGetConsoleLogs = false;
+    public static $supportsRemoteLogs = [
+        WebDriverBrowserType::CHROME,
+        WebDriverBrowserType::SAFARI,
+        WebDriverBrowserType::PHANTOMJS,
+    ];
 
     /**
      * Get the callback which resolves the default user to authenticate.
@@ -237,7 +241,7 @@ class Browser
      */
     public function storeConsoleLog($name)
     {
-        if (static::$alwaysGetConsoleLogs || WebDriverBrowserType::CHROME === $this->driver->getCapabilities()->getBrowserName()) {
+        if (in_array($this->driver->getCapabilities()->getBrowserName(), static::$supportsRemoteLogs)) {
             $console = $this->driver->manage()->getLog('browser');
 
             if (!empty($console)) {

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -229,12 +229,20 @@ class Browser
      */
     public function storeConsoleLog($name)
     {
-        $console = $this->driver->manage()->getLog('browser');
-
-        if (! empty($console)) {
+        try {
+            $console = $this->driver->manage()->getLog('browser');
+        
+            if (!empty($console)) {
+                file_put_contents(
+                    sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name)
+                    , json_encode($console, JSON_PRETTY_PRINT)
+                );
+            }
+        } catch (UnknownServerException $exception) {
+            // Some drivers do not support the getLog command
             file_put_contents(
                 sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name)
-                , json_encode($console, JSON_PRETTY_PRINT)
+                , json_encode(['error' => 'Console logs not supported by current driver.'], JSON_PRETTY_PRINT)
             );
         }
 


### PR DESCRIPTION
Many drivers (Firefox, MSIE, etc) do not support retrieving console logs (the GET_LOG) command, resulting in:

```
Facebook\WebDriver\Exception\UnknownServerException: Command not found: POST
    /session/<session_id>/log
```

This catches that error and writes an error message to the log file instead. This would only affect people using alternate drivers.