### PR TITLE
added support for attaching multiple files into input type file with …

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Dusk\Concerns;
 
+use Exception;
 use Illuminate\Support\Str;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverKeys;
@@ -261,6 +262,30 @@ trait InteractsWithElements
         $element = $this->resolver->resolveForAttachment($field);
 
         $element->setFileDetector(new LocalFileDetector)->sendKeys($path);
+
+        return $this;
+    }
+
+    /**
+     * Attach the given files into to the field.
+     *
+     * @param  string  $field
+     * @param  array  $paths
+     * @return $this
+     */
+    public function attachMultiple($field, array $paths = [])
+    {
+        $element = $this->resolver->resolveForAttachment($field);
+
+        $files = array_map(function($local_file){
+            if (!is_file($local_file) || !file_exists($local_file)) {
+                throw new Exception('You may only upload existing files: ' . $local_file);
+            }
+
+            return realpath($local_file);
+        }, $paths);
+
+        $element->sendKeys(implode("\n ", $files));
 
         return $this;
     }


### PR DESCRIPTION
Hello,

Currently is supported attaching only one file into input type file. Multiple file inputs are not supported.

I added support for attaching files into input type file with multiple attribute.

$browser->attachMultiple('my-input[]', ['file1.jpg', 'file2.jpg']);

Thanks

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
