### PR TITLE
Have a manual override to enable Dusk in production.

### DIFF
--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -39,7 +39,7 @@ class DuskServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if ($this->app->environment('production')) {
+        if ($this->app->environment('production') && env('DUSK_FAILSAFE', true)) {
             throw new Exception('It is unsafe to run Dusk in production.');
         }
 


### PR DESCRIPTION
An option to disable the production-mode check would be a nice addition. Sometimes the security risks are not valid if you know what you are doing.

Dusk is an awesome tool, not only for testing websites 👍 