### PR TITLE
Allow tests to be run on an alternative port

### DIFF
--- a/src/Chrome/ChromeProcess.php
+++ b/src/Chrome/ChromeProcess.php
@@ -17,13 +17,22 @@ class ChromeProcess
     protected $driver;
 
     /**
+     * The port to run the Chromedriver on.
+     *
+     * @var int
+     */
+    protected $port;
+
+    /**
      * Create a new ChromeProcess instance.
      *
      * @param  string  $driver
+     * @param  int     $port
      * @return void
      */
-    public function __construct($driver = null)
+    public function __construct($driver = null, int $port = null)
     {
+        $this->port = $port ?: 9515;
         $this->driver = $driver;
 
         if (! is_null($driver) && realpath($driver) === false) {
@@ -63,7 +72,7 @@ class ChromeProcess
     protected function process()
     {
         return (new Process(
-            [realpath($this->driver)], null, $this->chromeEnvironment()
+            [realpath($this->driver), " --port={$this->port}"], null, $this->chromeEnvironment()
         ));
     }
 
@@ -76,6 +85,7 @@ class ChromeProcess
     {
         return (new ProcessBuilder)
             ->setPrefix(realpath($this->driver))
+            ->add("--port={$this->port}")
             ->getProcess()
             ->setEnv($this->chromeEnvironment());
     }

--- a/src/Chrome/SupportsChrome.php
+++ b/src/Chrome/SupportsChrome.php
@@ -23,13 +23,14 @@ trait SupportsChrome
     /**
      * Start the Chromedriver process.
      *
+     * @param  int  $port
      * @throws \RuntimeException if the driver file path doesn't exist.
      *
      * @return void
      */
-    public static function startChromeDriver()
+    public static function startChromeDriver(int $port = null)
     {
-        static::$chromeProcess = static::buildChromeProcess();
+        static::$chromeProcess = static::buildChromeProcess($port);
 
         static::$chromeProcess->start();
 
@@ -53,13 +54,13 @@ trait SupportsChrome
     /**
      * Build the process to run the Chromedriver.
      *
-     *
+     * @param  int     $port
      * @return \Symfony\Component\Process\Process
      * @throws \RuntimeException if the driver file path doesn't exist.
      */
-    protected static function buildChromeProcess()
+    protected static function buildChromeProcess(int $port = null)
     {
-        return (new ChromeProcess(static::$chromeDriver))->toProcess();
+        return (new ChromeProcess(static::$chromeDriver, $port))->toProcess();
     }
 
     /**

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -18,6 +18,13 @@ abstract class TestCase extends FoundationTestCase
         SupportsChrome;
 
     /**
+     * The port to run the browser driver on.
+     *
+     * @var int
+     */
+    protected static $port = 9515;
+
+    /**
      * Register the base URL with Dusk.
      *
      * @return void
@@ -45,8 +52,19 @@ abstract class TestCase extends FoundationTestCase
     protected function driver()
     {
         return RemoteWebDriver::create(
-            'http://localhost:9515', DesiredCapabilities::chrome()
+            'http://localhost:'.static::$port, DesiredCapabilities::chrome()
         );
+    }
+
+    /**
+     * Set the port to run the browser driver on.
+     *
+     * @param  int  $port
+     * @return void
+     */
+    public static function usePort($port)
+    {
+        static::$port = $port;
     }
 
     /**

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -35,7 +35,7 @@ abstract class DuskTestCase extends BaseTestCase
         ]);
 
         return RemoteWebDriver::create(
-            'http://localhost:9515', DesiredCapabilities::chrome()->setCapability(
+            'http://localhost:'.static::$port, DesiredCapabilities::chrome()->setCapability(
                 ChromeOptions::CAPABILITY, $options
             )
         );

--- a/tests/ChromeProcessTest.php
+++ b/tests/ChromeProcessTest.php
@@ -38,6 +38,22 @@ class ChromeProcessTest extends TestCase
         $this->assertContains('chromedriver-linux', $process->getCommandLine());
     }
 
+    public function test_build_process_without_port()
+    {
+        $process = (new ChromeProcessLinux)->toProcess();
+
+        $this->assertInstanceOf(Symfony\Component\Process\Process::class, $process);
+        $this->assertContains('--port=9515', $process->getCommandLine());
+    }
+
+    public function test_build_process_with_port()
+    {
+        $process = (new ChromeProcessLinux(null, 8888))->toProcess();
+
+        $this->assertInstanceOf(Symfony\Component\Process\Process::class, $process);
+        $this->assertContains('--port=8888', $process->getCommandLine());
+    }
+
     public function test_invalid_path()
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
Following on from #430 and #441 this pr introduces the alternative port feature:

```php
    /**
     * Prepare for Dusk test execution.
     *
     * @beforeClass
     * @return void
     */
    public static function prepare()
    {
        $port = 9517;
        static::startChromeDriver($port);
        static::usePort($port);
    }
```