### PR TITLE
Update WaitsForElements.php

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -65,16 +65,17 @@ trait WaitsForElements
     /**
      * Wait for the given text to be visible.
      *
-     * @param  string  $text
+     * @param  array|string  $text
      * @param  int  $seconds
      * @return $this
      * @throws \Facebook\WebDriver\Exception\TimeOutException
      */
     public function waitForText($text, $seconds = null)
     {
+        $text = array_wrap($text);
         return $this->waitUsing($seconds, 100, function () use ($text) {
             return Str::contains($this->resolver->findOrFail('')->getText(), $text);
-        }, "Waited %s seconds for text [{$text}].");
+        }, "Waited %s seconds for text ['" . implode("', '", $text) . "'].");
     }
 
     /**


### PR DESCRIPTION
Allow the passing of an array or text since the underlying `Str:contains` call will take an array or string and will check for any of those text values. This allows a test to wait until any of the supplied text is visible.

Example w/ Multiples:
```
$browser->waitForText(['Success', 'Failure']);
```
Output:
```
Waited 5 seconds for text ['Success', 'Failure'].
```

Example w/ single:
```
$browser->waitForText('Success');
```
Output:
```
Waited 5 seconds for text ['Success'].
```