### PR TITLE
[4.0] add assertions for url scheme, host, and port

### DIFF
--- a/src/Concerns/MakesUrlAssertions.php
+++ b/src/Concerns/MakesUrlAssertions.php
@@ -44,13 +44,105 @@ trait MakesUrlAssertions
     {
         $pattern = str_replace('\*', '.*', preg_quote($scheme, '/'));
 
-        $segments = parse_url($this->driver->getCurrentURL());
-
-        $actualScheme = $segments['scheme'] ?? '';
+        $actual = parse_url($this->driver->getCurrentURL(), PHP_URL_SCHEME) ?? '';
 
         PHPUnit::assertRegExp(
-            '/^'.$pattern.'$/u', $actualScheme,
-            "Actual scheme [{$actualScheme}] does not equal expected scheme [{$pattern}]."
+            '/^'.$pattern.'$/u', $actual,
+            "Actual scheme [{$actual}] does not equal expected scheme [{$pattern}]."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the current scheme does not match the given scheme.
+     *
+     * @param  string  $scheme
+     * @return $this
+     */
+    public function assertSchemeIsNot($scheme)
+    {
+        $actual = parse_url($this->driver->getCurrentURL(), PHP_URL_SCHEME) ?? '';
+
+        PHPUnit::assertNotEquals(
+            $scheme, $actual,
+            "Scheme [{$scheme}] should not equal the actual value."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the current host matches the given host.
+     *
+     * @param  string  $host
+     * @return $this
+     */
+    public function assertHostIs($host)
+    {
+        $pattern = str_replace('\*', '.*', preg_quote($host, '/'));
+
+        $actual = parse_url($this->driver->getCurrentURL(), PHP_URL_HOST) ?? '';
+
+        PHPUnit::assertRegExp(
+            '/^'.$pattern.'$/u', $actual,
+            "Actual host [{$actual}] does not equal expected host [{$pattern}]."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the current host does not match the given host.
+     *
+     * @param  string  $host
+     * @return $this
+     */
+    public function assertHostIsNot($host)
+    {
+        $actual = parse_url($this->driver->getCurrentURL(), PHP_URL_HOST) ?? '';
+
+        PHPUnit::assertNotEquals(
+            $host, $actual,
+            "Host [{$host}] should not equal the actual value."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the current port matches the given port.
+     *
+     * @param  string  $port
+     * @return $this
+     */
+    public function assertPortIs($port)
+    {
+        $pattern = str_replace('\*', '.*', preg_quote($port, '/'));
+
+        $actual = parse_url($this->driver->getCurrentURL(), PHP_URL_PORT) ?? '';
+
+        PHPUnit::assertRegExp(
+            '/^'.$pattern.'$/u', $actual,
+            "Actual port [{$actual}] does not equal expected port [{$pattern}]."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the current host does not match the given host.
+     *
+     * @param  string  $port
+     * @return $this
+     */
+    public function assertPortIsNot($port)
+    {
+        $actual = parse_url($this->driver->getCurrentURL(), PHP_URL_PORT) ?? '';
+
+        PHPUnit::assertNotEquals(
+            $port, $actual,
+            "Port [{$port}] should not equal the actual value."
         );
 
         return $this;
@@ -64,11 +156,9 @@ trait MakesUrlAssertions
      */
     public function assertPathIs($path)
     {
-        $pattern = preg_quote($path, '/');
+        $pattern = str_replace('\*', '.*', preg_quote($path, '/'));
 
-        $pattern = str_replace('\*', '.*', $pattern);
-
-        $actualPath = parse_url($this->driver->getCurrentURL())['path'];
+        $actualPath = parse_url($this->driver->getCurrentURL(), PHP_URL_PATH) ?? '';
 
         PHPUnit::assertRegExp(
             '/^'.$pattern.'$/u', $actualPath,
@@ -86,7 +176,7 @@ trait MakesUrlAssertions
      */
     public function assertPathBeginsWith($path)
     {
-        $actualPath = parse_url($this->driver->getCurrentURL())['path'];
+        $actualPath = parse_url($this->driver->getCurrentURL(), PHP_URL_PATH) ?? '';
 
         PHPUnit::assertStringStartsWith(
             $path, $actualPath,
@@ -104,7 +194,7 @@ trait MakesUrlAssertions
      */
     public function assertPathIsNot($path)
     {
-        $actualPath = parse_url($this->driver->getCurrentURL())['path'];
+        $actualPath = parse_url($this->driver->getCurrentURL(), PHP_URL_PATH) ?? '';
 
         PHPUnit::assertNotEquals(
             $path, $actualPath,

--- a/tests/MakesUrlAssertionsTest.php
+++ b/tests/MakesUrlAssertionsTest.php
@@ -58,6 +58,134 @@ class MakesUrlAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_scheme_is_not()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('getCurrentURL')->andReturn(
+            'http://www.google.com/test'.
+            'https://www.google.com/test',
+            'https://www.google.com/test'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertSchemeIsNot('https');
+        $browser->assertSchemeIsNot('http');
+
+        try {
+            $browser->assertSchemeIsNot('https');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Scheme [https] should not equal the actual value.',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_host_is()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('getCurrentURL')->once()->andReturn(
+            'http://www.google.com?foo=bar',
+            'http://google.com?foo=bar',
+            'https://www.laravel.com:80/test?foo=bar',
+            'https://www.laravel.com'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertHostIs('www.google.com');
+        $browser->assertHostIs('google.com');
+        $browser->assertHostIs('www.laravel.com');
+
+        try {
+            $browser->assertHostIs('testing.com');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Actual host [www.laravel.com] does not equal expected host [testing\.com].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_host_is_not()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('getCurrentURL')->andReturn(
+            'http://www.google.com/test',
+            'https://www.laravel.com/test',
+            'https://laravel.com/test',
+            'https://laravel.com/test'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertHostIsNot('laravel.com');
+        $browser->assertHostIsNot('laravel.com');
+        $browser->assertHostIsNot('www.laravel.com');
+
+        try {
+            $browser->assertHostIsNot('laravel.com');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Host [laravel.com] should not equal the actual value.',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_port_is()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('getCurrentURL')->once()->andReturn(
+            'http://www.laravel.com:80/test?foo=bar',
+            'https://www.laravel.com:443/test?foo=bar',
+            'https://www.laravel.com',
+            'https://www.laravel.com:22'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertPortIs('80');
+        $browser->assertPortIs('443');
+        $browser->assertPortIs('');
+
+        try {
+            $browser->assertPortIs('21');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Actual port [22] does not equal expected port [21].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_port_is_not()
+    {
+        $driver = Mockery::mock(StdClass::class);
+        $driver->shouldReceive('getCurrentURL')->andReturn(
+            'http://www.laravel.com:80/test?foo=bar',
+            'https://www.laravel.com:443/test?foo=bar',
+            'https://www.laravel.com',
+            'https://www.laravel.com:22'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertPortIsNot('443');
+        $browser->assertPortIsNot('80');
+        $browser->assertPortIsNot('22');
+
+        try {
+            $browser->assertPortIsNot('22');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Port [22] should not equal the actual value.',
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_path_is()
     {
         $driver = Mockery::mock(StdClass::class);


### PR DESCRIPTION
- add new method `assertSchemeIsNot()` to assert the scheme portion of a URL is not a specific value
- add new method `assertHostIs()` to assert the host portion of a URL is a specific value
- add new method `assertHostIsNot()` to assert the host portion of a URL is not a specific value
- add new method `assertPortIs()` to assert the port portion of a URL is a specific value
- add new method `assertPortIsNot()` to assert the port portion of a URL is not a specific value
- add tests for all new methods
- when using the `parse_url` function, pass through the 'component' parameter, rather than accessing via an array key. this allows us to use constants, and not unnecessarily retrieve info we don't need.  On seriously malformed URLs, `parse_url` can return `FALSE`, and if a requested component doesn't exist within the given URL, `null` will be returned.  Therefore we also normalize everything using the null coalesce operator.
- some code cleanup for consistency, and removing some temporary variables.