### PR TITLE
Remove Safari from the browsers supporting remote logs 

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -50,7 +50,6 @@ class Browser
      */
     public static $supportsRemoteLogs = [
         WebDriverBrowserType::CHROME,
-        WebDriverBrowserType::SAFARI,
         WebDriverBrowserType::PHANTOMJS,
     ];
 


### PR DESCRIPTION
**As stated in #452:**

I wanted to run my tests on Safari with the `safaridriver` executable, I got this error:

```
1) Tests\Browser\HomeTest::testCheckRegistrationLink
Facebook\WebDriver\Exception\WebDriverException: JSON decoding of remote response failed.
Error code: 4
The response: 'The command 'POST /session/8C9AB598-8BD7-4478-B808-7E7A34EEDFB5/log' is not implemented.'

...
```

Removing Safari from `Browser::supportsRemoteLogs` solved the issue.