### PR TITLE
Add component objects (for re-usable UI components)

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -39,6 +39,6 @@ abstract class Component
      */
     public function __toString()
     {
-        return $this->selector();
+        return '';
     }
 }

--- a/src/Component.php
+++ b/src/Component.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Dusk;
+
+abstract class Component
+{
+    /**
+     * Get the root selector associated with this component.
+     *
+     * @return string
+     */
+    abstract public function selector();
+
+    /**
+     * Assert that the current page contains this component.
+     *
+     * @param  \Laravel\Dusk\Browser  $browser
+     * @return void
+     */
+    public function assert(Browser $browser)
+    {
+        //
+    }
+
+    /**
+     * Get the element shortcuts for the page.
+     *
+     * @return array
+     */
+    public function elements()
+    {
+        return [];
+    }
+
+    /**
+     * Allow this class to be used in place of a selector string.
+     * 
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->selector();
+    }
+}

--- a/src/Console/ComponentCommand.php
+++ b/src/Console/ComponentCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Laravel\Dusk\Console;
+
+use Illuminate\Console\GeneratorCommand;
+
+class ComponentCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'dusk:component {name : The name of the class}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Dusk component class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Component';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/component.stub';
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $name = str_replace_first($this->rootNamespace(), '', $name);
+
+        return $this->laravel->basePath().'/tests'.str_replace('\\', '/', $name).'.php';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Browser\Components';
+    }
+
+    /**
+     * Get the root namespace for the class.
+     *
+     * @return string
+     */
+    protected function rootNamespace()
+    {
+        return 'Tests';
+    }
+}

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -41,6 +41,10 @@ class InstallCommand extends Command
             mkdir(base_path('tests/Browser/Pages'), 0755, true);
         }
 
+        if (! is_dir(base_path('tests/Browser/Components'))) {
+            mkdir(base_path('tests/Browser/Components'), 0755, true);
+        }
+
         if (! is_dir(base_path('tests/Browser/screenshots'))) {
             $this->createScreenshotsDirectory();
         }
@@ -54,6 +58,7 @@ class InstallCommand extends Command
             'HomePage.stub' => base_path('tests/Browser/Pages/HomePage.php'),
             'DuskTestCase.stub' => base_path('tests/DuskTestCase.php'),
             'Page.stub' => base_path('tests/Browser/Pages/Page.php'),
+            'LoginComponent.stub' => base_path('tests/Browser/Components/LoginComponent.php'),
         ];
 
         foreach ($subs as $stub => $file) {

--- a/src/Console/stubs/component.stub
+++ b/src/Console/stubs/component.stub
@@ -1,0 +1,42 @@
+<?php
+
+namespace DummyNamespace;
+
+use Laravel\Dusk\Browser;
+use Laravel\Dusk\Component as BaseComponent;
+
+class DummyClass extends BaseComponent
+{
+    /**
+     * Get the root selector for the component.
+     *
+     * @return string
+     */
+    public function selector()
+    {
+        return '#selector';
+    }
+
+    /**
+     * Assert that the browser page contains the component.
+     *
+     * @param  Browser  $browser
+     * @return void
+     */
+    public function assert(Browser $browser)
+    {
+        $browser->assertVisible($this->selector());
+    }
+
+    /**
+     * Get the element shortcuts for the component.
+     *
+     * @return array
+     */
+    public function elements()
+    {
+        return [
+            '@element' => '#selector',
+        ];
+    }
+}

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -49,6 +49,7 @@ class DuskServiceProvider extends ServiceProvider
                 Console\DuskCommand::class,
                 Console\MakeCommand::class,
                 Console\PageCommand::class,
+                Console\ComponentCommand::class,
             ]);
         }
     }

