### PR TITLE
Fixes Support invocation of dusk testcases through phpdbg #530

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -81,6 +81,10 @@ class DuskCommand extends Command
      */
     protected function binary()
     {
+        if ('phpdbg' === \PHP_SAPI) {
+            return [PHP_BINARY, '-qrr', 'vendor/phpunit/phpunit/phpunit' ];
+        }
+
         return [PHP_BINARY, 'vendor/phpunit/phpunit/phpunit'];
     }
 


### PR DESCRIPTION
I have checked how php unit and symphony process handles phpdbg and it looks like hard coding -qrr option as they do is simplest solution. Initially I had thought about generalizing PHP_OPTIONS somehow but php doesn't provide nice way to determine arguments sent to php/phpdbg command itself (and not the script). Other alternative is to rely on environment variables which doesn't look nice either.