### PR TITLE
[5.x] Prevent using pcntl when not installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "php": ">=7.1.0",
         "ext-json": "*",
         "ext-zip": "*",
-        "ext-pcntl": "*",
         "facebook/webdriver": "^1.7",
         "nesbot/carbon": "^1.20|^2.0",
         "illuminate/console": "~5.7.0|~5.8.0|^6.0|^7.0",
@@ -26,6 +25,9 @@
     "require-dev": {
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^7.5|^8.0"
+    },
+    "suggest": {
+        "ext-pcntl": "Used to gracefully terminate Dusk when tests are running."
     },
     "autoload": {
         "psr-4": {

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -74,7 +74,7 @@ class DuskCommand extends Command
                     $this->output->write($line);
                 });
             } catch (ProcessSignaledException $e) {
-                if ($e->getSignal() !== SIGINT) {
+                if (extension_loaded('pcntl') && $e->getSignal() !== SIGINT) {
                     throw $e;
                 }
             }
@@ -88,7 +88,7 @@ class DuskCommand extends Command
      */
     protected function binary()
     {
-        if ('phpdbg' === \PHP_SAPI) {
+        if ('phpdbg' === PHP_SAPI) {
             return [PHP_BINARY, '-qrr', 'vendor/phpunit/phpunit/phpunit'];
         }
 
@@ -248,11 +248,13 @@ class DuskCommand extends Command
      */
     protected function setupSignalHandler()
     {
-        pcntl_async_signals(true);
+        if (extension_loaded('pcntl')) {
+            pcntl_async_signals(true);
 
-        pcntl_signal(SIGINT, function () {
-            $this->teardownDuskEnviroment();
-        });
+            pcntl_signal(SIGINT, function () {
+                $this->teardownDuskEnviroment();
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
This prevents using pcntl when it's not installed. This was preventing Dusk from being run on Windows.

I have no way of testing this on Windows so I hope this will work.

Fixes https://github.com/laravel/dusk/issues/689