### PR TITLE
Prevent breaking console and screenshot filenames and restore #472

### DIFF
--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -132,7 +132,7 @@ trait ProvidesBrowser
     protected function captureFailuresFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
-            $browser->screenshot('failure-'.$this->getName().'-'.$key);
+            $browser->screenshot('failure-'.$this->getName(false).'-'.$key);
         });
     }
 
@@ -145,7 +145,7 @@ trait ProvidesBrowser
     protected function storeConsoleLogsFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
-            $browser->storeConsoleLog($this->getName().'-'.$key);
+            $browser->storeConsoleLog($this->getName(false).'-'.$key);
         });
     }
 

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -132,7 +132,9 @@ trait ProvidesBrowser
     protected function captureFailuresFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
-            $browser->screenshot('failure-'.$this->getName(false).'-'.$key);
+            $name = str_replace('\\', '_', get_class($this)).'_'.$this->getName(false);
+
+            $browser->screenshot('failure-'.$name.'-'.$key);
         });
     }
 
@@ -145,7 +147,9 @@ trait ProvidesBrowser
     protected function storeConsoleLogsFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
-            $browser->storeConsoleLog($this->getName(false).'-'.$key);
+            $name = str_replace('\\', '_', get_class($this)).'_'.$this->getName(false);
+
+            $browser->storeConsoleLog($name.'-'.$key);
         });
     }
 

--- a/tests/ProvidesBrowserTest.php
+++ b/tests/ProvidesBrowserTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Dusk\Tests;
+
+use Mockery;
+use StdClass;
+use PHPUnit\Framework\TestCase;
+use Laravel\Dusk\Concerns\ProvidesBrowser;
+
+class ProvidesBrowserTest extends TestCase
+{
+    use ProvidesBrowser;
+
+    /**
+     * @dataProvider testData
+     */
+    public function test_capture_failures_for()
+    {
+        $browser = Mockery::mock(StdClass::class);
+        $browser->shouldReceive('screenshot')->with(
+            'failure-Dusk_Tests_ProvidesBrowserTest_test_capture_failures_for-0'
+        );
+        $browsers = collect([$browser]);
+
+        $this->captureFailuresFor($browsers);
+    }
+
+    /**
+     * @dataProvider testData
+     */
+    public function test_store_console_logs_for()
+    {
+        $browser = Mockery::mock(StdClass::class);
+        $browser->shouldReceive('storeConsoleLog')->with(
+            'Dusk_Tests_ProvidesBrowserTest_test_store_console_logs_for-0'
+        );
+        $browsers = collect([$browser]);
+
+        $this->storeConsoleLogsFor($browsers);
+    }
+
+    public function testData()
+    {
+        return [
+            ['foo']
+        ];
+    }
+
+    /**
+     * implementation of abstract ProvidesBrowser::driver()
+     */
+    protected function driver()
+    {
+    }
+}


### PR DESCRIPTION
The reverted PR #472 only caused part of the problem discussed in #475, the general problem with datasets existed before. Breaking filenames like  `testExample with data set "foo/bar"-0.log` can still occur.

This PR completely removes datasets from console and screenshot filenames.

It also restores the intended feature of #472 – adding the class to filenames to prevent collisions with duplicate test names:
`failure-Tests_FooTest_testExample-0.png`
`failure-Tests_BarTest_testExample-0.png`
