### PR TITLE
[3.0] Improve assertions and tests

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -17,7 +17,10 @@ trait MakesAssertions
      */
     public function assertTitle($title)
     {
-        PHPUnit::assertEquals($title, $this->driver->getTitle(), "Expected title [{$title}] does not equal actual title [{$this->driver->getTitle()}].");
+        PHPUnit::assertEquals(
+            $title, $this->driver->getTitle(),
+            "Expected title [{$title}] does not equal actual title [{$this->driver->getTitle()}]."
+        );
 
         return $this;
     }
@@ -58,7 +61,10 @@ trait MakesAssertions
             array_get($segments, 'path', '')
         );
 
-        PHPUnit::assertRegExp('/^'.$pattern.'$/u', $currentUrl, "Actual URL [{$currentUrl}] does not equal expected URL [{$pattern}].");
+        PHPUnit::assertRegExp(
+            '/^'.$pattern.'$/u', $currentUrl,
+            "Actual URL [{$this->driver->getCurrentURL()}] does not equal expected URL [{$url}]."
+        );
 
         return $this;
     }
@@ -77,7 +83,10 @@ trait MakesAssertions
 
         $actualPath = parse_url($this->driver->getCurrentURL())['path'];
 
-        PHPUnit::assertRegExp('/^'.$pattern.'$/u', $actualPath, "Actual path [{$actualPath}] does not equal expected path [{$pattern}].");
+        PHPUnit::assertRegExp(
+            '/^'.$pattern.'$/u', $actualPath,
+            "Actual path [{$actualPath}] does not equal expected path [{$path}]."
+        );
 
         return $this;
     }
@@ -92,7 +101,10 @@ trait MakesAssertions
     {
         $actualPath = parse_url($this->driver->getCurrentURL())['path'];
 
-        PHPUnit::assertStringStartsWith($path, $actualPath, "Actual path [{$actualPath}] does not begin with expected path [{$path}].");
+        PHPUnit::assertStringStartsWith(
+            $path, $actualPath,
+            "Actual path [{$actualPath}] does not begin with expected path [{$path}]."
+        );
 
         return $this;
     }
@@ -107,7 +119,10 @@ trait MakesAssertions
     {
         $actualPath = parse_url($this->driver->getCurrentURL())['path'];
 
-        PHPUnit::assertNotEquals($path, $actualPath, "Path [{$path}] should not equal the actual value.");
+        PHPUnit::assertNotEquals(
+            $path, $actualPath,
+            "Path [{$path}] should not equal the actual value."
+        );
 
         return $this;
     }
@@ -124,7 +139,10 @@ trait MakesAssertions
 
         $actualFragment = (string) parse_url($this->driver->executeScript('return window.location.href;'), PHP_URL_FRAGMENT);
 
-        PHPUnit::assertRegExp('/^'.str_replace('\*', '.*', $pattern).'$/u', $actualFragment, "Actual fragment [{$actualFragment}] does not equal expected fragment [{$pattern}].");
+        PHPUnit::assertRegExp(
+            '/^'.str_replace('\*', '.*', $pattern).'$/u', $actualFragment,
+            "Actual fragment [{$actualFragment}] does not equal expected fragment [{$fragment}]."
+        );
 
         return $this;
     }
@@ -139,7 +157,10 @@ trait MakesAssertions
     {
         $actualFragment = (string) parse_url($this->driver->executeScript('return window.location.href;'), PHP_URL_FRAGMENT);
 
-        PHPUnit::assertStringStartsWith($fragment, $actualFragment, "Actual fragment [$actualFragment] does not begin with expected fragment [$fragment].");
+        PHPUnit::assertStringStartsWith(
+            $fragment, $actualFragment,
+            "Actual fragment [$actualFragment] does not begin with expected fragment [$fragment]."
+        );
 
         return $this;
     }
@@ -154,7 +175,10 @@ trait MakesAssertions
     {
         $actualFragment = (string) parse_url($this->driver->executeScript('return window.location.href;'), PHP_URL_FRAGMENT);
 
-        PHPUnit::assertNotEquals($fragment, $actualFragment, "Fragment [{$fragment}] should not equal the actual value.");
+        PHPUnit::assertNotEquals(
+            $fragment, $actualFragment,
+            "Fragment [{$fragment}] should not equal the actual value."
+        );
 
         return $this;
     }
