### PR TITLE
[5.0] Implement ChromeDriverCommand

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) Taylor Otwell
+Copyright (c) Jonas Staudenmeir
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
     ],
     "require": {
         "php": ">=7.1.0",
+        "ext-json": "*",
+        "ext-zip": "*",
         "facebook/webdriver": "^1.3",
         "nesbot/carbon": "^1.20|^2.0",
         "illuminate/console": "~5.7.0|~5.8.0|~5.9.0",

--- a/src/Chrome/ChromeProcess.php
+++ b/src/Chrome/ChromeProcess.php
@@ -3,7 +3,7 @@
 namespace Laravel\Dusk\Chrome;
 
 use RuntimeException;
-use Illuminate\Support\Str;
+use Laravel\Dusk\OperatingSystem;
 use Symfony\Component\Process\Process;
 
 class ChromeProcess
@@ -87,7 +87,7 @@ class ChromeProcess
      */
     protected function onWindows()
     {
-        return PHP_OS === 'WINNT' || Str::contains(php_uname(), 'Microsoft');
+        return OperatingSystem::onWindows();
     }
 
     /**
@@ -97,6 +97,6 @@ class ChromeProcess
      */
     protected function onMac()
     {
-        return PHP_OS === 'Darwin';
+        return OperatingSystem::onMac();
     }
 }

--- a/src/Chrome/ChromeProcess.php
+++ b/src/Chrome/ChromeProcess.php
@@ -44,13 +44,11 @@ class ChromeProcess
 
         if ($this->onWindows()) {
             $this->driver = realpath(__DIR__.'/../../bin/chromedriver-win.exe');
-
-            return $this->process($arguments);
+        } elseif ($this->onMac()) {
+            $this->driver = realpath(__DIR__.'/../../bin/chromedriver-mac');
+        } else {
+            $this->driver = realpath(__DIR__.'/../../bin/chromedriver-linux');
         }
-
-        $this->driver = $this->onMac()
-                        ? realpath(__DIR__.'/../../bin/chromedriver-mac')
-                        : realpath(__DIR__.'/../../bin/chromedriver-linux');
 
         return $this->process($arguments);
     }

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Laravel\Dusk\Console;
+
+use ZipArchive;
+use Illuminate\Console\Command;
+use Laravel\Dusk\OperatingSystem;
+
+class ChromeDriverCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dusk:chrome-driver {version?} {--all : Install a ChromeDriver binary for every OS}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Install the ChromeDriver binary';
+
+    /**
+     * URL to the index page.
+     *
+     * @var string
+     */
+    protected $indexUrl = 'https://chromedriver.storage.googleapis.com';
+
+    /**
+     * URL to the latest release version.
+     *
+     * @var string
+     */
+    protected $versionUrl = 'https://chromedriver.storage.googleapis.com/LATEST_RELEASE_%d';
+
+    /**
+     * URL to the ChromeDriver download.
+     *
+     * @var string
+     */
+    protected $downloadUrl = 'https://chromedriver.storage.googleapis.com/%s/chromedriver_%s.zip';
+
+    /**
+     * Download slugs for the available operating systems.
+     *
+     * @var array
+     */
+    protected $slugs = [
+        'linux' => 'linux64',
+        'mac' => 'mac64',
+        'win' => 'win32',
+    ];
+
+    /**
+     * The legacy versions for the ChromeDriver.
+     *
+     * @var array
+     */
+    protected $legacyVersions = [
+        43 => '2.20',
+        44 => '2.20',
+        45 => '2.20',
+        46 => '2.21',
+        47 => '2.21',
+        48 => '2.21',
+        49 => '2.22',
+        50 => '2.22',
+        51 => '2.23',
+        52 => '2.24',
+        53 => '2.26',
+        54 => '2.27',
+        55 => '2.28',
+        56 => '2.29',
+        57 => '2.29',
+        58 => '2.31',
+        59 => '2.32',
+        60 => '2.33',
+        61 => '2.34',
+        62 => '2.35',
+        63 => '2.36',
+        64 => '2.37',
+        65 => '2.38',
+        66 => '2.40',
+        67 => '2.41',
+        68 => '2.42',
+        69 => '2.44',
+    ];
+
+    /**
+     * Path to the bin directory.
+     *
+     * @var string
+     */
+    protected $directory = __DIR__.'/../../bin/';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $version = $this->version();
+        $all = $this->option('all');
+        $currentOS = OperatingSystem::id();
+
+        foreach ($this->slugs as $os => $slug) {
+            if ($all || ($os === $currentOS)) {
+                $archive = $this->download($version, $slug);
+
+                $binary = $this->extract($archive);
+
+                $this->rename($binary, $os);
+            }
+        }
+
+        $message = 'ChromeDriver %s successfully installed for version %s.';
+
+        $this->info(sprintf($message, $all ? 'binaries' : 'binary', $version));
+    }
+
+    /**
+     * Get the desired ChromeDriver version.
+     *
+     * @return string
+     */
+    protected function version()
+    {
+        $version = $this->argument('version');
+
+        if ($version) {
+            if (! ctype_digit($version)) {
+                return $version;
+            }
+
+            $version = (int) $version;
+
+            if ($version < 70) {
+                return $this->legacyVersions[$version];
+            }
+        } else {
+            $version = $this->latestChromeVersion();
+        }
+
+        $url = sprintf($this->versionUrl, $version);
+
+        return trim(file_get_contents($url));
+    }
+
+    /**
+     * Get the latest major Chrome version.
+     *
+     * @return int
+     */
+    protected function latestChromeVersion()
+    {
+        $index = file_get_contents($this->indexUrl);
+
+        preg_match('#.*<Key>LATEST_RELEASE_(\d+)</Key>#', $index, $matches);
+
+        return (int) $matches[1];
+    }
+
+    /**
+     * Download the ChromeDriver archive.
+     *
+     * @param  string  $version
+     * @param  string  $slug
+     * @return string
+     */
+    protected function download($version, $slug)
+    {
+        $archive = $this->directory.'chromedriver.zip';
+        $url = sprintf($this->downloadUrl, $version, $slug);
+
+        file_put_contents($archive, fopen($url, 'r'));
+
+        return $archive;
+    }
+
+    /**
+     * Extract the ChromeDriver binary from the archive and delete the archive.
+     *
+     * @param  string  $archive
+     * @return string
+     */
+    protected function extract($archive)
+    {
+        $zip = new ZipArchive;
+        $zip->open($archive);
+        $zip->extractTo($this->directory);
+
+        $binary = $zip->getNameIndex(0);
+
+        $zip->close();
+
+        unlink($archive);
+
+        return $binary;
+    }
+
+    /**
+     * Rename the ChromeDriver binary and make it executable.
+     *
+     * @param  string  $binary
+     * @param  string  $os
+     * @return void
+     */
+    protected function rename($binary, $os)
+    {
+        $newName = str_replace('chromedriver', 'chromedriver-'.$os, $binary);
+
+        rename($this->directory.$binary, $this->directory.$newName);
+
+        chmod($this->directory.$newName, 0755);
+    }
+}

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -21,16 +21,6 @@ class InstallCommand extends Command
     protected $description = 'Install Dusk into the application';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -57,6 +57,10 @@ class InstallCommand extends Command
         }
 
         $this->info('Dusk scaffolding installed successfully.');
