### PR TITLE
Method to wait for text in selector

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -85,7 +85,7 @@ trait WaitsForElements
             return Str::contains($this->resolver->findOrFail('')->getText(), $text);
         }, $message);
     }
-    
+
     /**
      * @param string $selector
      * @param string $text
@@ -95,7 +95,7 @@ trait WaitsForElements
      */
     public function waitForTextIn($selector, $text, $seconds = null)
     {
-        $message = 'Waited %s seconds for text "'.$text.'" in selector ' . $selector;
+        $message = 'Waited %s seconds for text "'.$text.'" in selector '.$selector;
 
         return $this->waitUsing($seconds, 100, function () use ($selector, $text) {
             return $this->assertSeeIn($selector, $text);

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -85,6 +85,22 @@ trait WaitsForElements
             return Str::contains($this->resolver->findOrFail('')->getText(), $text);
         }, $message);
     }
+    
+    /**
+     * @param string $selector
+     * @param string $text
+     * @param int|null $seconds
+     * @return WaitsForElements
+     * @throws TimeOutException
+     */
+    public function waitForTextIn($selector, $text, $seconds = null)
+    {
+        $message = 'Waited %s seconds for text "'.$text.'" in selector ' . $selector;
+
+        return $this->waitUsing($seconds, 100, function () use ($selector, $text) {
+            return $this->assertSeeIn($selector, $text);
+        }, $message);
+    }
 
     /**
      * Wait for the given link to be visible.


### PR DESCRIPTION
Added Method to wait for text in selector.

```php
public function waitForTextIn($selector, $text, $seconds = null)

```
Example usage:

```php
$this->browse(function(Browser $browser) use($user){
    $browser->loginAs($user)
        ->visit('/datatable')
        ->waitForTextIn('@datatableColStatus', STATUS_DONE, 60);
});
```