### PR TITLE
Replace '/' from captured logs/screenshots names to prevent failure

### DIFF
--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -132,7 +132,7 @@ trait ProvidesBrowser
     protected function captureFailuresFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
-            $name = str_replace(['\\', ':', '/'], '_', $this->toString());
+            $name = str_replace(['\\', ':', '/', '>', '<', '"', '|', '?', '*'], '_', $this->toString());
 
             $browser->screenshot('failure-'.$name.'-'.$key);
         });
@@ -147,7 +147,7 @@ trait ProvidesBrowser
     protected function storeConsoleLogsFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
-            $name = str_replace(['\\', ':', '/'], '_', $this->toString());
+            $name = str_replace(['\\', ':', '/', '>', '<', '"', '|', '?', '*'], '_', $this->toString());
 
             $browser->storeConsoleLog($name.'-'.$key);
         });

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -132,7 +132,7 @@ trait ProvidesBrowser
     protected function captureFailuresFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
-            $name = str_replace(['\\', ':'], '_', $this->toString());
+            $name = str_replace(['\\', ':', '/'], '_', $this->toString());
 
             $browser->screenshot('failure-'.$name.'-'.$key);
         });
@@ -147,7 +147,7 @@ trait ProvidesBrowser
     protected function storeConsoleLogsFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
-            $name = str_replace(['\\', ':'], '_', $this->toString());
+            $name = str_replace(['\\', ':', '/'], '_', $this->toString());
 
             $browser->storeConsoleLog($name.'-'.$key);
         });


### PR DESCRIPTION
When running a test with a data provider that was supplying URLs, I hit an error because of an invalid file name being passed to file_put_contents.  This PR extends the filename scrubbing to remove the '/' which was causing the failure (at least on Windows).