### PR TITLE
[4.0] Check directories before purging files

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -106,8 +106,14 @@ class DuskCommand extends Command
      */
     protected function purgeScreenshots()
     {
+        $path = base_path('tests/Browser/screenshots');
+
+        if (! is_dir($path)) {
+            return;
+        }
+
         $files = Finder::create()->files()
-                        ->in(base_path('tests/Browser/screenshots'))
+                        ->in($path)
                         ->name('failure-*');
 
         foreach ($files as $file) {
@@ -122,8 +128,14 @@ class DuskCommand extends Command
      */
     protected function purgeConsoleLogs()
     {
+        $path = base_path('tests/Browser/console');
+
+        if (! is_dir($path)) {
+            return;
+        }
+
         $files = Finder::create()->files()
-            ->in(base_path('tests/Browser/console'))
+            ->in($path)
             ->name('*.log');
 
         foreach ($files as $file) {


### PR DESCRIPTION
Dusk allows users to change the location of the `console` and `screenshots` directories by overriding `Browser::$storeConsoleLogAt` and `Browser::$storeScreenshotsAt` in their tests.

Before `php artisan dusk` executes the tests, it removes existing log files and screenshots from the default directories in `tests/Browser`. There is no way to purge the alternative directories because Dusk can't know about them at this point of the execution.

But when users want to remove the default directories completely (e.g. to make `tests/Browser` PSR-4 compliant [#393]), Dusk fails because it expects the directories to exist.

This PR adds an `is_dir()` check to fix this issue.