### PR TITLE
Run the Windows chrome driver for WSL

### DIFF
--- a/src/Chrome/ChromeProcess.php
+++ b/src/Chrome/ChromeProcess.php
@@ -3,6 +3,7 @@
 namespace Laravel\Dusk\Chrome;
 
 use RuntimeException;
+use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
 
@@ -94,13 +95,13 @@ class ChromeProcess
     }
 
     /**
-     * Determine if Dusk is running on Windows.
+     * Determine if Dusk is running on Windows or Windows Subsystem for Linux.
      *
      * @return bool
      */
     protected function onWindows()
     {
-        return PHP_OS === 'WINNT';
+        return PHP_OS === 'WINNT' || Str::contains(php_uname(), 'Microsoft');
     }
 
     /**


### PR DESCRIPTION
We use the Windows Subsystem for Linux as our local development system (better known as Bash on Windows). This simulates a linux environment on a Windows machine.

However, the expected 'chromedriver-linux' does not work on this environment. The 'chromedriver-win.exe' however does.

This ensures that when the `uname` contains `Microsoft` (i.e. what happens on this simulated instance), the correct binary is selected.