### PR TITLE
Add methods for JavaScript dialog testing

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -430,4 +430,17 @@ trait InteractsWithElements
 
         return $this;
     }
+
+    /**
+     * Type the given value in an open JavaScript prompt dialog.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function typeInDialog($value)
+    {
+        $this->driver->switchTo()->alert()->sendKeys($value);
+
+        return $this;
+    }
 }

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Str;
 use Facebook\WebDriver\Exception\TimeOutException;
 use Facebook\WebDriver\Exception\NoSuchElementException;
+use Facebook\WebDriver\WebDriverExpectedCondition;
 
 trait WaitsForElements
 {
@@ -178,6 +179,23 @@ trait WaitsForElements
 
             $this->pause($interval);
         }
+
+        return $this;
+    }
+
+    /**
+     * Wait for a JavaScript dialog to be open.
+     *
+     * @param  int  $seconds
+     * @return $this
+     */
+    public function waitForDialog($seconds = null)
+    {
+        $seconds = is_null($seconds) ? static::$waitSeconds : $seconds;
+
+        $message = "Waited {$seconds} seconds for dialog.";
+
+        $this->driver->wait($seconds, 100)->until(WebDriverExpectedCondition::alertIsPresent(), $message);
 
         return $this;
     }


### PR DESCRIPTION
Adds two new methods:
    - type in prompt dialog
    - wait for dialog to open