### PR TITLE
Fix tests when running on Windows.

### DIFF
--- a/tests/ChromeProcessTest.php
+++ b/tests/ChromeProcessTest.php
@@ -61,11 +61,21 @@ class ChromeProcessDarwin extends \Laravel\Dusk\Chrome\ChromeProcess
     {
         return true;
     }
+
+    protected function onWindows()
+    {
+        return false;
+    }
 }
 
 class ChromeProcessLinux extends \Laravel\Dusk\Chrome\ChromeProcess
 {
     protected function onMac()
+    {
+        return false;
+    }
+
+    protected function onWindows()
     {
         return false;
     }


### PR DESCRIPTION
As the current logic in ChromeProcess::toProcess is to check if we're on Windows first, and the method not being overridden in ChromeProcessDarwin and ChromeProcessLinux, the onWindows method will true. The fix in this case is simply to override onWindows for both classes so it returns false.