### PR TITLE
Disable auto-registering service provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,6 @@
     "extra": {
         "branch-alias": {
             "dev-master": "4.0-dev"
-        },
-        "laravel": {
-            "providers": [
-                "Laravel\\Dusk\\DuskServiceProvider"
-            ]
         }
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
Dusk took down a production app today (whoops page across entire site)

The problem:
- Dusk auto-registers its service provider
- Its service provider throws an exception of being registered in production

The solutions:
A) Go back to the old manual way (and revert the docs to pre 5.5)
B) Update DuskServiceProvider to not register the Dusk routes in production (not ideal IMO)

This PR is the laravel/dusk part of solution A. The other part is changing laravel/docs back to pre 5.5.

Also, currently, to use Dusk in a production app, you have to add it to "dont-discover" in composer.json - which is a bug if my thinking isn't off.

I can PR the reverted docs to all the version branches if you're up for it.