### PR TITLE
Add $ to match the end of a line

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -48,7 +48,7 @@ trait MakesAssertions
 
         $pattern = str_replace('\*', '.*', $pattern);
 
-        PHPUnit::assertRegExp('/^'.$pattern.'/u', parse_url(
+        PHPUnit::assertRegExp('/^'.$pattern.'$/u', parse_url(
             $this->driver->getCurrentURL()
         )['path']);
 


### PR DESCRIPTION
Without the dollar sign, matching the `/foo` path will assert true for both `/f` and `/foo`

Related issue: https://github.com/laravel/dusk/issues/386