### PR TITLE
Escape single quotes

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -62,7 +62,9 @@ trait InteractsWithElements
         if (is_null($value)) {
             return $this->resolver->findOrFail($selector)->getAttribute('value');
         }
+
         $value = addslashes($value);
+
         $selector = $this->resolver->format($selector);
 
         $this->driver->executeScript(

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -62,7 +62,7 @@ trait InteractsWithElements
         if (is_null($value)) {
             return $this->resolver->findOrFail($selector)->getAttribute('value');
         }
-
+        $value = addslashes($value);
         $selector = $this->resolver->format($selector);
 
         $this->driver->executeScript(


### PR DESCRIPTION
***Note:*** This might be a rare use-case but it does break when someone passes single quote in the string.
 
The `value` function does not escape the contents of  `$value` variable as a result if someone passes a string even with a escaped single quote, the code breaks because value is assigned using single quotes  on line 68 argument passed to `executeScript`,
`"document.querySelector('{$selector}').value = '{$value}';"`

```php
$browser->value('myField', "Field\'s Name");
```

***Current output of the script:***
```js
document.querySelector('myField').value = 'Field's Name';
```
***Expected output of the script:***
```js
document.querySelector('{$selector}').value = 'Field\'s Name';"
```

Fixes #312

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
