### PR TITLE
[2.0] Updated dev dependencies in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "symfony/process": "~3.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
-        "mockery/mockery": "^0.9.6"
+        "mockery/mockery": "~1.0",
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"


### PR DESCRIPTION
Updated `mockery/mockery` to `~1.0` and `phpunit/phpunit` to `~6.0`.

PS: I've used [this commit](https://github.com/laravel/framework/pull/17864) from `laravel/framework` to prevent failed tests.