### PR TITLE
[5.0] Add proxy support to the 'dusk:install' command

### DIFF
--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -165,7 +165,7 @@ class ChromeDriverCommand extends Command
      */
     protected function latestVersion()
     {
-        $home = $this->get($this->homeUrl);
+        $home = $this->getUrl($this->homeUrl);
 
         preg_match('/Latest stable release:.*?\?path=([\d.]+)/', $home, $matches);
 
@@ -185,7 +185,7 @@ class ChromeDriverCommand extends Command
 
         file_put_contents(
             $archive = $this->directory.'chromedriver.zip',
-            $this->get($url)
+            $this->getUrl($url)
         );
 
         return $archive;
@@ -235,7 +235,7 @@ class ChromeDriverCommand extends Command
      *
      * @return string|bool
      */
-    protected function get($url)
+    protected function getUrl($url)
     {
         $contextOptions = [];
 

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -231,13 +231,13 @@ class ChromeDriverCommand extends Command
     }
 
     /**
-     * Get URL using the 'proxy' and 'ssl-no-verify' command options
+     * Get URL using the 'proxy' and 'ssl-no-verify' command options.
      *
      * @return false|string
      */
     protected function get($url)
     {
-        $contextOptions  = array();
+        $contextOptions  = [];
 
         if ($this->option('proxy')) {
             $contextOptions['http'] = ['proxy' => $this->option('proxy'), 'request_fulluri' => true];

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -237,7 +237,7 @@ class ChromeDriverCommand extends Command
      */
     protected function get($url)
     {
-        $contextOptions  = [];
+        $contextOptions = [];
 
         if ($this->option('proxy')) {
             $contextOptions['http'] = ['proxy' => $this->option('proxy'), 'request_fulluri' => true];

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -165,7 +165,7 @@ class ChromeDriverCommand extends Command
      */
     protected function latestVersion()
     {
-        $home = $this->getUrl($this->homeUrl);
+        $home = $this->get($this->homeUrl);
 
         preg_match('/Latest stable release:.*?\?path=([\d.]+)/', $home, $matches);
 
@@ -185,7 +185,7 @@ class ChromeDriverCommand extends Command
 
         file_put_contents(
             $archive = $this->directory.'chromedriver.zip',
-            $this->getUrl($url)
+            $this->get($url)
         );
 
         return $archive;

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -233,6 +233,8 @@ class ChromeDriverCommand extends Command
     /**
      * Get URL using the 'proxy' and 'ssl-no-verify' command options.
      *
+     * @param $url
+     *
      * @return string|bool
      */
     protected function getUrl($url)

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -233,11 +233,10 @@ class ChromeDriverCommand extends Command
     /**
      * Get URL using the 'proxy' and 'ssl-no-verify' command options.
      *
-     * @param $url
-     *
+     * @param string $url
      * @return string|bool
      */
-    protected function getUrl($url)
+    protected function getUrl(string $url)
     {
         $contextOptions = [];
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -11,7 +11,9 @@ class InstallCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'dusk:install';
+    protected $signature = 'dusk:install
+        {--proxy= : Proxy address e.g. "tcp://127.0.0.1:9000"}
+        {--ssl-no-verify : Bypass SSL certificate verification}';
 
     /**
      * The console command description.
@@ -60,7 +62,15 @@ class InstallCommand extends Command
 
         $this->comment('Downloading ChromeDriver binaries...');
 
-        $this->call('dusk:chrome-driver', ['--all' => true]);
+        $driverCommandArgs = ['--all' => true];
+
+        if ($this->option('proxy'))
+            $driverCommandArgs += ['--proxy' => $this->option('proxy')];
+
+        if ($this->option('ssl-no-verify'))
+            $driverCommandArgs += ['--ssl-no-verify' => true];
+
+        $this->call('dusk:chrome-driver', $driverCommandArgs);
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -64,11 +64,13 @@ class InstallCommand extends Command
 
         $driverCommandArgs = ['--all' => true];
 
-        if ($this->option('proxy'))
+        if ($this->option('proxy')) {
             $driverCommandArgs += ['--proxy' => $this->option('proxy')];
+        }
 
-        if ($this->option('ssl-no-verify'))
+        if ($this->option('ssl-no-verify')) {
             $driverCommandArgs += ['--ssl-no-verify' => true];
+        }
 
         $this->call('dusk:chrome-driver', $driverCommandArgs);
     }


### PR DESCRIPTION
Running `php artisan dusk:install` fails behind a proxy. 


This commit adds two new options:

-  `--proxy=PROXY_ADDRESS` - e.g. `--proxy=tcp://127.0.0.1:9000`, the address gets passed to `file_get_contents()` via stream context

- `--ssl-no-verify` - skips SSL certificate verification by `file_get_contents()`; useful when the proxy replaces the original SSL certificate with it's own for HTTPS traffic inspection. In that case the `dusk:install` command fails:
```
 ErrorException  : file_get_contents(): SSL operation failed with code 1. OpenSSL Error messages:
error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed
```

PS: I could not test this commit without a proxy! Please test the defaults (no proxy) before merging.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
