### PR TITLE
[5.0] automatically fit content on failures

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -99,7 +99,7 @@ class Browser
     public $component;
 
     /**
-     * Flag to fit the browser before taking screenshots for failures.
+     * Indicates that the browser should be resized to fit the entire "body" before screenshotting failures.
      *
      * @var bool
      */

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -99,6 +99,13 @@ class Browser
     public $component;
 
     /**
+     * Flag to fit the browser before taking screenshots for failures.
+     *
+     * @var bool
+     */
+    public $fitOnFailure = true;
+
+    /**
      * Create a browser instance.
      *
      * @param  \Facebook\WebDriver\Remote\RemoteWebDriver  $driver
@@ -259,6 +266,30 @@ class Browser
         if (! empty($body)) {
             $this->resize($body->getSize()->getWidth(), $body->getSize()->getHeight());
         }
+
+        return $this;
+    }
+
+    /**
+     * Disable fit on failures.
+     *
+     * @return $this
+     */
+    public function disableFitOnFailure()
+    {
+        $this->fitOnFailure = false;
+
+        return $this;
+    }
+
+    /**
+     * Enable fit on failures.
+     *
+     * @return $this
+     */
+    public function enableFitOnFailure()
+    {
+        $this->fitOnFailure = true;
 
         return $this;
     }

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -137,7 +137,6 @@ trait ProvidesBrowser
     protected function captureFailuresFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
-
             if (property_exists($browser, 'fitOnFailure') && $browser->fitOnFailure) {
                 $browser->fitContent();
             }

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -137,6 +137,11 @@ trait ProvidesBrowser
     protected function captureFailuresFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
+
+            if (property_exists($browser, 'fitOnFailure') && $browser->fitOnFailure) {
+                $browser->fitContent();
+            }
+
             $name = str_replace('\\', '_', get_class($this)).'_'.$this->getName(false);
 
             $browser->screenshot('failure-'.$name.'-'.$key);

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -198,6 +198,22 @@ class BrowserTest extends TestCase
 
         $this->assertFileExists(Browser::$storeScreenshotsAt.'/'.$name.'.png');
     }
+
+    public function test_can_disable_fit_on_failure()
+    {
+        $this->browser->fitOnFailure = true;
+        $this->browser->disableFitOnFailure();
+
+        $this->assertFalse($this->browser->fitOnFailure);
+    }
+
+    public function test_can_enable_fit_on_failure()
+    {
+        $this->browser->fitOnFailure = false;
+        $this->browser->enableFitOnFailure();
+
+        $this->assertTrue($this->browser->fitOnFailure);
+    }
 }
 
 class BrowserTestPage extends Page


### PR DESCRIPTION
I added a feature a couple months ago called `fitContent` which resizes the browser to the dimensions of the content.

https://github.com/laravel/dusk/pull/655

Finally got around to documenting it today.

https://github.com/laravel/docs/pull/5658

Next step is to have this automatically happen prior to taking screenshots.

I think we can safely enable this on a minor or patch release, but if people have strong objections to that, I can default it to `false` for now, and enable it on `master` for the 6.0 release.
