### PR TITLE
Add assertions for testing Vue component data and props

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -696,9 +696,9 @@ JS;
      * @param  string  $key
      * @return mixed
      */
-    public function vueAttribute($key, $component = null)
+    public function vueAttribute($componentSelector, $key)
     {
-        $fullSelector = $this->resolver->format($component);
+        $fullSelector = $this->resolver->format($componentSelector);
 
         return $this->driver->executeScript(
             "return document.querySelector('" . $fullSelector . "').__vue__." . $key
@@ -712,9 +712,9 @@ JS;
      * @param  string  $value
      * @return $this
      */
-    public function assertVueAttribute($key, $value, $component = null)
+    public function assertVueAttribute($key, $value, $componentSelector = null)
     {
-        PHPUnit::assertEquals($value, $this->vueAttribute($key, $component));
+        PHPUnit::assertEquals($value, $this->vueAttribute($componentSelector, $key));
 
         return $this;
     }
@@ -727,9 +727,9 @@ JS;
      * @param  string  $value
      * @return $this
      */
-    public function assertVueAttributeIsNot($key, $value, $component = null)
+    public function assertVueAttributeIsNot($key, $value, $componentSelector = null)
     {
-        PHPUnit::assertNotEquals($value, $this->vueAttribute($key, $component));
+        PHPUnit::assertNotEquals($value, $this->vueAttribute($componentSelector, $key));
 
         return $this;
     }
@@ -742,9 +742,9 @@ JS;
      * @param  string  $value
      * @return $this
      */
-    public function assertVueAttributeContains($key, $value, $component = null)
+    public function assertVueAttributeContains($key, $value, $componentSelector = null)
     {
-        PHPUnit::assertContains($value, $this->vueAttribute($key, $component));
+        PHPUnit::assertContains($value, $this->vueAttribute($componentSelector, $key));
 
         return $this;
     }
@@ -757,9 +757,9 @@ JS;
      * @param  string  $value
      * @return $this
      */
-    public function assertVueAttributeDoesNotContain($key, $value, $component = null)
+    public function assertVueAttributeDoesNotContain($key, $value, $componentSelector = null)
     {
-        PHPUnit::assertNotContains($value, $this->vueAttribute($key, $component));
+        PHPUnit::assertNotContains($value, $this->vueAttribute($componentSelector, $key));
 
         return $this;
     }

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -689,4 +689,79 @@ JS;
 
         return $this;
     }
+
+    /**
+     * Retrieve the value of the Vue component's attribute at the given key.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function vueAttribute($key)
+    {
+        $fullSelector = $this->resolver->format(null);
+
+        return $this->driver->executeScript(
+            "return document.querySelector('" . $fullSelector . "').__vue__." . $key
+        );
+    }
+
+    /**
+     * Assert that the Vue component's attribute at the given key has the given value.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertVueAttribute($key, $value)
+    {
+        PHPUnit::assertEquals($value, $this->vueAttribute($key));
+
+        return $this;
+    }
+
+    /**
+     * Assert that the Vue component's attribute at the given key
+     * does not have the given value.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertVueAttributeIsNot($key, $value)
+    {
+        PHPUnit::assertNotEquals($value, $this->vueAttribute($key));
+
+        return $this;
+    }
+
+    /**
+     * Assert that the Vue component's attribute at the given key
+     * is an array that contains the given value.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertVueAttributeContains($key, $value)
+    {
+        PHPUnit::assertContains($value, $this->vueAttribute($key));
+
+        return $this;
+    }
+
+    /**
+     * Assert that the Vue component's attribute at the given key
+     * is an array that contains the given value.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return $this
+     */
+
+    public function assertVueAttributeDoesNotContain($key, $value)
+    {
+        PHPUnit::assertNotContains($value, $this->vueAttribute($key));
+
+        return $this;
+    }
 }

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -696,9 +696,9 @@ JS;
      * @param  string  $key
      * @return mixed
      */
