### PR TITLE
Add assertions

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -788,6 +788,74 @@ JS;
     }
 
     /**
+     * Assert that the given field is disabled.
+     *
+     * @param  string  $field
+     * @return $this
+     */
+    public function assertDisabled($field) {
+        $element = $this->resolver->resolveForField($field);
+
+        PHPUnit::assertFalse(
+            $element->isEnabled(),
+            "Expected element [{$field}] to be disabled, but it wasn't."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given field is enabled.
+     *
+     * @param  string  $field
+     * @return $this
+     */
+    public function assertEnabled($field) {
+        $element = $this->resolver->resolveForField($field);
+
+        PHPUnit::assertTrue(
+            $element->isEnabled(),
+            "Expected element [{$field}] to be enabled, but it wasn't."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given field is focused.
+     *
+     * @param  string  $field
+     * @return $this
+     */
+    public function assertFocused($field) {
+        $element = $this->resolver->resolveForField($field);
+
+        PHPUnit::assertTrue(
+            $this->driver->switchTo()->activeElement()->equals($element),
+            "Expected element [{$field}] to be focused, but it wasn't."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given field is not focused.
+     *
+     * @param  string  $field
+     * @return $this
+     */
+    public function assertNotFocused($field) {
+        $element = $this->resolver->resolveForField($field);
+
+        PHPUnit::assertFalse(
+            $this->driver->switchTo()->activeElement()->equals($element),
+            "Expected element [{$field}] not to be focused, but it was."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the Vue component's attribute at the given key has the given value.
      *
      * @param  string  $key

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -193,6 +193,24 @@ class ElementResolver
     }
 
     /**
+     * Resolve the element for a given "field".
+     *
+     * @param  string  $field
+     * @return \Facebook\WebDriver\Remote\RemoteWebElement
+     */
+    public function resolveForField($field)
+    {
+        if (! is_null($element = $this->findById($field))) {
+            return $element;
+        }
+
+        return $this->firstOrFail([
+            $field, "input[name='{$field}']", "textarea[name='{$field}']",
+            "select[name='{$field}']", "button[name='{$field}']"
+        ]);
+    }
+
+    /**
      * Resolve the element for a given button.
      *
      * @param  string  $button

--- a/tests/ElementResolverTest.php
+++ b/tests/ElementResolverTest.php
@@ -95,6 +95,22 @@ class ElementResolverTest extends TestCase
         $this->assertEquals('foo', $resolver->resolveForAttachment('foo'));
     }
 
+    public function test_resolve_for_field_resolves_by_id()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement')->once()->andReturn('foo');
+        $resolver = new ElementResolver($driver);
+        $this->assertEquals('foo', $resolver->resolveForField('#foo'));
+    }
+
+    public function test_resolve_for_field_falls_back_to_selectors_without_id()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement')->once()->andReturn('foo');
+        $resolver = new ElementResolver($driver);
+        $this->assertEquals('foo', $resolver->resolveForField('foo'));
+    }
+
     public function test_format_correctly_formats_selectors()
     {
         $resolver = new ElementResolver(new StdClass);

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -305,4 +305,98 @@ class MakesAssertionsTest extends TestCase
             );
         }
     }
+
+    public function test_assert_disabled()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $resolver = Mockery::mock(StdClass::class);
+        $resolver->shouldReceive('resolveForField->isEnabled')->andReturn(
+            false,
+            true
+        );
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertDisabled('foo');
+
+        try {
+            $browser->assertDisabled('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringStartsWith(
+                "Expected element [foo] to be disabled, but it wasn't.",
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_enabled()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $resolver = Mockery::mock(StdClass::class);
+        $resolver->shouldReceive('resolveForField->isEnabled')->andReturn(
+            true,
+            false
+        );
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertEnabled('foo');
+
+        try {
+            $browser->assertEnabled('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringStartsWith(
+                "Expected element [foo] to be enabled, but it wasn't.",
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_focused()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('switchTo->activeElement->equals')->with('element')->andReturn(
+            true,
+            false
+        );
+        $resolver = Mockery::mock(StdClass::class);
+        $resolver->shouldReceive('resolveForField')->with('foo')->andReturn('element');
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertFocused('foo');
+
+        try {
+            $browser->assertFocused('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringStartsWith(
+                "Expected element [foo] to be focused, but it wasn't.",
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_not_focused()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('switchTo->activeElement->equals')->with('element')->andReturn(
+            false,
+            true
+        );
+        $resolver = Mockery::mock(StdClass::class);
+        $resolver->shouldReceive('resolveForField')->with('foo')->andReturn('element');
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertNotFocused('foo');
+
+        try {
+            $browser->assertNotFocused('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringStartsWith(
+                "Expected element [foo] not to be focused, but it was.",
+                $e->getMessage()
+            );
+        }
+    }
 }


### PR DESCRIPTION
Adds new assertions:

- assertDisabled()
- assertEnabled()
- assertFocused()
- assertNotFocused()

This requires the new resolver method `resolveForField()` that finds all kinds of form elements:
`<input>`, `<textarea>`, `<select>`, `<button>`