### PR TITLE
[3.0] Simplify switching frames

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -410,6 +410,23 @@ class Browser
     }
 
     /**
+     * Switch to a specified frame in the browser.
+     *
+     * @param  string  $selector
+     * @return $this
+     */
+    public function frame($selector = null)
+    {
+        if ($selector) {
+            $this->driver->switchTo()->frame($this->resolver->findOrFail($selector));
+        } else {
+            $this->driver->switchTo()->defaultContent();
+        }
+
+        return $this;
+    }
+
+    /**
      * Dynamically call a method on the browser.
      *
      * @param  string  $method


### PR DESCRIPTION
If a page includes an iFrame, it is currently rather clunky to interact with it.  For example, we use a 3rd party form service to submit and aggregate things like Contact forms. I would like to test that we can indeed submit to them, and need to interact with their iFrame to do so.

this new method provides a seamless way to switch frames, and continue chaining methods on the browser.  Simply pass any valid selector to the `frame()` method.

```php
 $this->browse(function (Browser $browser) {

            $browser->visit('https://example.com/contact')
                    ->frame('#iframeId')
                    ->type('name', 'Andrew Brown')
                    ->type('email', 'andrew@example.com')
                    ->press('submit')
                    ->assertSee('Thank you for contacting us!');
        });
```

If you need to continue interacting with the default frame when done, you can call the method without an argument.

```php
 $this->browse(function (Browser $browser) {

            $browser->visit('https://example.com/contact')
                    ->frame('#iframeId')
                    ->type('name', 'Andrew Brown')
                    ->type('email', 'andrew@example.com')
                    ->press('submit')
                    ->assertSee('Thank you for contacting us!')
                    ->frame()
                    ->click('#defaultFrameElement');
        });
```

Credit for this code goes to everyone in this thread:

https://laracasts.com/discuss/channels/laravel/dusk-click-element-in-iframe?page=1