### PR TITLE
Fix assertPresent() with PHP 7.2

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -744,7 +744,7 @@ JS;
         $fullSelector = $this->resolver->format($selector);
 
         PHPUnit::assertTrue(
-            count($this->resolver->find($selector)) > 0,
+            ! is_null($this->resolver->find($selector)),
             "Element [{$fullSelector}] is not present."
         );
 

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -306,6 +306,31 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_present()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $element = Mockery::mock(StdClass::class);
+        $resolver = Mockery::mock(StdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
+        $resolver->shouldReceive('find')->with('foo')->andReturn(
+            $element,
+            null
+        );
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertPresent('foo');
+
+        try {
+            $browser->assertPresent('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                "Element [body foo] is not present.",
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_disabled()
     {
         $driver = Mockery::mock(StdClass::class);


### PR DESCRIPTION
`ElementResolver::find()` returns a single `RemoteWebElement` or `null`.

Testing `count($this->resolver->find($selector)) > 0` works in PHP 7.1, but fails in [PHP 7.2](http://php.net/manual/de/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types):

    count(): Parameter must be an array or an object that implements Countable

Fixes #510.