### PR TITLE
Update the requested facebook/webdriver version to 1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "facebook/webdriver": "~1.0",
+        "facebook/webdriver": "~1.3",
         "nesbot/carbon": "~1.20",
         "illuminate/console": "~5.6",
         "illuminate/support": "~5.6",


### PR DESCRIPTION
Dusk now calls `Facebook\WebDriver\Remote\RemoteWebDriver::getCapabilities()` method which is added to facebook/webdriver since version 1.3.
(https://github.com/facebook/php-webdriver/blob/community/CHANGELOG.md)

Therefore, I think that the request version described in composer.json should be updated.

Fixes #385,#464