@@ -437,7 +461,7 @@ trait MakesAssertions
         if ($this->resolver->prefix) {
             $message = "Saw unexpected link [{$link}] within [{$this->resolver->prefix}].";
         } else {
-            $message = "Saw unexpected expected link [{$link}].";
+            $message = "Saw unexpected link [{$link}].";
         }
 
         PHPUnit::assertFalse(
@@ -477,7 +501,10 @@ JS;
      */
     public function assertInputValue($field, $value)
     {
-        PHPUnit::assertEquals($value, $this->inputValue($field), "Expected value [{$value}] for the [{$field}] input does not equal the actual value [{$this->inputValue($field)}].");
+        PHPUnit::assertEquals(
+            $value, $this->inputValue($field),
+            "Expected value [{$value}] for the [{$field}] input does not equal the actual value [{$this->inputValue($field)}]."
+        );
 
         return $this;
     }
@@ -491,7 +518,10 @@ JS;
      */
     public function assertInputValueIsNot($field, $value)
     {
-        PHPUnit::assertNotEquals($value, $this->inputValue($field), "Value [{$value}] for the [{$field}] input should not equal the actual value.");
+        PHPUnit::assertNotEquals(
+            $value, $this->inputValue($field),
+            "Value [{$value}] for the [{$field}] input should not equal the actual value."
+        );
 
         return $this;
     }
@@ -780,8 +810,11 @@ JS;
      */
     public function assertDialogOpened($message)
     {
+        $actualMessage = $this->driver->switchTo()->alert()->getText();
+
         PHPUnit::assertEquals(
-            $message, $this->driver->switchTo()->alert()->getText()
+            $message, $actualMessage,
+            "Expected dialog message [{$message}] does not equal actual message [{$actualMessage}]."
         );
 
         return $this;
@@ -904,7 +937,7 @@ JS;
 
     /**
      * Assert that the Vue component's attribute at the given key
-     * is an array that contains the given value.
+     * is an array that does not contain the given value.
      *
      * @param  string  $key
      * @param  string  $value

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -21,7 +21,7 @@ class MakesAssertionsTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertContains(
-                'Failed asserting that two strings are equal.',
+                'Expected title [Foo] does not equal actual title [foo].',
                 $e->getMessage()
             );
         }
@@ -41,7 +41,7 @@ class MakesAssertionsTest extends TestCase
             $browser->assertTitleContains('Fo');
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringStartsWith(
+            $this->assertContains(
                 'Did not see expected value [Fo] within title [foo].',
                 $e->getMessage()
             );
@@ -66,8 +66,7 @@ class MakesAssertionsTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertContains(
-                'Failed asserting that \'http://www.google.com:80/test\' matches PCRE pattern '.
-                '"/^http\:\/\/www\.google\.com$/u".',
+                'Actual URL [http://www.google.com:80/test?foo=bar] does not equal expected URL [http://www.google.com].',
                 $e->getMessage()
             );
         }
@@ -95,7 +94,7 @@ class MakesAssertionsTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertContains(
-                'Failed asserting that \'foo/1/bar/1\' matches PCRE pattern "/^foo\/.*\/$/u".',
+                'Actual path [foo/1/bar/1] does not equal expected path [foo/*/].',
                 $e->getMessage()
             );
         }
@@ -116,7 +115,7 @@ class MakesAssertionsTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertContains(
-                'Failed asserting that \'/test\' starts with "test".',
+                'Actual path [/test] does not begin with expected path [test].',
                 $e->getMessage()
             );
         }
@@ -137,7 +136,7 @@ class MakesAssertionsTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertContains(
-                'Failed asserting that \'/test\' is not equal to "/test".',
+                'Path [/test] should not equal the actual value.',
                 $e->getMessage()
             );
         }
@@ -158,7 +157,7 @@ class MakesAssertionsTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertContains(
-                'Failed asserting that \'baz\' matches PCRE pattern "/^ba$/u".',
+                'Actual fragment [baz] does not equal expected fragment [ba].',
                 $e->getMessage()
             );
         }
@@ -179,7 +178,7 @@ class MakesAssertionsTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertContains(
-                'Failed asserting that \'baz\' starts with "Ba".',
+                'Actual fragment [baz] does not begin with expected fragment [Ba].',
                 $e->getMessage()
             );
         }
