### PR TITLE
[4.0] Fix TimeOutException sprintf() error

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -37,9 +37,11 @@ trait WaitsForElements
      */
     public function waitFor($selector, $seconds = null)
     {
+        $message = $this->formatTimeOutMessage('Waited %s seconds for selector', $selector);
+
         return $this->waitUsing($seconds, 100, function () use ($selector) {
             return $this->resolver->findOrFail($selector)->isDisplayed();
-        }, "Waited %s seconds for selector [{$selector}].");
+        }, $message);
     }
 
     /**
@@ -52,6 +54,8 @@ trait WaitsForElements
      */
     public function waitUntilMissing($selector, $seconds = null)
     {
+        $message = $this->formatTimeOutMessage('Waited %s seconds for removal of selector', $selector);
+
         return $this->waitUsing($seconds, 100, function () use ($selector) {
             try {
                 $missing = ! $this->resolver->findOrFail($selector)->isDisplayed();
@@ -60,7 +64,7 @@ trait WaitsForElements
             }
 
             return $missing;
-        }, "Waited %s seconds for removal of selector [{$selector}].");
+        }, $message);
     }
 
     /**
@@ -75,9 +79,11 @@ trait WaitsForElements
     {
         $text = Arr::wrap($text);
 
+        $message = $this->formatTimeOutMessage('Waited %s seconds for text', implode("', '", $text));
+
         return $this->waitUsing($seconds, 100, function () use ($text) {
             return Str::contains($this->resolver->findOrFail('')->getText(), $text);
-        }, "Waited %s seconds for text ['".implode("', '", $text)."'].");
+        }, $message);
     }
 
     /**
@@ -90,9 +96,11 @@ trait WaitsForElements
      */
     public function waitForLink($link, $seconds = null)
     {
+        $message = $this->formatTimeOutMessage('Waited %s seconds for link', $link);
+
         return $this->waitUsing($seconds, 100, function () use ($link) {
             return $this->seeLink($link);
-        }, "Waited %s seconds for link [{$link}].");
+        }, $message);
     }
 
     /**
@@ -105,7 +113,9 @@ trait WaitsForElements
      */
     public function waitForLocation($path, $seconds = null)
     {
-        return $this->waitUntil("window.location.pathname == '{$path}'", $seconds, "Waited %s seconds for location [{$path}].");
+        $message = $this->formatTimeOutMessage('Waited %s seconds for location', $path);
+
+        return $this->waitUntil("window.location.pathname == '{$path}'", $seconds, $message);
     }
 
     /**
@@ -224,5 +234,17 @@ trait WaitsForElements
         }
 
         return $this;
+    }
+
+    /**
+     * Prepare custom TimeOutException message for sprintf().
+     *
+     * @param  string  $message
+     * @param  string  $expected
+     * @return string
+     */
+    protected function formatTimeOutMessage($message, $expected)
+    {
+        return $message.' [' .str_replace('%', '%%', $expected).'].';
     }
 }

--- a/tests/WaitsForElementsTest.php
+++ b/tests/WaitsForElementsTest.php
@@ -80,4 +80,31 @@ class WaitsForElementsTest extends TestCase
 
         $browser->waitForRoute('home');
     }
+
+    public function test_can_wait_for_text()
+    {
+        $element = Mockery::mock(StdClass::class);
+        $element->shouldReceive('getText')->andReturn('Discount: 20%');
+        $resolver = Mockery::mock(StdClass::class);
+        $resolver->shouldReceive('findOrFail')->with('')->andReturn($element);
+        $browser = new Browser(new StdClass, $resolver);
+
+        $browser->waitForText('Discount: 20%');
+    }
+
+    public function test_wait_for_text_failure_message_containing_a_percent_character()
+    {
+        $element = Mockery::mock(StdClass::class);
+        $element->shouldReceive('getText')->andReturn('Discount: None');
+        $resolver = Mockery::mock(StdClass::class);
+        $resolver->shouldReceive('findOrFail')->with('')->andReturn($element);
+        $browser = new Browser(new StdClass, $resolver);
+
+        try {
+            $browser->waitForText('Discount: 20%', 1);
+            $this->fail('waitForText() did not timeout.');
+        } catch (TimeOutException $e) {
+            $this->assertEquals('Waited 1 seconds for text [Discount: 20%].', $e->getMessage());
+        }
+    }
 }


### PR DESCRIPTION
When asserting:

```php
$browser->waitForText('Discount: 20%');
```

If this fails on a timeout, instead of Dusk feedback:

> `Facebook\WebDriver\Exception\TimeOutException: Waited 5 seconds for text [Discount: 20%].`

You'll see:

> `sprintf(): Too few arguments`

This is because the expected string is passed into `sprintf()` for `TimeOutException` so we'll have to escape `'%'` characters mistaken as placeholders.

This affects the `wait*()` methods that assert selectors, URLs, and text.