### PR TITLE
Add assertion to check if a button is disabled

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -665,7 +665,7 @@ JS;
      * @param  string  $button
      * @return $this
      */
-    public function assertButtonIsEnabled($button)
+    public function assertButtonEnabled($button)
     {
         $element = $this->resolver->resolveForButtonPress($button);
 
@@ -683,7 +683,7 @@ JS;
      * @param  string  $button
      * @return $this
      */
-    public function assertButtonIsDisabled($button)
+    public function assertButtonDisabled($button)
     {
         $element = $this->resolver->resolveForButtonPress($button);
 

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -660,6 +660,42 @@ JS;
     }
 
     /**
+     * Assert that the given button is enabled.
+     *
+     * @param  string  $button
+     * @return $this
+     */
+    public function assertButtonIsEnabled($button)
+    {
+        $element = $this->resolver->resolveForButtonPress($button);
+
+        PHPUnit::assertTrue(
+            $element->isEnabled(),
+            "Expected button [{$button}] to be enabled, but it wasn't."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given button is disabled.
+     *
+     * @param  string  $button
+     * @return $this
+     */
+    public function assertButtonIsDisabled($button)
+    {
+        $element = $this->resolver->resolveForButtonPress($button);
+
+        PHPUnit::assertFalse(
+            $element->isEnabled(),
+            "Expected button [{$button}] to be disabled, but it wasn't."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the given field is focused.
      *
      * @param  string  $field

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -137,9 +137,9 @@ class MakesAssertionsTest extends TestCase
         );
         $browser = new Browser($driver, $resolver);
 
-        $browser->assertButtonIsEnabled('Press me');
+        $browser->assertButtonEnabled('Press me');
 
-        $browser->assertButtonIsEnabled('Cant press me');
+        $browser->assertButtonEnabled('Cant press me');
     }
 
     public function test_assert_button_is_disabled()
@@ -155,9 +155,9 @@ class MakesAssertionsTest extends TestCase
         );
         $browser = new Browser($driver, $resolver);
 
-        $browser->assertButtonIsDisabled('Cant press me');
+        $browser->assertButtonDisabled('Cant press me');
 
-        $browser->assertButtonIsDisabled('Press me');
+        $browser->assertButtonDisabled('Press me');
     }
 
     public function test_assert_focused()

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -124,7 +124,7 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
-    public function test_assert_button_is_enabled()
+    public function test_assert_button_enabled()
     {
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Expected button [Cant press me] to be enabled, but it wasn't.");

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -6,6 +6,7 @@ use stdClass;
 use Mockery as m;
 use Laravel\Dusk\Browser;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\AssertionFailedError;
 use Facebook\WebDriver\Remote\RemoteWebElement;
 use PHPUnit\Framework\ExpectationFailedException;
 
@@ -122,6 +123,42 @@ class MakesAssertionsTest extends TestCase
                 $e->getMessage()
             );
         }
+    }
+
+    public function test_assert_button_is_enabled()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected button [Cant press me] to be enabled, but it wasn't.");
+
+        $driver = m::mock(stdClass::class);
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('resolveForButtonPress->isEnabled')->andReturn(
+            true,
+            false
+        );
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertButtonIsEnabled('Press me');
+
+        $browser->assertButtonIsEnabled('Cant press me');
+    }
+
+    public function test_assert_button_is_disabled()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected button [Press me] to be disabled, but it wasn't.");
+
+        $driver = m::mock(stdClass::class);
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('resolveForButtonPress->isEnabled')->twice()->andReturn(
+            false,
+            true
+        );
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertButtonIsDisabled('Cant press me');
+
+        $browser->assertButtonIsDisabled('Press me');
     }
 
     public function test_assert_focused()

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -6,7 +6,6 @@ use stdClass;
 use Mockery as m;
 use Laravel\Dusk\Browser;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\AssertionFailedError;
 use Facebook\WebDriver\Remote\RemoteWebElement;
 use PHPUnit\Framework\ExpectationFailedException;
 
@@ -127,7 +126,7 @@ class MakesAssertionsTest extends TestCase
 
     public function test_assert_button_is_enabled()
     {
-        $this->expectException(AssertionFailedError::class);
+        $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Expected button [Cant press me] to be enabled, but it wasn't.");
 
         $driver = m::mock(stdClass::class);
@@ -145,7 +144,7 @@ class MakesAssertionsTest extends TestCase
 
     public function test_assert_button_is_disabled()
     {
-        $this->expectException(AssertionFailedError::class);
+        $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Expected button [Press me] to be disabled, but it wasn't.");
 
         $driver = m::mock(stdClass::class);

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -142,7 +142,7 @@ class MakesAssertionsTest extends TestCase
         $browser->assertButtonEnabled('Cant press me');
     }
 
-    public function test_assert_button_is_disabled()
+    public function test_assert_button_disabled()
     {
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Expected button [Press me] to be disabled, but it wasn't.");


### PR DESCRIPTION
This PR adds the following two assertions:
```php
public function assertButtonEnabled($button)

public function assertButtonDisabled($button)
```

Asserting that a button is disabled is something I frequently do, I feel like it deserves its own assertion. Both new assertions select a button in the same way `->press($button)` does.

Without these assertions, checking if a button is disabled has to be done something like this:
```php
->tap(function (Browser $browser) {
    $this->assertFalse($browser->resolver->resolveForButtonPress('Press me')->isEnabled());
})
```

There is already a `assertDisabled($field)` assertion, but since that uses `->resolveForField()` it can not be used to select buttons.