### PR TITLE
Added missing return statement in withDuskEnvironment

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -169,7 +169,7 @@ class DuskCommand extends Command
         $this->setupDuskEnvironment();
 
         try {
-            $callback();
+            return $callback();
         } finally {
             $this->teardownDuskEnviroment();
         }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The callback in the WithDuskEnvironment was not returned, this caused the exit codes for the dusk command to be always 0. Which means CI environments could not distinguish between succesfull and failed tests. 

This will fix issue #690 