### PR TITLE
Switch the phpunit to a required dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         "nesbot/carbon": "~1.20",
         "illuminate/console": "~5.6",
         "illuminate/support": "~5.6",
+        "phpunit/phpunit": "~7.0",
         "symfony/console": "~4.0",
         "symfony/process": "~4.0"
     },
     "require-dev": {
-        "mockery/mockery": "~1.0",
-        "phpunit/phpunit": "~7.0"
+        "mockery/mockery": "~1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The [MakesAssertions](https://github.com/laravel/dusk/blob/3.0/src/Concerns/MakesAssertions.php) requires phpunit, but it's only declared as a dev dependency.

This PR switches it so that it's always available