### PR TITLE
Comply to PSR-2 coding standards

### DIFF
--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -36,8 +36,10 @@ abstract class DuskTestCase extends BaseTestCase
         ]);
 
         return RemoteWebDriver::create(
-            'http://localhost:9515', DesiredCapabilities::chrome()->setCapability(
-                ChromeOptions::CAPABILITY, $options
+            'http://localhost:9515',
+            DesiredCapabilities::chrome()->setCapability(
+                ChromeOptions::CAPABILITY,
+                $options
             )
         );
     }


### PR DESCRIPTION
Only one argument is allowed per line in a multi-line function call