+
+        $this->info('Installing ChromeDriver binaries...');
+
+        $this->call('dusk:chrome-driver', ['--all']);
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -60,7 +60,7 @@ class InstallCommand extends Command
 
         $this->info('Installing ChromeDriver binaries...');
 
-        $this->call('dusk:chrome-driver', ['--all']);
+        $this->call('dusk:chrome-driver', ['--all' => true]);
     }
 
     /**

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -35,7 +35,7 @@ class DuskServiceProvider extends ServiceProvider
      * Register any package services.
      *
      * @return void
-     * @throws Exception
+     * @throws \Exception
      */
     public function register()
     {
@@ -51,6 +51,7 @@ class DuskServiceProvider extends ServiceProvider
                 Console\MakeCommand::class,
                 Console\PageCommand::class,
                 Console\ComponentCommand::class,
+                Console\ChromeDriverCommand::class,
             ]);
         }
     }

--- a/src/OperatingSystem.php
+++ b/src/OperatingSystem.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Laravel\Dusk;
+
+use Illuminate\Support\Str;
+
+class OperatingSystem
+{
+    /**
+     * Returns the current OS identifier.
+     *
+     * @return string
+     */
+    public static function id()
+    {
+        return static::onWindows() ? 'win' : (static::onMac() ? 'mac' : 'linux');
+    }
+
+    /**
+     * Determine if the operating system is Windows or Windows Subsystem for Linux.
+     *
+     * @return bool
+     */
+    public static function onWindows()
+    {
+        return PHP_OS === 'WINNT' || Str::contains(php_uname(), 'Microsoft');
+    }
+
+    /**
+     * Determine if the operating system is macOS.
+     *
+     * @return bool
+     */
+    public static function onMac()
+    {
+        return PHP_OS === 'Darwin';
+    }
+}


### PR DESCRIPTION
This PR implements the functionality offered by https://github.com/staudenmeir/dusk-updater which was written by @staudenmeir.

This command will allow users to update their chrome driver for their OS. It has a flag that will also allow users to update every binary if they want. I've added this to the install command so the driver is updated whenever the install command is run. This means we don't have to update the docs.

I wrote this as an install command so we can remove the binaries in a future version of Dusk and always have them installed with this command. This will save having them to be packaged with the repo. ~It's also written in such a way that it only installs the binary for the current OS.~

Fixes https://github.com/laravel/dusk/issues/641