### PR TITLE
[3.0] Add assertion tests

### DIFF
--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -1,5 +1,9 @@
 <?php
 
+use Facebook\WebDriver\Cookie;
+use Facebook\WebDriver\Exception\NoSuchElementException;
+use Facebook\WebDriver\Remote\RemoteWebElement;
+use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
@@ -305,17 +309,653 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
-    public function test_assert_present()
+    public function test_assert_has_cookie()
+    {
+        require_once __DIR__.'/stubs/decrypt.php';
+
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('manage->getCookieNamed')->with('foo')->andReturn(
+            new Cookie('foo', 's%3A0%3A%22%22%3B'), // ""
+            null
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertHasCookie('foo');
+
+        try {
+            $browser->assertHasCookie('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Did not find expected cookie [foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_cookie_missing()
+    {
+        require_once __DIR__.'/stubs/decrypt.php';
+
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('manage->getCookieNamed')->with('foo')->andReturn(
+            null,
+            new Cookie('foo', 's%3A0%3A%22%22%3B') // ""
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertCookieMissing('foo');
+
+        try {
+            $browser->assertCookieMissing('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Found unexpected cookie [foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_cookie_value()
+    {
+        require_once __DIR__.'/stubs/decrypt.php';
+
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('manage->getCookieNamed')->with('foo')->andReturn(
+            new Cookie('foo', '%25'), // "%"
+            new Cookie('foo', 's%3A1%3A%22%25%22%3B') // "%"
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertCookieValue('foo', '%', false);
+        $browser->assertCookieValue('foo', '%');
+
+        try {
+            $browser->assertCookieValue('foo', 'bar');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Cookie [foo] had value [%], but expected [bar].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_plain_cookie_value()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('manage->getCookieNamed')->with('foo')->andReturn(
+            new Cookie('foo', '%25') // "%"
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertPlainCookieValue('foo', '%');
+
+        try {
+            $browser->assertPlainCookieValue('foo', 'bar');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Cookie [foo] had value [%], but expected [bar].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_see()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement->getText')->andReturn(
+            'foo'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertSee('foo');
+
+        try {
+            $browser->assertSee('Foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Did not see expected text [Foo] within element [body].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_dont_see()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement->getText')->andReturn(
+            'foo'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertDontSee('Foo');
+
+        try {
+            $browser->assertDontSee('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Saw unexpected text [foo] within element [body].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_see_in()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement->getText')->andReturn(
+            'foo'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertSeeIn('div', 'foo');
+
+        try {
+            $browser->assertSeeIn('div', 'Foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Did not see expected text [Foo] within element [body div].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_dont_see_in()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement->getText')->andReturn(
+            'foo'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertDontSeeIn('div', 'Foo');
+
+        try {
+            $browser->assertDontSeeIn('div', 'foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Saw unexpected text [foo] within element [body div].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_source_has()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('getPageSource')->andReturn(
+            '<p>foo</p>'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertSourceHas('foo');
+
+        try {
+            $browser->assertSourceHas('Foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Did not find expected source code [Foo]',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_source_missing()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('getPageSource')->andReturn(
+            '<p>foo</p>'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertSourceMissing('Foo');
+
+        try {
+            $browser->assertSourceMissing('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Found unexpected source code [foo]',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_see_link()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('executeScript')->andReturn(
+            false, // jQuery
+            true,
+            false, // jQuery
+            false
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertSeeLink('foo');
+
+        try {
+            $browser->assertSeeLink('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Did not see expected link [foo] within [body].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_dont_see_link()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('executeScript')->andReturn(
+            false, // jQuery
+            false,
+            false, // jQuery
+            true
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertDontSeeLink('foo');
+
+        try {
+            $browser->assertDontSeeLink('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Saw unexpected link [foo] within [body].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_see_link()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('executeScript')->with('return window.jQuery == null')->andReturn(false);
+        $driver->shouldReceive('executeScript')->with(Mockery::on(function ($argument) {
+            return Str::contains($argument, "body a:contains(\'foo\')");
+        }))->andReturn(
+            true
+        );
+        $browser = new Browser($driver);
+
+        $this->assertTrue($browser->seeLink('foo'));
+    }
+
+    public function test_assert_input_value()
     {
         $driver = Mockery::mock(StdClass::class);
         $element = Mockery::mock(StdClass::class);
-        $resolver = Mockery::mock(StdClass::class);
-        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
-        $resolver->shouldReceive('find')->with('foo')->andReturn(
-            $element,
+        $element->shouldReceive('getTagName')->andReturn('input');
+        $element->shouldReceive('getAttribute')->andReturn(
+            'value'
+        );
+        $driver->shouldReceive('findElement')->andReturn($element);
+        $browser = new Browser($driver);
+
+        $browser->assertInputValue('foo', 'value');
+
+        try {
+            $browser->assertInputValue('foo', 'Value');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Expected value [Value] for the [foo] input does not equal the actual value [value]',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_input_value_is_not()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $element = Mockery::mock(StdClass::class);
+        $element->shouldReceive('getTagName')->andReturn('input');
+        $element->shouldReceive('getAttribute')->andReturn(
+            'value'
+        );
+        $driver->shouldReceive('findElement')->andReturn($element);
+        $browser = new Browser($driver);
+
+        $browser->assertInputValueIsNot('foo', 'Value');
+
+        try {
+            $browser->assertInputValueIsNot('foo', 'value');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Value [value] for the [foo] input should not equal the actual value.',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_input_value()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $element = Mockery::mock(StdClass::class);
+        $element->shouldReceive('getTagName')->andReturn(
+            'input',
+            'p'
+        );
+        $element->shouldReceive('getAttribute')->with('value')->andReturn(
+            'value'
+        );
+        $element->shouldReceive('getText')->andReturn(
+            'text'
+        );
+        $driver->shouldReceive('findElement')->andReturn($element);
+        $browser = new Browser($driver);
+
+        $this->assertEquals('value', $browser->inputValue('foo'));
+        $this->assertEquals('text', $browser->inputValue('foo'));
+    }
+
+    public function test_assert_checked()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement->isSelected')->andReturn(
+            true,
+            false
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertChecked('foo');
+
+        try {
+            $browser->assertChecked('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                "Expected checkbox [foo] to be checked, but it wasn't.",
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_not_checked()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement->isSelected')->andReturn(
+            false,
+            true
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertNotChecked('foo');
+
+        try {
+            $browser->assertNotChecked('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Checkbox [foo] was unexpectedly checked.',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_radio_selected()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement->isSelected')->andReturn(
+            true,
+            false
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertRadioSelected('foo', 'bar');
+
+        try {
+            $browser->assertRadioSelected('foo', 'bar');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                "Expected radio [foo] to be selected, but it wasn't.",
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_radio_not_selected()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement->isSelected')->andReturn(
+            false,
+            true
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertRadioNotSelected('foo', 'bar');
+
+        try {
+            $browser->assertRadioNotSelected('foo', 'bar');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Radio [foo] was unexpectedly selected.',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_selected()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement->getAttribute')->andReturn(
+            'bar'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertSelected('foo', 'bar');
+
+        try {
+            $browser->assertSelected('foo', 'Bar');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                "Expected value [Bar] to be selected for [foo], but it wasn't.",
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_not_selected()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement->getAttribute')->andReturn(
+            'bar'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertNotSelected('foo', 'Bar');
+
+        try {
+            $browser->assertNotSelected('foo', 'bar');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Unexpected value [bar] selected for [foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_select_has_options()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $option = Mockery::mock(RemoteWebElement::class);
+        $option->shouldReceive('getAttribute')->with('value')->andReturn(
+            'bar'
+        );
+        $driver->shouldReceive('findElement->findElements')->andReturn(
+            [$option, $option]
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertSelectHasOptions('foo', ['bar']);
+
+        try {
+            $browser->assertSelectHasOptions('foo', ['bar', 'baz']);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Expected options [bar,baz] for selection field [foo] to be available.',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_select_missing_options()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $option = Mockery::mock(RemoteWebElement::class);
+        $option->shouldReceive('getAttribute')->with('value')->andReturn(
+            'bar'
+        );
+        $driver->shouldReceive('findElement->findElements')->andReturn(
+            [],
+            [$option]
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertSelectMissingOptions('foo', ['bar']);
+
+        try {
+            $browser->assertSelectMissingOptions('foo', ['bar', 'baz']);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Unexpected options [bar,baz] for selection field [foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_select_has_option()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $option = Mockery::mock(RemoteWebElement::class);
+        $option->shouldReceive('getAttribute')->with('value')->andReturn(
+            'bar'
+        );
+        $driver->shouldReceive('findElement->findElements')->andReturn(
+            [$option],
+            []
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertSelectHasOption('foo', 'bar');
+
+        try {
+            $browser->assertSelectHasOption('foo', 'bar');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Expected options [bar] for selection field [foo] to be available.',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_select_missing_option()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $option = Mockery::mock(RemoteWebElement::class);
+        $option->shouldReceive('getAttribute')->with('value')->andReturn(
+            'bar'
+        );
+        $driver->shouldReceive('findElement->findElements')->andReturn(
+            [],
+            [$option]
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertSelectMissingOption('foo', 'bar');
+
+        try {
+            $browser->assertSelectMissingOption('foo', 'bar');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Unexpected options [bar] for selection field [foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_selected()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement->getAttribute')->with('value')->andReturn(
+            'bar'
+        );
+        $browser = new Browser($driver);
+
+        $this->assertTrue($browser->selected('foo', 'bar'));
+        $this->assertFalse($browser->selected('foo', 'Bar'));
+    }
+
+    public function test_assert_value()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement->getAttribute')->with('value')->andReturn(
+            'bar'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertValue('foo', 'bar');
+
+        try {
+            $browser->assertValue('foo', 'Bar');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Failed asserting that two strings are equal.',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_visible()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement->isDisplayed')->andReturn(
+            true,
+            false
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertVisible('foo');
+
+        try {
+            $browser->assertVisible('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Element [body foo] is not visible.',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_present()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement')->andReturn(
+            'element',
             null
         );
-        $browser = new Browser($driver, $resolver);
+        $browser = new Browser($driver);
 
         $browser->assertPresent('foo');
 
@@ -324,7 +964,54 @@ class MakesAssertionsTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertContains(
-                "Element [body foo] is not present.",
+                'Element [body foo] is not present.',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_missing()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement')->once()->andThrow(NoSuchElementException::class);
+        $element = Mockery::mock(StdClass::class);
+        $element->shouldReceive('isDisplayed')->andReturn(
+            false,
+            true
+        );
+        $driver->shouldReceive('findElement')->andReturn($element);
+        $browser = new Browser($driver);
+
+        $browser->assertMissing('foo'); // Missing element.
+        $browser->assertMissing('foo'); // Hidden element.
+
+        try {
+            $browser->assertMissing('foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Saw unexpected element [body foo]',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_dialog_opened()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('switchTo->alert->getText')->andReturn(
+            'foo'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertDialogOpened('foo');
+
+        try {
+            $browser->assertDialogOpened('Foo');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Expected dialog message [Foo] does not equal actual message [foo].',
                 $e->getMessage()
             );
         }
@@ -333,12 +1020,11 @@ class MakesAssertionsTest extends TestCase
     public function test_assert_enabled()
     {
         $driver = Mockery::mock(StdClass::class);
-        $resolver = Mockery::mock(StdClass::class);
-        $resolver->shouldReceive('resolveForField->isEnabled')->andReturn(
+        $driver->shouldReceive('findElement->isEnabled')->andReturn(
             true,
             false
         );
-        $browser = new Browser($driver, $resolver);
+        $browser = new Browser($driver);
 
         $browser->assertEnabled('foo');
 
@@ -356,12 +1042,11 @@ class MakesAssertionsTest extends TestCase
     public function test_assert_disabled()
     {
         $driver = Mockery::mock(StdClass::class);
-        $resolver = Mockery::mock(StdClass::class);
-        $resolver->shouldReceive('resolveForField->isEnabled')->andReturn(
+        $driver->shouldReceive('findElement->isEnabled')->andReturn(
             false,
             true
         );
-        $browser = new Browser($driver, $resolver);
+        $browser = new Browser($driver);
 
         $browser->assertDisabled('foo');
 
@@ -379,13 +1064,12 @@ class MakesAssertionsTest extends TestCase
     public function test_assert_focused()
     {
         $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement')->andReturn('element');
         $driver->shouldReceive('switchTo->activeElement->equals')->with('element')->andReturn(
             true,
             false
         );
-        $resolver = Mockery::mock(StdClass::class);
-        $resolver->shouldReceive('resolveForField')->with('foo')->andReturn('element');
-        $browser = new Browser($driver, $resolver);
+        $browser = new Browser($driver);
 
         $browser->assertFocused('foo');
 
@@ -403,13 +1087,12 @@ class MakesAssertionsTest extends TestCase
     public function test_assert_not_focused()
     {
         $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('findElement')->andReturn('element');
         $driver->shouldReceive('switchTo->activeElement->equals')->with('element')->andReturn(
             false,
             true
         );
-        $resolver = Mockery::mock(StdClass::class);
-        $resolver->shouldReceive('resolveForField')->with('foo')->andReturn('element');
-        $browser = new Browser($driver, $resolver);
+        $browser = new Browser($driver);
 
         $browser->assertNotFocused('foo');
 
@@ -422,5 +1105,101 @@ class MakesAssertionsTest extends TestCase
                 $e->getMessage()
             );
         }
+    }
+
+    public function test_assert_vue()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('executeScript')->andReturn(
+            'bar'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertVue('foo', 'bar', 'baz');
+
+        try {
+            $browser->assertVue('foo', 'Bar', 'baz');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Failed asserting that two strings are equal.',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_vue_is_not()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('executeScript')->andReturn(
+            'bar'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertVueIsNot('foo', 'Bar', 'baz');
+
+        try {
+            $browser->assertVueIsNot('foo', 'bar', 'baz');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Failed asserting that \'bar\' is not equal to "bar".',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_vue_contains()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('executeScript')->andReturn(
+            ['bar']
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertVueContains('foo', 'bar', 'baz');
+
+        try {
+            $browser->assertVueContains('foo', 'Bar', 'baz');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                "Failed asserting that an array contains 'Bar'.",
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_vue_does_not_contain()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('executeScript')->andReturn(
+            ['bar']
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertVueDoesNotContain('foo', 'Bar', 'baz');
+
+        try {
+            $browser->assertVueDoesNotContain('foo', 'bar', 'baz');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                "Failed asserting that an array does not contain 'bar'.",
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_vue_attribute()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $script = "return document.querySelector('body foo').__vue__.bar";
+        $driver->shouldReceive('executeScript')->with($script)->andReturn(
+            'baz'
+        );
+        $browser = new Browser($driver);
+
+        $this->assertEquals('baz', $browser->vueAttribute('foo', 'bar'));
     }
 }

--- a/tests/stubs/decrypt.php
+++ b/tests/stubs/decrypt.php
@@ -1,0 +1,6 @@
+<?php
+
+function decrypt($payload)
+{
+    return unserialize($payload);
+}


### PR DESCRIPTION
Adds the remaining assertion tests.

Now without `$resolver` mocks and with as few mocks as I could achieve.