### PR TITLE
Configurable selector prefix (related to issue #666)

### DIFF
--- a/config/dusk.php
+++ b/config/dusk.php
@@ -1,0 +1,16 @@
+    
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Dusk Selector Prefix
+    |--------------------------------------------------------------------------
+    |
+    | This is the prefix Dusk will use when resolving selectors prefixed with @
+    | (see https://laravel.com/docs/master/dusk#dusk-selectors)
+    |
+    */
+    'selector_prefix' => 'dusk',
+
+];

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -15,6 +15,10 @@ class DuskServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
+            $this->publishes([__DIR__.'/../config/dusk.php' => config_path('dusk.php')]);
+        }
+        
         Route::get('/_dusk/login/{userId}/{guard?}', [
             'middleware' => 'web',
             'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
@@ -42,6 +46,10 @@ class DuskServiceProvider extends ServiceProvider
         if ($this->app->environment('production')) {
             throw new Exception('It is unsafe to run Dusk in production.');
         }
+        
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/dusk.php', 'dusk'
+        );
 
         if ($this->app->runningInConsole()) {
             $this->commands([

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -399,7 +399,7 @@ class ElementResolver
         );
 
         if (Str::startsWith($selector, '@') && $selector === $originalSelector) {
-            $selector = '[dusk="'.explode('@', $selector)[1].'"]';
+            $selector = sprintf('[%s="%s"]', config('dusk.selector_prefix'), explode('@', $selector)[1]);
         }
 
         return trim($this->prefix.' '.$selector);


### PR DESCRIPTION
This fairly simple change allows users to configure the `dusk=""` prefix that Dusk uses to parse selectors with the `@` prefix. This is intended primarily to allow users to namespace the prefix into `data-[whatever]`, for compatibility with HTML validators. Validators are still important to many people's workflows. The default is still `dusk=""`, to avoid breakage of existing code.

There is *no new test coverage*, because the test `test_format_correctly_formats_selectors` in the file `https://github.com/laravel/dusk/blob/5.0/tests/ElementResolverTest.php` covers this change.