--- a/stubs/LoginComponent.stub
+++ b/stubs/LoginComponent.stub
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Browser\Components;
+
+use Laravel\Dusk\Browser;
+use Laravel\Dusk\Component;
+
+class LoginComponent extends Component
+{
+    /**
+     * Get the root selector for the component.
+     *
+     * @return string
+     */
+    public function selector()
+    {
+        return '#selector';
+    }
+
+    /**
+     * Assert that the browser page contains the component.
+     *
+     * @param  Browser  $browser
+     * @return void
+     */
+    public function assert(Browser $browser)
+    {
+        $browser->assertVisible($this->selector());
+    }
+
+    /**
+     * Get the element shortcuts for the component.
+     *
+     * @return array
+     */
+    public function elements()
+    {
+        return [
+            '@element' => '#selector',
+        ];
+    }
+}

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -1,0 +1,202 @@
+<?php
+
+use Laravel\Dusk\Page;
+use Laravel\Dusk\Browser;
+use Laravel\Dusk\Component;
+use PHPUnit\Framework\TestCase;
+
+class ComponentTest extends TestCase
+{
+    public function test_within_method_triggers_assertion()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $browser = new Browser($driver);
+
+        $browser->within($component = new TestComponent, function ($browser) {
+            $this->assertTrue($browser->component->asserted);
+
+            $browser->within($nested = new TestNestedComponent, function ($browser) use ($nested) {
+                $this->assertTrue($nested->asserted);
+            });
+        });
+    }
+
+    public function test_resolver_prefix()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $browser = new Browser($driver);
+
+        $browser->within($component = new TestComponent, function ($browser) use ($component) {
+            $this->assertEquals('body #component-root', $browser->resolver->prefix);
+
+            $browser->within($nested = new TestNestedComponent, function ($browser) use ($nested) {
+                $this->assertEquals('body #component-root #nested-root', $browser->resolver->prefix);
+
+                $browser->with('prefix', function ($browser) {
+                    $this->assertEquals('body #component-root #nested-root prefix', $browser->resolver->prefix);
+                });
+            });
+        });
+    }
+
+    public function test_component_macros()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $browser = new Browser($driver);
+
+        $browser->within($component = new TestComponent, function ($browser) {
+            $browser->doSomething();
+            $this->assertTrue($browser->component->macroed);
+
+            $browser->within($nested = new TestNestedComponent, function ($browser) use ($nested) {
+                $browser->doSomething();
+                $this->assertTrue($nested->macroed);
+            });
+        });
+    }
+
+    public function test_component_elements()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $browser = new Browser($driver);
+
+        $browser->within($component = new TestComponent, function ($browser) {
+            $this->assertEquals([
+                '@component-alias' => '#component-alias',
+                '@overridden-alias' => '#not-overridden',
+            ], $browser->resolver->elements);
+
+            $browser->within($nested = new TestNestedComponent, function ($browser) use ($nested) {
+                $this->assertEquals([
+                    '@nested-alias' => '#nested-alias',
+                    '@overridden-alias' => '#overridden',
+                    '@component-alias' => '#component-alias',
+                ], $browser->resolver->elements);
+            });
+        });
+    }
+
+    public function test_root_selector_can_be_dusk_hook()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $browser = new Browser($driver);
+
+        $component = new TestComponent;
+        $component->selector = '@dusk-hook-root';
+
+        $browser->within($component, function ($browser) {
+            $this->assertEquals('body [dusk="dusk-hook-root"]', $browser->resolver->prefix);
+        });
+    }
+
+    public function test_root_selector_can_be_element_alias()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $browser = new Browser($driver);
+
+        $component = new TestComponent;
+        $component->selector = '@component-alias';
+
+        $browser->within($component, function ($browser) {
+            $this->assertEquals('body #component-alias', $browser->resolver->prefix);
+        });
+    }
+
+    public function test_component_overrides_page_macros()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $browser = new Browser($driver);
+
+        $browser->on($page = new TestPage);
+
+        $browser->within($component = new TestComponent, function ($browser) {
+            $browser->doSomething();
+
+            $this->assertFalse($browser->page->macroed);
+            $this->assertTrue($browser->component->macroed);
+
+            $browser->doPageSpecificThing();
+
+            $this->assertTrue($browser->page->macroed);
+        });
+    }
+}
+
+class TestPage extends Page
+{
+    public $macroed = false;
+
+    public function url()
+    {
+        return '/login';
+    }
+
+    public function doSomething()
+    {
+        $this->macroed = true;
+    }
+
+    public function doPageSpecificThing()
+    {
+        $this->macroed = true;
+    }
+}
+
+class TestComponent extends Component
+{
+    public $selector = '#component-root';
+    public $asserted = false;
+    public $macroed = false;
+
+    public function assert(Browser $browser)
+    {
+        $this->asserted = true;
+    }
+
+    public function selector()
+    {
+        return $this->selector;
+    }
+
+    public function doSomething()
+    {
+        $this->macroed = true;
+    }
+
+    public function elements()
+    {
+        return [
+            '@component-alias' => '#component-alias',
+            '@overridden-alias' => '#not-overridden',
+        ];
+    }
+}
+
+class TestNestedComponent extends Component
+{
+    public $asserted = false;
+    public $macroed = false;
+
+    public function selector()
+    {
+        return '#nested-root';
+    }
+
+    public function assert(Browser $browser)
+    {
+        $this->asserted = true;
+    }
+
+    public function doSomething()
+    {
+        $this->macroed = true;
+    }
+
+    public function elements()
+    {
+        return [
+            '@nested-alias' => '#nested-alias',
+            '@overridden-alias' => '#overridden',
+        ];
+    }
+}


### PR DESCRIPTION
"Component Objects" are an established pattern in browser testing. They are similar to "Page Objects", except are meant for smaller scoped UI components that you might re-use across pages.

Example usage:
```php
$browser->visit(new PostPage)
  ->within(new Sidebar, function ($browser) { // Component object
    $browser->click('@expand-author-link')
      ->within(new AuthorProfile, function ($browser) { // Components can be nested
        $browser->click('@follow-button');
      });
  });
```

Example Component Object:
```php
SomeComponent extends Component
{
    public function selector()
    {
        return '@element';
    }

    public function assert(Browser $browser)
    {
        $browser->assertVisible($this->selector());
    }

    public function customMethod($browser) { // }

    public function elements()
    {
        return [
            '@element' => '#selector',
        ];
    }
}
```
Aside from being semantically distinct, Components differ from Page objects in the following ways:

- They add a selector to the css prefix (and use that selector to assert the component is visible)
- You can't "visit" a component like you can a page
- You can still access a Page objects elements and methods while in a Component
- You can nest them and utilize elements and methods of components/pages further up the chain.

This adds an `artisan dusk:component` command with stubs.

It also scaffolds a sample `LoginComponent` similar to `HomePage` when running `artisan dusk:install`

Our apps are FULL of vue / react components that we re-use, having re-usable Dusk components to match them in tests is a dream come true. It really makes my tests WAY cleaner, and quick to write.

\- hope you dig it
