### PR TITLE
Ability to customize attribute name for hooking a selector

### DIFF
--- a/src/Dusk.php
+++ b/src/Dusk.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 class Dusk
 {
     /**
-     * Attribute name for hooking a selector
+     * Attribute name for hooking a selector.
      *
      * @var string
      */
@@ -50,7 +50,7 @@ class Dusk
     }
 
     /**
-     * Customize attribute name for hooking a selector
+     * Customize attribute name for hooking a selector.
      *
      * @param string $name
      */

--- a/src/Dusk.php
+++ b/src/Dusk.php
@@ -7,6 +7,13 @@ use InvalidArgumentException;
 class Dusk
 {
     /**
+     * Attribute name for hooking a selector
+     *
+     * @var string
+     */
+    public static $attribute = 'dusk';
+
+    /**
      * Register the Dusk service provider.
      *
      * @param  array  $options
@@ -40,5 +47,15 @@ class Dusk
         }
 
         return app()->environment(...$options['environments']);
+    }
+
+    /**
+     * Customize attribute name for hooking a selector
+     *
+     * @param string $name
+     */
+    public static function attribute($name)
+    {
+        static::$attribute = $name;
     }
 }

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -399,7 +399,7 @@ class ElementResolver
         );
 
         if (Str::startsWith($selector, '@') && $selector === $originalSelector) {
-            $selector = '[dusk="'.explode('@', $selector)[1].'"]';
+            $selector = '['.Dusk::$attribute.'="'.explode('@', $selector)[1].'"]';
         }
 
         return trim($this->prefix.' '.$selector);


### PR DESCRIPTION
Using static `dusk` attribute for hooking a selector, can compromise which tools we are using on server. It would be better to have ability to customize it!