### PR TITLE
Prevent screenshot and console filename collisions

### DIFF
--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -132,7 +132,9 @@ trait ProvidesBrowser
     protected function captureFailuresFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
-            $browser->screenshot('failure-'.$this->getName().'-'.$key);
+            $name = str_replace(['\\', ':'], '_', $this->toString());
+
+            $browser->screenshot('failure-'.$name.'-'.$key);
         });
     }
 
@@ -145,7 +147,9 @@ trait ProvidesBrowser
     protected function storeConsoleLogsFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
-            $browser->storeConsoleLog($this->getName().'-'.$key);
+            $name = str_replace(['\\', ':'], '_', $this->toString());
+
+            $browser->storeConsoleLog($name.'-'.$key);
         });
     }
 


### PR DESCRIPTION
(re-post of closed #471)

Answer to your question:
`toString()` is a method in `PHPUnit\Framework\TestCase` (as is the currently used `getName()`).