### PR TITLE
Let Firefox users disable console

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -229,13 +229,15 @@ class Browser
      */
     public function storeConsoleLog($name)
     {
-        $console = $this->driver->manage()->getLog('browser');
+        if (static::$storeConsoleLogAt !== false) {
+            $console = $this->driver->manage()->getLog('browser');
 
-        if (! empty($console)) {
-            file_put_contents(
-                sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name)
-                , json_encode($console, JSON_PRETTY_PRINT)
-            );
+            if (!empty($console)) {
+                file_put_contents(
+                    sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name)
+                    , json_encode($console, JSON_PRETTY_PRINT)
+                );
+            }
         }
 
         return $this;

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -229,7 +229,7 @@ class Browser
      */
     public function storeConsoleLog($name)
     {
-        if (static::$storeConsoleLogAt !== false) {
+        if (! is_null(static::$storeConsoleLogAt)) {
             $console = $this->driver->manage()->getLog('browser');
 
             if (!empty($console)) {

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -229,7 +229,7 @@ class Browser
      */
     public function storeConsoleLog($name)
     {
-        if (! is_null(static::$storeConsoleLogAt)) {
+        if (static::$storeConsoleLogAt) {
             $console = $this->driver->manage()->getLog('browser');
 
             if (!empty($console)) {

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -118,6 +118,26 @@ class BrowserTest extends TestCase
 
         $this->assertTrue($browser->page->macroed);
     }
+    
+    public function test_retrieve_console()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('manage->getLog')->with('browser')->andReturnNull();
+        $browser = new Browser($driver);
+        Browser::$storeConsoleLogAt = 'not-null';
+
+        $browser->storeConsoleLog('file');
+    }
+
+    public function test_disable_console()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldNotReceive('manage');
+        $browser = new Browser($driver);
+        Browser::$storeConsoleLogAt = null;
+
+        $browser->storeConsoleLog('file');
+    }
 }
 
 

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -118,7 +118,7 @@ class BrowserTest extends TestCase
 
         $this->assertTrue($browser->page->macroed);
     }
-    
+
     public function test_retrieve_console()
     {
         $driver = Mockery::mock(StdClass::class);


### PR DESCRIPTION
An alternative to #354.

When using Firefox, simply override the `setUp` method.

```
    protected function setUp()
    {
        parent::setUp();

        // Any of the following will be a valid option. The user can choose one
        Browser::$storeConsoleLogAt = null;
        Browser::$storeConsoleLogAt = false;
        Browser::$storeConsoleLogAt = '';
        unset(Browser::$storeConsoleLogAt);
    }
```

- Why Firefox users should disable this themselves?

Dusk relies on Selenium to communicate with the browser and Selenium does offer getLog API (https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#log-type). Firefox hasn't caught up with that yet so if you do use Selenium with Firefox and make this API call, Firefox driver will fail and bubble up to Selenium. It doesn't necessarily mean that only Chrome offers this. PhantomJS is an example of that.