### PR TITLE
Add scrollTo method

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -250,6 +250,19 @@ class Browser
     }
 
     /**
+     * Scroll screen to element at the given selector.
+     *
+     * @param  string  $selector
+     * @return $this
+     */
+    public function scrollTo($selector)
+    {
+        $this->driver->executeScript("document.querySelector('$selector').scrollIntoView();");
+
+        return $this;
+    }
+
+    /**
      * Take a screenshot and store it with the given name.
      *
      * @param  string  $name

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -257,7 +257,7 @@ class Browser
      */
     public function scrollTo($selector)
     {
-        $this->driver->executeScript("document.querySelector('$selector').scrollIntoView();");
+        $this->driver->executeScript("$(\"html, body\").animate({scrollTop: $(\"$selector\").offset().top}, 0);");
 
         return $this;
     }

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -257,6 +257,8 @@ class Browser
      */
     public function scrollTo($selector)
     {
+        $selector = $this->resolver->format($selector);
+
         $this->driver->executeScript("$(\"html, body\").animate({scrollTop: $(\"$selector\").offset().top}, 0);");
 
         return $this;


### PR DESCRIPTION
Re-submission of https://github.com/laravel/dusk/pull/367.

When using click on elements which are not in the viewport, it's quite handy to add a simple `scrollTo` call to ensure the browser has the element in the viewport. We macro this in all our projects, but would be nicer to have support for this in the core.

Example:
```
$browser->visit(route('overview'))
   ->scrollTo('@create')
   ->click('@create')
```