### PR TITLE
Ensure the chrome driver binary can be started

### DIFF
--- a/tests/SupportsChromeTest.php
+++ b/tests/SupportsChromeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Laravel\Dusk\Chrome\SupportsChrome;
+use PHPUnit\Framework\TestCase;
+
+class SupportsChromeTest extends TestCase
+{
+    use SupportsChrome;
+
+    public function test_it_can_run_chrome_process()
+    {
+        $process = static::buildChromeProcess();
+
+        $process->start();
+
+        # Wait for the process to start up, and output any issues
+        sleep(2);
+
+        $process->stop();
+
+        $this->assertContains("Starting ChromeDriver", $process->getOutput());
+        $this->assertSame("", $process->getErrorOutput());
+    }
+}


### PR DESCRIPTION
[v2.0.9](https://github.com/laravel/dusk/releases/tag/v2.0.9) highlighted a short coming with the CI as there were no tests to ensure the chomedriver binary was able to start correctly.

This PR introduces a test that checks the chromedriver begins normally and doesn't output an error and quit
