### PR TITLE
[5.0] Fix with() and page assertions

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -167,6 +167,21 @@ class Browser
      */
     public function on($page)
     {
+        $this->onWithoutAssert($page);
+
+        $page->assert($this);
+
+        return $this;
+    }
+
+    /**
+     * Set the current page object without executing the assertions.
+     *
+     * @param  mixed  $page
+     * @return $this
+     */
+    public function onWithoutAssert($page)
+    {
         $this->page = $page;
 
         // Here we will set the page elements on the resolver instance, which will allow
@@ -175,8 +190,6 @@ class Browser
         $this->resolver->pageElements(array_merge(
             $page::siteElements(), $page->elements()
         ));
-
-        $page->assert($this);
 
         return $this;
     }
@@ -330,7 +343,7 @@ class Browser
         );
 
         if ($this->page) {
-            $browser->on($this->page);
+            $browser->onWithoutAssert($this->page);
         }
 
         if ($selector instanceof Component) {

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -82,10 +82,13 @@ class BrowserTest extends TestCase
 
         $browser->visit($page = new BrowserTestPage);
 
+        $page->asserted = false;
+
         $browser->with('prefix', function ($browser) use ($page) {
             $this->assertInstanceof(Browser::class, $browser);
             $this->assertEquals('body prefix', $browser->resolver->prefix);
             $this->assertEquals($page, $browser->page);
+            $this->assertFalse($page->asserted);
         });
     }
 
@@ -109,10 +112,13 @@ class BrowserTest extends TestCase
 
         $browser->visit($page = new BrowserTestPage);
 
+        $page->asserted = false;
+
         $browser->within('prefix', function ($browser) use ($page) {
             $this->assertInstanceof(Browser::class, $browser);
             $this->assertEquals('body prefix', $browser->resolver->prefix);
             $this->assertEquals($page, $browser->page);
+            $this->assertFalse($page->asserted);
         });
     }
 


### PR DESCRIPTION
Using `with()` in combination with a page can break tests:

```php
class TestPage extends Page
{
    public function assert(Browser $browser)
    {
        $browser->assertSee('Page Title');
    }
}

$this->browse(function (Browser $browser) {
    $browser->visit(new TestPage)
        ->with('.prefix', function (Browser $browser) {
            // 
        });
});
```

Dusk executes the page's assertions in `visit()` *and* in `with()`, but the latter one doesn't always work. In this example, the page title is not available inside the `.prefix` scope.

`on()` should only execute the assertions when being called directly or from `visit()`, but not when being called from `with()`.

Fixes #618.

---

A more elegant but breaking refactoring for Dusk 6.0 could look like this:

```php
public function on($page, $assert = true)
{
    $this->page = $page;

    // Here we will set the page elements on the resolver instance, which will allow
    // the developer to access short-cuts for CSS selectors on the page which can
    // allow for more expressive navigation and interaction with all the pages.
    $this->resolver->pageElements(array_merge(
        $page::siteElements(), $page->elements()
    ));

    if ($assert) {
        $page->assert($this);
    }

    return $this;
}

public function onWithoutAssert($page)
{
    return $this->on($page, false);
}
```