### PR TITLE
[4.0] Don't serialize cookies when encrypting

### DIFF
--- a/src/Concerns/InteractsWithCookies.php
+++ b/src/Concerns/InteractsWithCookies.php
@@ -22,7 +22,7 @@ trait InteractsWithCookies
         }
 
         if ($cookie = $this->driver->manage()->getCookieNamed($name)) {
-            return decrypt(rawurldecode($cookie['value']));
+            return decrypt(rawurldecode($cookie['value']), $unserialize = false);
         }
     }
 
@@ -59,7 +59,7 @@ trait InteractsWithCookies
     public function addCookie($name, $value, $expiry = null, array $options = [], $encrypt = true)
     {
         if ($encrypt) {
-            $value = encrypt($value);
+            $value = encrypt($value, $serialize = false);
         }
 
         if ($expiry instanceof DateTimeInterface) {


### PR DESCRIPTION
Starting in 5.6.30, "laravel/framework" no longer PHP serializes encrypted cookies by default. It can still be enabled in a "laravel/laravel" app `EncryptCookies` middleware.

This change allows Dusk to work in new Laravel projects out-of-the-box when "laravel/framework" is >= 5.6.33. In that version the `$unserialize` parameter was added to  `encrypt()` / `decrypt()` global helper functions called by Dusk.

Composer require-dev in "laravel/laravel" should be updated to suggest whatever "laravel/dusk" version this commit is tagged as.

## Backwards compatibility for encrypted serialized cookies >= 5.6.33

If projects on >= 5.6.33 still wish to support PHP serialized encrypted cookies, new methods can be added in the app's `tests/DuskTestCase.php` file (or even override the `InteractsWithCookies` methods):

```php
namespace Tests;

use Laravel\Dusk\TestCase as BaseTestCase;

abstract class DuskTestCase extends BaseTestCase
{
    use CreatesApplication;

    public function serializedCookie($name, $value = null, $expiry = null, array $options = [])
    {
        if ($value) {
            return $this->addSerializedCookie($name, $value, $expiry, $options);
        }

        if ($cookie = $this->driver->manage()->getCookieNamed($name)) {
            return decrypt(rawurldecode($cookie['value']));
        }
    }

    public function addSerializedCookie($name, $value, $expiry = null, array $options = [])
    {
        return $this->addCookie($name, encrypt($value), $expiry, $options, $encrypt = false);
    }
}
```

`InteractsWithCookies` trait methods already have a fair number of parameters so I didn't want to add another `$unserialize = false` boolean option.

 ```php
public function addCookie($name, $value, $expiry = null, array $options = [], $encrypt = true, $unserialize = false)
{
```

That would turn it into a somewhat gross non-expressive API.

## 4.0 Semantic versioning

I wasn't sure which branch to this base this on since AFAIK `master` is unstable and for when Laravel 5.7 is tagged. This should likely be tagged as breaking-change 4.0 before then.