### PR TITLE
Revert fb67e61 and fix return type

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -223,7 +223,7 @@ trait MakesAssertions
      * Assert that the given query string parameter is present.
      *
      * @param  string  $name
-     * @return $this
+     * @return array
      */
     protected function assertHasQueryStringParameter($name)
     {
@@ -241,7 +241,7 @@ trait MakesAssertions
             "Did not see expected query string parameter [{$name}] in [".$this->driver->getCurrentURL()."]."
         );
 
-        return $this;
+        return $output;
     }
 
     /**


### PR DESCRIPTION
(repost of falsely closed https://github.com/laravel/dusk/pull/456)

fb67e61 broke the `assertQueryStringHas()` assertion when testing a `$value`.

> I don't understand why all other assertions would return $this except for this one?

The changed method is just a helper method for the "real" assertion which returns `$this` as expected.

Fixes https://github.com/laravel/dusk/issues/455