@@ -200,7 +199,7 @@ class MakesAssertionsTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertContains(
-                'Failed asserting that \'baz\' is not equal to "baz".',
+                'Fragment [baz] should not equal the actual value.',
                 $e->getMessage()
             );
         }
@@ -223,7 +222,7 @@ class MakesAssertionsTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertContains(
-                'Failed asserting that \'/test/1\' matches PCRE pattern "/^\/test\/$/u".',
+                'Actual path [/test/1] does not equal expected path [/test/].',
                 $e->getMessage()
             );
         }
@@ -243,7 +242,7 @@ class MakesAssertionsTest extends TestCase
             $browser->assertQueryStringHas('foo');
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringStartsWith(
+            $this->assertContains(
                 'Did not see expected query string in [http://www.google.com].',
                 $e->getMessage()
             );
@@ -255,7 +254,7 @@ class MakesAssertionsTest extends TestCase
             $browser->assertQueryStringHas('bar');
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringStartsWith(
+            $this->assertContains(
                 'Did not see expected query string parameter [bar] in [http://www.google.com/?foo].',
                 $e->getMessage()
             );
@@ -276,7 +275,7 @@ class MakesAssertionsTest extends TestCase
             $browser->assertQueryStringHas('foo', '');
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringStartsWith(
+            $this->assertContains(
                 'Query string parameter [foo] had value [bar], but expected [].',
                 $e->getMessage()
             );
@@ -299,8 +298,8 @@ class MakesAssertionsTest extends TestCase
             $browser->assertQueryStringMissing('foo');
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringStartsWith(
-                "Found unexpected query string parameter [foo] in [http://www.google.com/?foo=bar].",
+            $this->assertContains(
+                'Found unexpected query string parameter [foo] in [http://www.google.com/?foo=bar].',
                 $e->getMessage()
             );
         }
@@ -331,29 +330,6 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
-    public function test_assert_disabled()
-    {
-        $driver = Mockery::mock(StdClass::class);
-        $resolver = Mockery::mock(StdClass::class);
-        $resolver->shouldReceive('resolveForField->isEnabled')->andReturn(
-            false,
-            true
-        );
-        $browser = new Browser($driver, $resolver);
-
-        $browser->assertDisabled('foo');
-
-        try {
-            $browser->assertDisabled('foo');
-            $this->fail();
-        } catch (ExpectationFailedException $e) {
-            $this->assertStringStartsWith(
-                "Expected element [foo] to be disabled, but it wasn't.",
-                $e->getMessage()
-            );
-        }
-    }
-
     public function test_assert_enabled()
     {
         $driver = Mockery::mock(StdClass::class);
@@ -370,8 +346,31 @@ class MakesAssertionsTest extends TestCase
             $browser->assertEnabled('foo');
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringStartsWith(
+            $this->assertContains(
                 "Expected element [foo] to be enabled, but it wasn't.",
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_disabled()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $resolver = Mockery::mock(StdClass::class);
+        $resolver->shouldReceive('resolveForField->isEnabled')->andReturn(
+            false,
+            true
+        );
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertDisabled('foo');
+
+        try {
+            $browser->assertDisabled('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                "Expected element [foo] to be disabled, but it wasn't.",
                 $e->getMessage()
             );
         }
@@ -394,7 +393,7 @@ class MakesAssertionsTest extends TestCase
             $browser->assertFocused('foo');
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringStartsWith(
+            $this->assertContains(
                 "Expected element [foo] to be focused, but it wasn't.",
                 $e->getMessage()
             );
@@ -418,8 +417,8 @@ class MakesAssertionsTest extends TestCase
             $browser->assertNotFocused('foo');
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringStartsWith(
-                "Expected element [foo] not to be focused, but it was.",
+            $this->assertContains(
+                'Expected element [foo] not to be focused, but it was.',
                 $e->getMessage()
             );
         }


### PR DESCRIPTION
Improve assertions:

- Improve code readability with shorter lines.
- Improve message readability by replacing regex patterns with values (`http://www.google.com` instead of `/^http\:\/\/www\.google\.com$/u`).
- Add message for `assertDialogOpened()`.
- Fix typos.

Improve assertion tests:

- Test new messages added in #506, #507 and #508.
- Re-order tests for `assertEnabled()` and `assertDisabled()` (c04173f0ed0351204ff34ae7e9be5d85a359e19c)