### PR TITLE
[5.0] Allow saving screenshots in a subdirectory

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -291,7 +291,7 @@ class Browser
 
         $directoryPath = dirname($filePath);
 
-        if (! file_exists($directoryPath)) {
+        if (! is_dir($directoryPath)) {
             mkdir($directoryPath, 0777, true);
         }
 

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -287,9 +287,15 @@ class Browser
      */
     public function screenshot($name)
     {
-        $this->driver->takeScreenshot(
-            sprintf('%s/%s.png', rtrim(static::$storeScreenshotsAt, '/'), $name)
-        );
+        $filePath = sprintf('%s/%s.png', rtrim(static::$storeScreenshotsAt, '/'), $name);
+
+        $directoryPath = dirname($filePath);
+
+        if (! file_exists($directoryPath)) {
+            mkdir($directoryPath, 0777, true);
+        }
+
+        $this->driver->takeScreenshot($filePath);
 
         return $this;
     }

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -11,6 +11,19 @@ use Facebook\WebDriver\Remote\WebDriverBrowserType;
 
 class BrowserTest extends TestCase
 {
+    /** @var \Mockery\MockInterface */
+    private $driver;
+
+    /** @var Browser */
+    private $browser;
+
+    protected function setUp(): void
+    {
+        $this->driver = m::mock(stdClass::class);
+
+        $this->browser = new Browser($this->driver);
+    }
+
     protected function tearDown(): void
     {
         m::close();
@@ -154,6 +167,36 @@ class BrowserTest extends TestCase
         $browser = new Browser($driver);
 
         $browser->storeConsoleLog('file');
+    }
+
+    public function test_screenshot()
+    {
+        $this->driver->shouldReceive('takeScreenshot')->andReturnUsing(function ($filePath) {
+            touch($filePath);
+        });
+
+        Browser::$storeScreenshotsAt = sys_get_temp_dir();
+
+        $this->browser->screenshot(
+            $name = 'screenshot-01'
+        );
+
+        $this->assertFileExists(Browser::$storeScreenshotsAt.'/'.$name.'.png');
+    }
+
+    public function test_screenshot_in_subdirectory()
+    {
+        $this->driver->shouldReceive('takeScreenshot')->andReturnUsing(function ($filePath) {
+            touch($filePath);
+        });
+
+        Browser::$storeScreenshotsAt = sys_get_temp_dir();
+
+        $this->browser->screenshot(
+            $name = uniqid('random').'/sub/dir/screenshot-01'
+        );
+
+        $this->assertFileExists(Browser::$storeScreenshotsAt.'/'.$name.'.png');
     }
 }
 


### PR DESCRIPTION
I have opened [a similar PR](https://github.com/facebook/php-webdriver/pull/632) in the php-webdriver repo, but since that is taking a long time to get merged I've decided to PR it straight into Dusk.

---

This PR adds the ability to save screenshots in subdirectories. Currently, the directory you give to the `$browser->screenshot()` method has to exist, else it will throw an exception. With this PR you can save the screenshot to a directory that does not exist, the directory will be created automatically.

I take screenshots of many pages and flows within my application. Without saving screenshots in subdirectories, I get a long list of screenshots with long names:
- `user-activation-single-company-step-1.png`
- `user-activation-single-company-step-2.png`
- `user-activation-multiple-companies-step-1.png`
- `user-activation-multiple-companies-step-2.png`
- (and many more)

With this PR you can I can create a structure like this, which is easier to navigate:

- `user-activation/single-company/step-1.png`
- `user-activation/single-company/step-2.png`
- `user-activation/multiple-companies/step-1.png`
- `user-activation/multiple-companies/step-2.png`
- (and many more)

