### PR TITLE
[5.0] Fix assertVueContains

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -737,9 +737,10 @@ JS;
      */
     public function assertVueContains($key, $value, $componentSelector = null)
     {
-        PHPUnit::assertTrue(
-            Str::contains($this->vueAttribute($componentSelector, $key), $value)
-        );
+        $attribute = $this->vueAttribute($componentSelector, $key);
+
+        PHPUnit::assertIsArray($attribute, "The attribute for key [$key] is not an array.");
+        PHPUnit::assertContains($value, $attribute);
 
         return $this;
     }
@@ -755,9 +756,10 @@ JS;
      */
     public function assertVueDoesNotContain($key, $value, $componentSelector = null)
     {
-        PHPUnit::assertFalse(
-            Str::contains($this->vueAttribute($componentSelector, $key), $value)
-        );
+        $attribute = $this->vueAttribute($componentSelector, $key);
+
+        PHPUnit::assertIsArray($attribute, "The attribute for key [$key] is not an array.");
+        PHPUnit::assertNotContains($value, $attribute);
 
         return $this;
     }

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -198,4 +198,48 @@ class MakesAssertionsTest extends TestCase
             );
         }
     }
+
+    public function test_assert_vue_contains()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('executeScript')->andReturn(['john']);
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('@vue-component')->andReturn('body foo');
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertVueContains('users', 'john', '@vue-component');
+
+        try {
+            $browser->assertVueDoesNotContain('users', 'john', '@vue-component');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                "Failed asserting that an array does not contain 'john'.",
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_vue_contains_with_no_result()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('executeScript')->andReturn(null);
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('@vue-component')->andReturn('body foo');
+
+        $browser = new Browser($driver, $resolver);
+
+        try {
+            $browser->assertVueContains('users', 'john', '@vue-component');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'The attribute for key [users] is not an array.',
+                $e->getMessage()
+            );
+        }
+    }
 }


### PR DESCRIPTION
This fixes the assertVueContains and assertVueDoesNotContain methods to properly check for an array and what it contains instead of checking for a string. This got broken in https://github.com/laravel/dusk/commit/1985616f82b702f29f9a302657e6bf3f65c5e8de

Fixes https://github.com/laravel/dusk/issues/637
