### PR TITLE
revert assertHasQueryStringParameter in v2 Branch

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -223,7 +223,7 @@ trait MakesAssertions
      * Assert that the given query string parameter is present.
      *
      * @param  string  $name
-     * @return $this
+     * @return array
      */
     protected function assertHasQueryStringParameter($name)
     {
@@ -241,7 +241,7 @@ trait MakesAssertions
             "Did not see expected query string parameter [{$name}] in [".$this->driver->getCurrentURL()."]."
         );
 
-        return $this;
+        return $output;
     }
 
     /**


### PR DESCRIPTION
Similar to https://github.com/laravel/dusk/pull/457 this just brings assertQueryStringHas back into a working state (in the v2 Branch) while tests are being written.

Related to https://github.com/laravel/dusk/pull/461