### PR TITLE
[5.0] Use custom DISPLAY variable when set on Linux

### DIFF
--- a/src/Chrome/ChromeProcess.php
+++ b/src/Chrome/ChromeProcess.php
@@ -79,7 +79,7 @@ class ChromeProcess
             return [];
         }
 
-        return ['DISPLAY' => ':0'];
+        return ['DISPLAY' => env('DISPLAY', ':0')];
     }
 
     /**

--- a/src/Chrome/ChromeProcess.php
+++ b/src/Chrome/ChromeProcess.php
@@ -79,7 +79,7 @@ class ChromeProcess
             return [];
         }
 
-        return ['DISPLAY' => env('DISPLAY', ':0')];
+        return ['DISPLAY' => getenv('DISPLAY') ?: ':0'];
     }
 
     /**


### PR DESCRIPTION
Use case: running Dusk on a server environment and using X11 forwarding via SSH to take a peek in the browser running the actions. This is particularity useful in combination with the https://github.com/nunomaduro/laravel-console-dusk package.

We automate specific browser actions on the server side and it's handy to see why it's failing on the server (for instance, we ran into issues because the user agent of the headless browser was different).

Am not aware of any side effects but happy to hear some thoughts about this.