### PR TITLE
[4.0] Fix assertQueryStringHas method when the query parameters contain an array.

### DIFF
--- a/src/Concerns/MakesUrlAssertions.php
+++ b/src/Concerns/MakesUrlAssertions.php
@@ -287,9 +287,12 @@ trait MakesUrlAssertions
             return $this;
         }
 
+        $strOutputName = is_array($output[$name]) ? join(',', $output[$name]) : $output[$name];
+        $strValue = is_array($value) ? join(',', $value) : $value;
+
         PHPUnit::assertEquals(
             $value, $output[$name],
-            "Query string parameter [{$name}] had value [{$output[$name]}], but expected [{$value}]."
+            "Query string parameter [{$name}] had value [{$strOutputName}], but expected [{$strValue}]."
         );
 
         return $this;

--- a/tests/MakesUrlAssertionsTest.php
+++ b/tests/MakesUrlAssertionsTest.php
@@ -400,6 +400,27 @@ class MakesUrlAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_query_string_has_name_array_value()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('getCurrentURL')->andReturn(
+            'http://www.google.com/?foo[]=bar&foo[]=buzz'
+        );
+        $browser = new Browser($driver);
+
+        $browser->assertQueryStringHas('foo', ['bar', 'buzz']);
+
+        try {
+            $browser->assertQueryStringHas('foo', '');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                'Query string parameter [foo] had value [bar,buzz], but expected [].',
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_query_string_missing()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
When using assertQueryStringHas to test the presence of an array-like value in the query string, dusk was crashing by trying to convert an array to a string. This PR resolves that.