### PR TITLE
select() excludes disabled options

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -210,7 +210,7 @@ trait InteractsWithElements
     {
         $element = $this->resolver->resolveForSelection($field);
 
-        $options = $element->findElements(WebDriverBy::tagName('option'));
+        $options = $element->findElements(WebDriverBy::cssSelector('option:not([disabled])'));
 
         if (is_null($value)) {
             $options[array_rand($options)]->click();


### PR DESCRIPTION
Disregard any disabled `<option>`s when selecting drop down options.  This is especially nice when you are letting it pick a random one and don't want it to occasionally pick a blank default. If you want an first option that is empty (no default), but require a non-empty one to be selected, you can use `<option selected disabled></option>`.

Based on #302.