### PR TITLE
 Allow tests to be run on an alternative port

### DIFF
--- a/src/Chrome/ChromeProcess.php
+++ b/src/Chrome/ChromeProcess.php
@@ -17,14 +17,23 @@ class ChromeProcess
     protected $driver;
 
     /**
+     * The port to run the Chromedriver on.
+     *
+     * @var int
+     */
+    protected $port;
+
+    /**
      * Create a new ChromeProcess instance.
      *
      * @param  string  $driver
+     * @param  int     $port
      * @return void
      */
-    public function __construct($driver = null)
+    public function __construct($driver = null, $port = 9515)
     {
         $this->driver = $driver;
+        $this->port = $port;
 
         if (! is_null($driver) && realpath($driver) === false) {
             throw new RuntimeException("Invalid path to Chromedriver [{$driver}].");
@@ -63,7 +72,7 @@ class ChromeProcess
     protected function process()
     {
         return (new Process(
-            [realpath($this->driver)], null, $this->chromeEnvironment()
+            [realpath($this->driver), " --port={$this->port}"], null, $this->chromeEnvironment()
         ));
     }
 
@@ -76,6 +85,7 @@ class ChromeProcess
     {
         return (new ProcessBuilder)
             ->setPrefix(realpath($this->driver))
+            ->add("--port={$this->port}")
             ->getProcess()
             ->setEnv($this->chromeEnvironment());
     }

--- a/src/Chrome/SupportsChrome.php
+++ b/src/Chrome/SupportsChrome.php
@@ -25,13 +25,15 @@ trait SupportsChrome
     /**
      * Start the Chromedriver process.
      *
+     * @param  int     $port
+     *
      * @throws \RuntimeException if the driver file path doesn't exist.
      *
      * @return void
      */
-    public static function startChromeDriver()
+    public static function startChromeDriver(int $port = null)
     {
-        static::$chromeProcess = static::buildChromeProcess();
+        static::$chromeProcess = static::buildChromeProcess($port);
 
         static::$chromeProcess->start();
 
@@ -55,13 +57,15 @@ trait SupportsChrome
     /**
      * Build the process to run the Chromedriver.
      *
+     * @param  int     $port
+     *
      * @throws \RuntimeException if the driver file path doesn't exist.
      *
      * @return \Symfony\Component\Process\Process
      */
-    protected static function buildChromeProcess()
+    protected static function buildChromeProcess(int $port = null)
     {
-        return (new ChromeProcess(static::$chromeDriver))->toProcess();
+        return (new ChromeProcess(static::$chromeDriver, $port))->toProcess();
     }
 
     /**

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -31,6 +31,13 @@ abstract class TestCase extends FoundationTestCase
     protected static $afterClassCallbacks = [];
 
     /**
+     * The port to run the ChromeDriver on.
+     *
+     * @var int
+     */
+    protected static $port = 9515;
+
+    /**
      * Register the base URL with Dusk.
      *
      * @return void
@@ -48,6 +55,18 @@ abstract class TestCase extends FoundationTestCase
         Browser::$userResolver = function () {
             return $this->user();
         };
+    }
+
+    /**
+     * Set the port to run the ChromeDriver on.
+     *
+     * @param  int     $port
+     *
+     * @return void
+     */
+    public static function setPort(int $port)
+    {
+        static::$port = 9515;
     }
 
     /**
@@ -219,7 +238,7 @@ abstract class TestCase extends FoundationTestCase
     protected function driver()
     {
         return RemoteWebDriver::create(
-            'http://localhost:9515', DesiredCapabilities::chrome()
+            'http://localhost:' . static::$port, DesiredCapabilities::chrome()
         );
     }
 

--- a/tests/ChromeProcessTest.php
+++ b/tests/ChromeProcessTest.php
@@ -38,6 +38,14 @@ class ChromeProcessTest extends TestCase
         $this->assertContains('chromedriver-linux', $process->getCommandLine());
     }
 
+    public function test_build_process_with_port()
+    {
+        $process = (new ChromeProcessLinux(null, 8888))->toProcess();
+
+        $this->assertInstanceOf(Symfony\Component\Process\Process::class, $process);
+        $this->assertContains('--port=8888', $process->getCommandLine());
+    }
+
     public function test_invalid_path()
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
By default the `chromeprocess` binaries run on port 9515, but they accept a command line option to use an alternative port, this PR makes use of that to allow tests to use whatever port they like.

The use case for this is to run tests in parallel, allowing us to run one test class on port 9515 and another on 9516 simultaneously:
```php
public static function prepare()
{
    $port = 9516;
    static::startChromeDriver($port);
    static::setPort($port);
}
```

