### PR TITLE
[3.0] Fix `waitForRoute()`

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -109,7 +109,7 @@ trait WaitsForElements
      */
     public function waitForRoute($route, $parameters = [], $seconds = null)
     {
-        return $this->waitForLocation(route($route, $parameters), $seconds);
+        return $this->waitForLocation(route($route, $parameters, false), $seconds);
     }
 
     /**

--- a/tests/WaitsForElementsTest.php
+++ b/tests/WaitsForElementsTest.php
@@ -80,5 +80,4 @@ class WaitsForElementsTest extends TestCase
 
         $browser->waitForRoute('home');
     }
-
 }

--- a/tests/WaitsForElementsTest.php
+++ b/tests/WaitsForElementsTest.php
@@ -62,4 +62,23 @@ class WaitsForElementsTest extends TestCase
             return false;
         });
     }
+
+    public function test_can_wait_for_location()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('executeScript')->with("return window.location.pathname == '/home';")->andReturnTrue();
+        $browser = new Browser($driver);
+
+        $browser->waitForLocation('/home');
+    }
+
+    public function test_can_wait_for_route()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('executeScript')->with("return window.location.pathname == '/home/';")->andReturnTrue();
+        $browser = new Browser($driver);
+
+        $browser->waitForRoute('home');
+    }
+
 }


### PR DESCRIPTION
pass `false` as the third parameter of `waitForRoute()` so it returns only the path info of the route, and not the absolute URL. we are comparing it to `window.location.pathname` which also only returns the path.

also add some tests.