### PR TITLE
[5.0] Add assertConsoleLogMissingErrors assertion

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -47,6 +47,13 @@ class Browser
     public static $storeConsoleLogAt;
 
     /**
+     * The closure that is used to filter console messages for console log assertions.
+     *
+     * @var Closure
+     */
+    public static $assertConsoleLogFilter;
+
+    /**
      * The browsers that support retrieving logs.
      *
      * @var array
@@ -302,17 +309,27 @@ class Browser
      */
     public function storeConsoleLog($name)
     {
-        if (in_array($this->driver->getCapabilities()->getBrowserName(), static::$supportsRemoteLogs)) {
-            $console = $this->driver->manage()->getLog('browser');
-
-            if (! empty($console)) {
-                file_put_contents(
-                    sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name), json_encode($console, JSON_PRETTY_PRINT)
-                );
-            }
+        if ($consoleLog = $this->getConsoleLog()) {
+            file_put_contents(
+                sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name), json_encode($consoleLog, JSON_PRETTY_PRINT)
+            );
         }
 
         return $this;
+    }
+
+    /**
+     * Get the console log entries.
+     *
+     * @return array|false The list of log entries.
+     */
+    public function getConsoleLog()
+    {
+        if (! in_array($this->driver->getCapabilities()->getBrowserName(), static::$supportsRemoteLogs)) {
+            return false;
+        }
+
+        return $this->driver->manage()->getLog('browser');
     }
 
     /**

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -829,7 +829,7 @@ JS;
         $errors = array_filter($consoleLog, Browser::$assertConsoleLogFilter);
 
         $messages = array_map(function ($message) {
-            return explode("\n", $message)[0];
+            return explode('\n', $message)[0];
         }, array_column($errors, 'message'));
 
         Assert::assertEmpty(

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -835,7 +835,7 @@ JS;
         Assert::assertEmpty(
             $errors,
             'Console log had unexpected errors: '.PHP_EOL.PHP_EOL.
-            json_encode($messages, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE |JSON_UNESCAPED_SLASHES)
+            json_encode($messages, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
         );
 
         return $this;

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -28,6 +28,10 @@ abstract class TestCase extends FoundationTestCase
 
         Browser::$storeConsoleLogAt = base_path('tests/Browser/console');
 
+        Browser::$assertConsoleLogFilter = function ($consoleLog) {
+            return $consoleLog;
+        };
+
         Browser::$userResolver = function () {
             return $this->user();
         };

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -175,7 +175,7 @@ class BrowserTest extends TestCase
             [
                 [
                     'level' => 'SEVERE',
-                    'message' => "http://example.test/js/vendors~app.js?28f8d5a6622d03b99bae 91554:31 \"Warning: Each child in a list should have a unique \\\"key\\\" prop .%s % s See https://fb.me/react-warning-keys for more information.%s\" \"\n\nCheck the render method of `Summary`.\" \"\" \"\n    in table (created by Summary)\n    in Summary (created by Context.Consumer)\n    in Connect(Summary) (created by Route)\n    in Route (created by CreateEmployerWizard)\n    in Switch (created by CreateEmployerWizard)\n    in Transition (created by CSSTransition)",
+                    'message' => "http://example.test/js/vendors~app.js?28f8d5a6622d03b99bae 91554:31 \"Warning: Each child in a list should have a unique \\\"key\\\" prop .%s % s See https://fb.me/react-warning-keys for more information.%s\" \"\\n\\nCheck the render method of `Summary`.\" \"\" \"\\n    in table (created by Summary)\\n    in Summary (created by Context.Consumer)\\n    in Connect(Summary) (created by Route)\\n    in Route (created by CreateEmployerWizard)\\n    in Switch (created by CreateEmployerWizard)\\n    in Transition (created by CSSTransition)",
                     'source' => 'console-api',
                     'timestamp' => 1564655342641,
                 ],
@@ -211,7 +211,7 @@ class BrowserTest extends TestCase
         $driver->shouldReceive('manage->getLog')->andReturn([
             [
                 'level' => 'SEVERE',
-                'message' => "http://example.test/js/vendors~app.js?28f8d5a6622d03b99bae 91554:31 \"Warning: Each child in a list should have a unique \\\"key\\\" prop.%s %s See https://fb.me/react-warning-keys for more information.%s\" \"\n\nCheck the render method of `Summary`.\" \"\" \"\n    in table (created by Summary)\n    in Summary (created by Context.Consumer)\n    in Connect(Summary) (created by Route)\n    in Route (created by CreateEmployerWizard)\n    in Switch (created by CreateEmployerWizard)\n    in Transition (created by CSSTransition)",
+                'message' => "http://example.test/js/vendors~app.js?28f8d5a6622d03b99bae 91554:31 \"Warning: Each child in a list should have a unique \\\"key\\\" prop.%s %s See https://fb.me/react-warning-keys for more information.%s\" \"\\n\\nCheck the render method of `Summary`.\" \"\" \"\\n    in table (created by Summary)\\n    in Summary (created by Context.Consumer)\\n    in Connect(Summary) (created by Route)\\n    in Route (created by CreateEmployerWizard)\\n    in Switch (created by CreateEmployerWizard)\\n    in Transition (created by CSSTransition)",
                 'source' => 'console-api',
                 'timestamp' => 1564655342641,
             ],

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -175,7 +175,7 @@ class BrowserTest extends TestCase
             [
                 [
                     'level' => 'SEVERE',
-                    'message' => "http://example.test/js/vendors~app.js?28f8d5a6622d03b99bae 91554:31 \"Warning: Each child in a list should have a unique \\\"key\\\" prop .%s % s See https://fb.me/react-warning-keys for more information.%s\" \"\\n\\nCheck the render method of `Summary`.\" \"\" \"\\n    in table (created by Summary)\\n    in Summary (created by Context.Consumer)\\n    in Connect(Summary) (created by Route)\\n    in Route (created by CreateEmployerWizard)\\n    in Switch (created by CreateEmployerWizard)\\n    in Transition (created by CSSTransition)",
+                    'message' => 'http://example.test/js/vendors~app.js?28f8d5a6622d03b99bae 91554:31 "Warning: Each child in a list should have a unique \\"key\\" prop .%s % s See https://fb.me/react-warning-keys for more information.%s" "\\n\\nCheck the render method of `Summary`." "" "\\n    in table (created by Summary)\\n    in Summary (created by Context.Consumer)\\n    in Connect(Summary) (created by Route)\\n    in Route (created by CreateEmployerWizard)\\n    in Switch (created by CreateEmployerWizard)\\n    in Transition (created by CSSTransition)',
                     'source' => 'console-api',
                     'timestamp' => 1564655342641,
                 ],
@@ -211,7 +211,7 @@ class BrowserTest extends TestCase
         $driver->shouldReceive('manage->getLog')->andReturn([
             [
                 'level' => 'SEVERE',
-                'message' => "http://example.test/js/vendors~app.js?28f8d5a6622d03b99bae 91554:31 \"Warning: Each child in a list should have a unique \\\"key\\\" prop.%s %s See https://fb.me/react-warning-keys for more information.%s\" \"\\n\\nCheck the render method of `Summary`.\" \"\" \"\\n    in table (created by Summary)\\n    in Summary (created by Context.Consumer)\\n    in Connect(Summary) (created by Route)\\n    in Route (created by CreateEmployerWizard)\\n    in Switch (created by CreateEmployerWizard)\\n    in Transition (created by CSSTransition)",
+                'message' => 'http://example.test/js/vendors~app.js?28f8d5a6622d03b99bae 91554:31 "Warning: Each child in a list should have a unique \\"key\\" prop.%s %s See https://fb.me/react-warning-keys for more information.%s" "\\n\\nCheck the render method of `Summary`." "" "\\n    in table (created by Summary)\\n    in Summary (created by Context.Consumer)\\n    in Connect(Summary) (created by Route)\\n    in Route (created by CreateEmployerWizard)\\n    in Switch (created by CreateEmployerWizard)\\n    in Transition (created by CSSTransition)',
                 'source' => 'console-api',
                 'timestamp' => 1564655342641,
             ],


### PR DESCRIPTION
This PR adds a `assertConsoleLogMissingErrors()` assertion that asserts that the console log does not contain any unexpected errors.

This assertion is especially useful when testing javascript heavy applications, such as an SPA made with Vue or React. Because javascript errors don't always break the test, they can be hard to discover. Using the `assertConsoleLogMissingErrors()` assertion at the end of your Dusk test gives extra confidence that nothing went wrong.

When the assertion fails, it looks something like this:
![image](https://user-images.githubusercontent.com/7202674/62292525-dd102f00-b466-11e9-9884-f179194252d6.png)


However, many console messages can be safely ignored. To ignore console log messages, you can define a custom closure. The code below contains an example of the messages we ignore in a legacy react SPA that we started adding Dusk tests to a few months ago (we are already using this assertion as a macro).
```php
Browser::$assertConsoleLogFilter = function ($consoleLog) {
    $ignoreIfMessageContains = [
        'Warning: Failed prop type:',
        'Warning: validateDOMNesting(...): %s cannot appear as a descendant of',
        'Warning: validateDOMNesting(...): %s cannot appear as a child of',
        'Warning: Cannot update during an existing state transition (such as within `render`)',
        'Warning: Each child in a list should have a unique \"key\" prop.',
        'Warning: `value` prop on `%s` should not be null',
        'Warning: A component is changing a controlled input of type %s to be uncontrolled',
    ];

    foreach ($ignoreIfMessageContains as $ignoreText) {
        if (stripos($consoleLog['message'], $ignoreText) !== false) {
            return false;
        }
    }

    return true;
};
```