### PR TITLE
Fix return value

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -239,7 +239,7 @@ trait MakesAssertions
             "Did not see expected query string parameter [{$name}] in [".$this->driver->getCurrentURL()."]."
         );
 
-        return $output;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Fixed typo for`assertHasQueryStringParameter`method returning $output rather than $this.