### PR TITLE
Add global wait time default on Browser.php

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -62,6 +62,13 @@ class Browser
     public static $userResolver;
 
     /**
+     * The default wait time in seconds.
+     *
+     * @var int
+     */
+    public static $waitInSeconds = 5;
+
+    /**
      * The RemoteWebDriver instance.
      *
      * @var \Facebook\WebDriver\Remote\RemoteWebDriver

--- a/tests/WaitsForElementsTest.php
+++ b/tests/WaitsForElementsTest.php
@@ -1,10 +1,48 @@
 <?php
 
+use Carbon\Carbon;
+use Facebook\WebDriver\Exception\TimeOutException;
 use Laravel\Dusk\Browser;
 use PHPUnit\Framework\TestCase;
 
 class WaitsForElementsTest extends TestCase
 {
+    public function test_default_wait_time()
+    {
+        Browser::$waitInSeconds = 2;
+
+        $browser = new Browser(new StdClass);
+        $then = microtime(true);
+
+        try {
+            $browser->waitUsing(null, 100, function () {
+                return false;
+            });
+        } catch (TimeOutException $e) {
+            //
+        }
+
+        $this->assertEquals(2, floor(microtime(true) - $then));
+    }
+
+    public function test_default_wait_time_can_be_overriden()
+    {
+        Browser::$waitInSeconds = 2;
+
+        $browser = new Browser(new StdClass);
+        $then = microtime(true);
+
+        try {
+            $browser->waitUsing(0, 100, function () {
+                return true;
+            });
+        } catch (TimeOutException $e) {
+            //
+        }
+
+        $this->assertEquals(0, floor(microtime(true) - $then));
+    }
+
     public function test_wait_using()
     {
         $browser = new Browser(new StdClass);


### PR DESCRIPTION
I'm working on some browser tests that rely on micro-services that sometimes take longer than 5 seconds to respond.

Currently, all the "wait" methods hard-code a default of 5 seconds wait time.

This PR adds the ability to globally specify the wait time using:

`$browser::$waitInSeconds = X`

Now, `$browser->waitFor('selector', ...` will wait for the default if now time is explicitly passed in.

Thanks!
Caleb