### PR TITLE
Overridable Chrome Driver Arguments via Env

### DIFF
--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -29,15 +29,25 @@ abstract class DuskTestCase extends BaseTestCase
      */
     protected function driver()
     {
-        $options = (new ChromeOptions)->addArguments([
-            '--disable-gpu',
-            '--headless'
-        ]);
+        $options = (new ChromeOptions)->addArguments($this->arguments());
 
         return RemoteWebDriver::create(
             'http://localhost:9515', DesiredCapabilities::chrome()->setCapability(
                 ChromeOptions::CAPABILITY, $options
             )
         );
+    }
+
+    /**
+    * Create Chrome Driver arguments.
+    * i.e ['--disable-gpu', '--headless']
+    *
+    * @return array
+    */
+    private function arguments()
+    {
+        $rawArguments = env('CHROME_DRIVER_ARGS', '--disable-gpu|--headless');
+
+        return explode('|', $rawArguments);
     }
 }


### PR DESCRIPTION
**Why we need this?**

In some setup, it needs to have different chrome driver arguments in order to run Dusk tests.
For instance, in laradock workspace container, the default argument (`--headless`), does not work.
I need to be able to change that to `--sandbox` to make it work.

**What has changed?**

Get the chrome driver arguments from env and maintain the previous arguments as default values.