### PR TITLE
Make clickLink() only select visible elements

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -43,7 +43,7 @@ trait InteractsWithElements
     {
         $this->ensurejQueryIsAvailable();
 
-        $selector = addslashes(trim($this->resolver->format("{$element}:contains({$link})")));
+        $selector = addslashes(trim($this->resolver->format("{$element}:contains({$link}):visible")));
 
         $this->driver->executeScript("jQuery.find(\"{$selector}\")[0].click();");
 


### PR DESCRIPTION
I think it makes sense that `clickLink()` only selects visible elements.

(Btw. should pull requests be made against `master` or `3.0`? Would be nice if this was stated somewhere, e.g. in the readme, since it's a bit confusing when `3.0` is the main branch.)