### PR TITLE
[5.x] scrollTo: add support for selectors with quotes

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -289,7 +289,7 @@ class Browser
     {
         $this->ensurejQueryIsAvailable();
 
-        $selector = $this->resolver->format($selector);
+        $selector = addslashes($this->resolver->format($selector));
 
         $this->driver->executeScript("jQuery(\"html, body\").animate({scrollTop: jQuery(\"$selector\").offset().top}, 0);");
 


### PR DESCRIPTION
This PR adds support for selectors with quotes for the scrollTo method.

Example:

```
$browser
    ->scrollTo('[name="action"]')
    ->press('...')
```

Without this fix the selector would fail with `Facebook\WebDriver\Exception\UnexpectedJavascriptException: javascript error: missing ) after argument list`