### PR TITLE
[5.x] Add graceful handler for SIGINT for .env restoration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": ">=7.1.0",
         "ext-json": "*",
         "ext-zip": "*",
+        "ext-pcntl": "*",
         "facebook/webdriver": "^1.7",
         "nesbot/carbon": "^1.20|^2.0",
         "illuminate/console": "~5.7.0|~5.8.0|^6.0|^7.0",

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -6,8 +6,8 @@ use Dotenv\Dotenv;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
+use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\Process;
 
 class DuskCommand extends Command

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -288,8 +288,8 @@ class DuskCommand extends Command
      */
     protected function removeConfiguration()
     {
-        if (! $this->hasPhpUnitConfiguration) {
-            unlink(base_path('phpunit.dusk.xml'));
+        if (! $this->hasPhpUnitConfiguration && file_exists($file = base_path('phpunit.dusk.xml'))) {
+            unlink($file);
         }
     }
 

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -202,7 +202,7 @@ class DuskCommand extends Command
      */
     protected function setupSignalHandler()
     {
-        declare(ticks=1);
+        pcntl_async_signals(true);
 
         pcntl_signal(SIGINT, function () {
             $this->teardownDuskEnviroment();

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -74,7 +74,7 @@ class DuskCommand extends Command
                     $this->output->write($line);
                 });
             } catch (ProcessSignaledException $e) {
-                if ($e->getSignal() !== 2) {
+                if ($e->getSignal() !== SIGINT) {
                     throw $e;
                 }
             }


### PR DESCRIPTION
This PR ensures that if the `php artisan dusk` command is cancelled by a CTRL+C (command cancel, i.e. SIGINT), the original .env is restored correctly.

We often run a dusk test, and cancel within the test suite if an issue comes up. In that case, the `.env.backup` isn't restored, and requires it to be restored manually.

Also adds a `try {} finally {}` clause if the Dusk commands fails themself the environment is still restored.