### PR TITLE
fix user phpDoc

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -56,9 +56,9 @@ abstract class TestCase extends FoundationTestCase
     }
 
     /**
-     * Get a callback that returns the default user to authenticate.
+     * Return the default user to authenticate.
      *
-     * @return \Closure
+     * @return \App\User|int|null
      * @throws \Exception
      */
     protected function user()


### PR DESCRIPTION
Hi, I noticed the following: the phpDoc for the `user` method claims that the method is supposed to return a `Closure`. However, on line 32 this method call is itself wrapped in a closure, which means that when `Browser::$userResolver` is actually called, it will return an instance of `Closure` instead of a user, and it will not be able to login successfully, throwing an `ErrorException: Object of class Closure could not be converted to string`.

I changed the phpDoc signature for this method, so when someone wants to override it in their project, they won't get confused.

The other option of course would be to remove the closure from the `setUp` method, but I didn't think it prudent to muck around with actual functionality here.