### PR TITLE
Added 'move' to Browser to allow multiple browser windows to be positioned

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -6,6 +6,7 @@ use Closure;
 use BadMethodCallException;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Facebook\WebDriver\WebDriverPoint;
 use Facebook\WebDriver\WebDriverDimension;
 use Facebook\WebDriver\Remote\WebDriverBrowserType;
 
@@ -226,6 +227,22 @@ class Browser
     {
         $this->driver->manage()->window()->setSize(
             new WebDriverDimension($width, $height)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Move the browser window.
+     *
+     * @param  int  $x
+     * @param  int  $y
+     * @return $this
+     */
+    public function move($x, $y)
+    {
+        $this->driver->manage()->window()->setPosition(
+            new WebDriverPoint($x, $y)
         );
 
         return $this;


### PR DESCRIPTION
This can be used in conjunction with the `resize` method to both size and position the windows on screen. This is useful when doing automation which involves multiple windows.

Usage:
`$browser->resize(1024, 768)->move(200, 200);`