-    public function vueAttribute($key)
+    public function vueAttribute($key, $component = null)
     {
-        $fullSelector = $this->resolver->format(null);
+        $fullSelector = $this->resolver->format($component);
 
         return $this->driver->executeScript(
             "return document.querySelector('" . $fullSelector . "').__vue__." . $key
@@ -712,9 +712,9 @@ JS;
      * @param  string  $value
      * @return $this
      */
-    public function assertVueAttribute($key, $value)
+    public function assertVueAttribute($key, $value, $component = null)
     {
-        PHPUnit::assertEquals($value, $this->vueAttribute($key));
+        PHPUnit::assertEquals($value, $this->vueAttribute($key, $component));
 
         return $this;
     }
@@ -727,9 +727,9 @@ JS;
      * @param  string  $value
      * @return $this
      */
-    public function assertVueAttributeIsNot($key, $value)
+    public function assertVueAttributeIsNot($key, $value, $component = null)
     {
-        PHPUnit::assertNotEquals($value, $this->vueAttribute($key));
+        PHPUnit::assertNotEquals($value, $this->vueAttribute($key, $component));
 
         return $this;
     }
@@ -742,9 +742,9 @@ JS;
      * @param  string  $value
      * @return $this
      */
-    public function assertVueAttributeContains($key, $value)
+    public function assertVueAttributeContains($key, $value, $component = null)
     {
-        PHPUnit::assertContains($value, $this->vueAttribute($key));
+        PHPUnit::assertContains($value, $this->vueAttribute($key, $component));
 
         return $this;
     }
@@ -757,10 +757,9 @@ JS;
      * @param  string  $value
      * @return $this
      */
-
-    public function assertVueAttributeDoesNotContain($key, $value)
+    public function assertVueAttributeDoesNotContain($key, $value, $component = null)
     {
-        PHPUnit::assertNotContains($value, $this->vueAttribute($key));
+        PHPUnit::assertNotContains($value, $this->vueAttribute($key, $component));
 
         return $this;
     }


### PR DESCRIPTION
This PR adds the ability to assert against a Vue component's underlying attributes, for testing `data` and `prop` values directly. The `data` and `prop` values retrieved by these assertions are reactive, meaning they'll reflect any change to a component's initial state that happens in the course of the test. It can test any Vue component on the page, and would dovetail nicely with @calebporzio's https://github.com/laravel/dusk/pull/374 (adding Component Objects).

The primary assertion is `$browser->assertVueAttribute($attribute, $value)`. The assertion should be contained in a `within` statement which targets the component:

```php
$browser->visit(new HomePage)
    ->within('@my-vue-component', function ($component) {
        $component->click('@some-button')
            ->assertVueAttribute('some_prop', 123)
            ->assertVueAttribute('some_data', 'abc');
    });
```

Alternatively, the component selector can be passed as the third parameter:

```php
$browser->assertVueAttribute('some_prop', 123, '@my-vue-component');
```

### Specifying selectors

Component selectors can either be a CSS or `dusk` selector, e.g. `.my-vue-component` or `dusk="my-vue-component"`. The selector can either be specified where the component is included in the markup, or on the top-level element of the Vue component's template:

```html
<my-component 
    dusk="my-vue-component" 
    :some_prop="123"
></my-component>
```

or


```vue
<template>
    <div dusk="my-vue-component">
        ...
    </div>
</template>

<script>
    export default {
        props: {
            some_prop : {},
        },

        data() {
            return {
                some_data: {
                    first: 1,
                    second: 2,
                },
             }
        },
    }
</script>
```

### Testing object and array values

The assertion works for testing props or data that contain objects, which can be specified using dot notation:

```
$component->assertVueAttribute('some_data.second', 2);
```

Array values can also be tested using the `assertVueAttributeContains` assertion, which applies PHPUnit's `assertContains` assertion:

```php
$component->assertVueAttributeContains('data_array', 'an-array-item')
$component->assertVueAttributeContains('data_array', ['an-array-key' => 'an-array-value']);
```

### Testing the negative conditions

The converse assertions are included as well:

```php
$browser->assertVueAttributeIsNot('some_prop', 123, '@my-vue-component');
$browser->assertVueAttributeDoesNotContain('some_array_prop', 123, '@my-vue-component');
```

### Retrieving attributes with `vueAttribute()`

Finally, the underlying `vueAttribute()` method that is used to fetch values from a Vue component is `public`, so a user can access it in a test for more complicated assertions using PHPunit:

```php
use PHPUnit\Framework\Assert;

...

Assert::assertCount(3, $browser->vueAttribute('@my-vue-component', 'some_prop'));
```

The method is similar to the `attribute` method that already exists.

---

I have no idea how to write tests for this that don't involve spinning up a browser like we would in a typical Dusk test, so I'd love to hear ideas on that front. And naturally, if this method of directly testing Vue components is viable, we should extend the same behavior for React components.