### PR TITLE
Fixed Browser#visit docblock to include Page

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -112,7 +112,7 @@ class Browser
     /**
      * Browse to the given URL.
      *
-     * @param  string  $url
+     * @param  string|Page  $url
      * @return $this
      */
     public function visit($url)


### PR DESCRIPTION
The docblock for the `visit` function of `Browser` did include a page as possible arguments, but was limited to a string.