### PR TITLE
[5.0] add option to fullsize the browser

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -256,7 +256,7 @@ class Browser
     {
         $body = $this->driver->findElement(WebDriverBy::tagName('body'));
 
-        if (!empty($body)) {
+        if (! empty($body)) {
             $this->resize($body->getSize()->getWidth(), $body->getSize()->getHeight());
         }
 

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -5,6 +5,7 @@ namespace Laravel\Dusk;
 use Closure;
 use BadMethodCallException;
 use Illuminate\Support\Str;
+use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverPoint;
 use Illuminate\Support\Traits\Macroable;
 use Facebook\WebDriver\WebDriverDimension;
@@ -242,6 +243,22 @@ class Browser
         $this->driver->manage()->window()->setSize(
             new WebDriverDimension($width, $height)
         );
+
+        return $this;
+    }
+
+    /**
+     * Make the browser window as large as the content.
+     *
+     * @return $this
+     */
+    public function fullsize()
+    {
+        $body = $this->driver->findElement(WebDriverBy::tagName('body'));
+
+        if (!empty($body)) {
+            $this->resize($body->getSize()->getWidth(), $body->getSize()->getHeight());
+        }
 
         return $this;
     }


### PR DESCRIPTION
this will calculate the size of the `<body>` and resize the browser to match it.

this can be especially helpful taking screenshots due to failures, because often times we cannot see all the content in the screenshot, making it difficult to debug.  eventually it may be nice to have an option to automatically screenshot at fullsize, but we'll start with this PR.