### PR TITLE
Fix pattern for fetch last release of chromedriver

### DIFF
--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -167,7 +167,7 @@ class ChromeDriverCommand extends Command
     {
         $home = $this->getUrl($this->homeUrl);
 
-        preg_match('/Latest stable release:.*?\?path=([\d.]+)/', $home, $matches);
+        preg_match('/release:.*?\?path=([\d.]+)/', $home, $matches);
 
         return $matches[1];
     }


### PR DESCRIPTION
Release element is change so that regex cannot fetch the version now.

The release element today is:

```
<span style="background-color:transparent">Latest stable </span>release:  <a href="https://chromedriver.storage.googleapis.com/index.html?path=77.0.3865.40/"
```

So we can use this regex to fetch version:

```
'/release:.*?\?path=([\d.]+)/'
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
