### PR TITLE
extend base .env values instead of redefining in .env.dusk.local

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -164,6 +164,9 @@ class DuskCommand extends Command
         copy(base_path('.env'), base_path('.env.backup'));
 
         copy(base_path($this->duskFile()), base_path('.env'));
+
+        $base = file_get_contents(base_path('.env.backup'));
+        file_put_contents(base_path('.env'), "\n" . $base, FILE_APPEND);
     }
 
     /**

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -166,7 +166,8 @@ class DuskCommand extends Command
         copy(base_path($this->duskFile()), base_path('.env'));
 
         $base = file_get_contents(base_path('.env.backup'));
-        file_put_contents(base_path('.env'), "\n" . $base, FILE_APPEND);
+
+        file_put_contents(base_path('.env'), PHP_EOL.$base, FILE_APPEND);
     }
 
     /**


### PR DESCRIPTION
This allows you do define only what you need to override in `.env.dusk.local` instead of having to copy over the whole `.env` file to the dusk one. Achieved by appending the _original_ `.env` file contents to the temporary one after `.env.dusk.local` is copied to `.env`.  **Dotenv will load the first key in case of duplicates.** This makes `.env.dusk.local` behave more like the `phpunit.xml` env overrides for unit tests.
 
Happy to discuss alternate methods or other ideas for implementing this. Thoughts?