### PR TITLE
Add support for passing arguments to the chromedriver process.

### DIFF
--- a/src/Chrome/ChromeProcess.php
+++ b/src/Chrome/ChromeProcess.php
@@ -33,36 +33,38 @@ class ChromeProcess
     /**
      * Build the process to run Chromedriver.
      *
+     * @param array $args
      * @return \Symfony\Component\Process\Process
      */
-    public function toProcess()
+    public function toProcess(array $args = [])
     {
         if ($this->driver) {
-            return $this->process();
+            return $this->process($args);
         }
 
         if ($this->onWindows()) {
             $this->driver = realpath(__DIR__.'/../../bin/chromedriver-win.exe');
 
-            return $this->process();
+            return $this->process($args);
         }
 
         $this->driver = $this->onMac()
                         ? realpath(__DIR__.'/../../bin/chromedriver-mac')
                         : realpath(__DIR__.'/../../bin/chromedriver-linux');
 
-        return $this->process();
+        return $this->process($args);
     }
 
     /**
      * Build the Chromedriver with Symfony Process.
      *
+     * @param array $args
      * @return \Symfony\Component\Process\Process
      */
-    protected function process()
+    protected function process(array $args = [])
     {
         return (new Process(
-            [realpath($this->driver)], null, $this->chromeEnvironment()
+            array_merge([realpath($this->driver)], $args), null, $this->chromeEnvironment()
         ));
     }
 

--- a/src/Chrome/SupportsChrome.php
+++ b/src/Chrome/SupportsChrome.php
@@ -23,13 +23,15 @@ trait SupportsChrome
     /**
      * Start the Chromedriver process.
      *
+     * @param array $args
+     *
      * @throws \RuntimeException if the driver file path doesn't exist.
      *
      * @return void
      */
-    public static function startChromeDriver()
+    public static function startChromeDriver(array $args = [])
     {
-        static::$chromeProcess = static::buildChromeProcess();
+        static::$chromeProcess = static::buildChromeProcess($args);
 
         static::$chromeProcess->start();
 
@@ -57,9 +59,9 @@ trait SupportsChrome
      * @return \Symfony\Component\Process\Process
      * @throws \RuntimeException if the driver file path doesn't exist.
      */
-    protected static function buildChromeProcess()
+    protected static function buildChromeProcess(array $args = [])
     {
-        return (new ChromeProcess(static::$chromeDriver))->toProcess();
+        return (new ChromeProcess(static::$chromeDriver))->toProcess($args);
     }
 
     /**


### PR DESCRIPTION
This is quite useful to add support for running multiple instances of Dusk in parallel (by setting the `port` argument for instance).