### PR TITLE
[4.0] ProvidesBrowser createBrowsersFor wrong browser count

### DIFF
--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -93,7 +93,6 @@ trait ProvidesBrowser
             static::$browsers[] = $this->newBrowser($this->createWebDriver());
         }
 
-
         return static::$browsers;
     }
 

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -93,6 +93,7 @@ trait ProvidesBrowser
             static::$browsers[] = $this->newBrowser($this->createWebDriver());
         }
 
+
         return static::$browsers;
     }
 

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -92,6 +92,7 @@ trait ProvidesBrowser
         for ($i = count(static::$browsers); $i < $this->browsersNeededFor($callback); $i++) {
             static::$browsers[] = $this->newBrowser($this->createWebDriver());
         }
+
         return static::$browsers;
     }
 

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -89,7 +89,8 @@ trait ProvidesBrowser
      */
     protected function createBrowsersFor(Closure $callback)
     {
-        for ($i = count(static::$browsers); $i < $this->browsersNeededFor($callback); $i++) {
+        $browsersNeeded = $this->browsersNeededFor($callback);
+        for ($i = count(static::$browsers); $i < $browsersNeeded; $i++) {
             static::$browsers[] = $this->newBrowser($this->createWebDriver());
         }
 

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -92,7 +92,6 @@ trait ProvidesBrowser
         for ($i = count(static::$browsers); $i < $this->browsersNeededFor($callback); $i++) {
             static::$browsers[] = $this->newBrowser($this->createWebDriver());
         }
-
         return static::$browsers;
     }
 

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -89,14 +89,8 @@ trait ProvidesBrowser
      */
     protected function createBrowsersFor(Closure $callback)
     {
-        if (count(static::$browsers) === 0) {
-            static::$browsers = collect([$this->newBrowser($this->createWebDriver())]);
-        }
-
-        $additional = $this->browsersNeededFor($callback) - 1;
-
-        for ($i = 0; $i < $additional; $i++) {
-            static::$browsers->push($this->newBrowser($this->createWebDriver()));
+        for ($i = count(static::$browsers); $i < $this->browsersNeededFor($callback); $i++) {
+            static::$browsers[] = $this->newBrowser($this->createWebDriver());
         }
 
         return static::$browsers;


### PR DESCRIPTION
continue pull request https://github.com/laravel/dusk/pull/573
Laravel dusk open more browser windows as needed in function createBrowsersFor.
This code will open 3 browser windows instead of 2
```
<?php

namespace Tests\Browser;

use Tests\DuskTestCase;
use Laravel\Dusk\Browser;
use Illuminate\Foundation\Testing\DatabaseMigrations;

class ExampleTest extends DuskTestCase
{
    protected function setUp()
    {
        parent::setUp();
        self::$browsers = collect([new Browser($this->driver()), new Browser($this->driver())]);
       // loginAs (admin,client, ...) / visit some page for any browser
    }

    public function testExample()
    {
        $this->browse(function (Browser $browser1, Browser $browser2) {
            $browser1->tinker();
        });
    }
}