### PR TITLE
[5.0] Fix cookies with falsey values

### DIFF
--- a/src/Concerns/InteractsWithCookies.php
+++ b/src/Concerns/InteractsWithCookies.php
@@ -17,7 +17,7 @@ trait InteractsWithCookies
      */
     public function cookie($name, $value = null, $expiry = null, array $options = [])
     {
-        if ($value) {
+        if (! is_null($value)) {
             return $this->addCookie($name, $value, $expiry, $options);
         }
 
@@ -37,7 +37,7 @@ trait InteractsWithCookies
      */
     public function plainCookie($name, $value = null, $expiry = null, array $options = [])
     {
-        if ($value) {
+        if (! is_null($value)) {
             return $this->addCookie($name, $value, $expiry, $options, false);
         }
 


### PR DESCRIPTION
The loose comparison doesn't work with falsey values like `0` or `''`:

```php
$browser->cookie('foo', 0); // Gets the cookie instead of setting it.
```