### PR TITLE
[4.0] update dusk test case stub

### DIFF
--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -31,7 +31,8 @@ abstract class DuskTestCase extends BaseTestCase
     {
         $options = (new ChromeOptions)->addArguments([
             '--disable-gpu',
-            '--headless'
+            '--headless',
+            '--window-size=1920,1080',
         ]);
 
         return RemoteWebDriver::create(


### PR DESCRIPTION
I don't know about other people, but I often run into inconsistent results when I run tests in headless vs non-headless mode.  Usually it's because some element is not visible or clickable, and it is usually solved by manually resizing the browser.

This PR updates the stub base dusk test to explicitly set a sensible default browser size, rather than relying on the whim of chromedriver to create whatever size it likes.  Users can easily adjust their base size or remove it completely, and can still override the size in individual tests with the `resize()` method.

I considered using `--start-maximized`, but there are lots of issues across the internet about problems with maximizing the browser not working, depending on what version of chromedriver you're using.

Since this is merely a **stub** and not an actual file, I think we are safe sending it to the current **major** version, as existing users will not be affected, unless they rerun `php artisan dusk:install` (and maybe not even then, not sure if we overwrite or not).