### PR TITLE
Fix the page stub

### DIFF
--- a/src/Console/stubs/page.stub
+++ b/src/Console/stubs/page.stub
@@ -3,9 +3,8 @@
 namespace DummyNamespace;
 
 use Laravel\Dusk\Browser;
-use Laravel\Dusk\Page as BasePage;
 
-class DummyClass extends BasePage
+class DummyClass extends Page
 {
     /**
      * Get the URL for the page.


### PR DESCRIPTION
Hi,
I submitted this pull request a couple weeks ago referencing Issue #496, but it seems that it was automatically rejected because I forgot to add a description. So here it is again.

The stub as it is now extends `Laravel\Dusk\Page` instead of the abstract class `Tests\Browser\Pages\Page` included with a fresh installation of Dusk.  This means that any custom shortcuts defined in `Tests\Browser\Pages\Page::siteElements()` aren't available to tests.

This has already broken one of my tests when I forgot to change the `extends` for a page.  So I'm submitting a PR changing the `extends` in this stub. Thanks for looking into this.