### PR TITLE
[5.5] Improve detection of latest stable ChromeDriver release

### DIFF
--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -29,14 +29,14 @@ class ChromeDriverCommand extends Command
     protected $description = 'Install the ChromeDriver binary';
 
     /**
-     * URL to the home page.
+     * URL to the latest stable release version.
      *
      * @var string
      */
-    protected $homeUrl = 'http://chromedriver.chromium.org/home';
+    protected $latestVersionUrl = 'https://chromedriver.storage.googleapis.com/LATEST_RELEASE';
 
     /**
-     * URL to the latest release version.
+     * URL to the latest release version for a major Chrome version.
      *
      * @var string
      */
@@ -165,11 +165,7 @@ class ChromeDriverCommand extends Command
      */
     protected function latestVersion()
     {
-        $home = $this->getUrl($this->homeUrl);
-
-        preg_match('/release:.*?\?path=([\d.]+)/', $home, $matches);
-
-        return $matches[1];
+        return trim(file_get_contents($this->latestVersionUrl));
     }
 
     /**


### PR DESCRIPTION
By default, `php artisan dusk:chrome-driver` downloads the latest stable ChromeDriver release. We are currently parsing http://chromedriver.chromium.org to get the version number, but that's not ideal. When the HTML changes (as it did last week), it breaks the updater (#672).

https://chromedriver.storage.googleapis.com/LATEST_RELEASE does contain this version number, but the file had been deprecated for the last months. I explained our issue to the ChromeDriver team and they removed the deprecation: https://bugs.chromium.org/p/chromedriver/issues/detail?id=3128
