### PR TITLE
[3.0] Allow to use --env from command line

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -91,7 +91,11 @@ class DuskCommand extends Command
      */
     protected function phpunitArguments($options)
     {
-        return array_merge(['-c', base_path('phpunit.dusk.xml')], $options);
+        $phpUnitOptions = array_filter($options, function($option) {
+            return !starts_with($option, '--env=');
+        });
+
+        return array_merge(['-c', base_path('phpunit.dusk.xml')], $phpUnitOptions);
     }
 
     /**


### PR DESCRIPTION
When running `php artisan dusk --help` you get:

```
--env[=ENV]       The environment the command should run under
```

but in fact it's not working because it's later passed to PHPUnit when running so you end up with:

> unrecognized option --env

from PHPUnit.

This PR fixed this - env will be used as it should be but this argument won't be passed to PHPUnit so it will be possible to run tests.

It's also quite important to allow this in case you have multiple domains and you need set different environment and use different .env files depending on what you are testing.