### PR TITLE
add `waitForRoute` method

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -100,6 +100,17 @@ trait WaitsForElements
     }
 
     /**
+     * @param  string  $route
+     * @param  array  $parameters
+     * @param  int  $seconds
+     * @return $this
+     */
+    public function waitForRoute($route, $parameters = [], $seconds = null)
+    {
+        return $this->waitForLocation(route($route, $parameters), $seconds);
+    }
+
+    /**
      * Wait until the given script returns true.
      *
      * @param  string  $script


### PR DESCRIPTION
this is a convenience method to use routes instead of URLs.

behaves the same as `visitRoute` as a wrapper of `visit`.

not sure if this is possible to unit test. couldn't find a test for `waitForLocation`, but let me know if one needs to be added.