### PR TITLE
Customize title assertion error messages

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -17,7 +17,7 @@ trait MakesAssertions
      */
     public function assertTitle($title)
     {
-        PHPUnit::assertEquals($title, $this->driver->getTitle());
+        PHPUnit::assertEquals($title, $this->driver->getTitle(), "Expected title [{$title}] does equal actual title [{$this->driver->getTitle()}].");
 
         return $this;
     }

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -17,7 +17,7 @@ trait MakesAssertions
      */
     public function assertTitle($title)
     {
-        PHPUnit::assertEquals($title, $this->driver->getTitle(), "Expected title [{$title}] does equal actual title [{$this->driver->getTitle()}].");
+        PHPUnit::assertEquals($title, $this->driver->getTitle(), "Expected title [{$title}] does not equal actual title [{$this->driver->getTitle()}].");
 
         return $this;
     }

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -20,7 +20,7 @@ class MakesAssertionsTest extends TestCase
             $browser->assertTitle('Foo');
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertEquals(
+            $this->assertContains(
                 'Failed asserting that two strings are equal.',
                 $e->getMessage()
             );


### PR DESCRIPTION
Provides clearer error messages for failed assertions.