### PR TITLE
[4.0] Fixes Support invocation of dusk testcases through phpdbg #530

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -81,6 +81,10 @@ class DuskCommand extends Command
      */
     protected function binary()
     {
+        if ('phpdbg' === \PHP_SAPI) {
+            return [PHP_BINARY, '-qrr', 'vendor/phpunit/phpunit/phpunit' ];
+        }
+
         return [PHP_BINARY, 'vendor/phpunit/phpunit/phpunit'];
     }
 


### PR DESCRIPTION
This is an enhancement to support invoking dusk via phpdbg #530 :

Before, dusk entered interactive prompt as it did not pass '-qrr' options:

```
$ phpdbg -qrr artisan dusk
[Welcome to phpdbg, the interactive PHP debugger, v0.5.0]
To get help using phpdbg type "help" and press enter
[Please report bugs to <http://bugs.php.net/report.php>]
[Successful compilation of /Users/shiva/Sandbox/sites/play/vendor/phpunit/phpunit/phpunit]
prompt> run
PHPUnit 7.2.6 by Sebastian Bergmann and contributors.



Time: 24 ms, Memory: 6.00MB

No tests executed!
[Script ended normally]
prompt>
```

After:

```
 $ phpdbg -qrr artisan dusk
PHPUnit 7.5.2 by Sebastian Bergmann and contributors.



Time: 48 ms, Memory: 6.02MB

No tests executed!

```

While deciding on the exact change that needs to be done I have checked how PHPUnit and Symphony `Process` handles phpdbg and it looks like hard coding -qrr option as they do is simplest solution. Initially I had thought about generalizing PHP_OPTIONS somehow but php doesn't provide nice way to determine arguments sent to php/phpdbg command itself (and not the script). Other alternative is to rely on environment variables which doesn't look nice either. Let me know if any improvement is needed.