### PR TITLE
[5.0] store the source of the browser

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -47,6 +47,13 @@ class Browser
     public static $storeConsoleLogAt;
 
     /**
+     * The directory that will contain any source files.
+     *
+     * @var string
+     */
+    public static $storeSourceAt;
+
+    /**
      * The browsers that support retrieving logs.
      *
      * @var array
@@ -333,6 +340,25 @@ class Browser
                     sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name), json_encode($console, JSON_PRETTY_PRINT)
                 );
             }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Store the source with the given name.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function storeSource($name)
+    {
+        $source = $this->driver->getPageSource();
+
+        if (! empty($source)) {
+            file_put_contents(
+                sprintf('%s/%s.txt', rtrim(static::$storeSourceAt, '/'), $name), $source
+            );
         }
 
         return $this;

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -76,6 +76,7 @@ trait ProvidesBrowser
             throw $e;
         } finally {
             $this->storeConsoleLogsFor($browsers);
+            $this->storeSourceFor($browsers);
 
             static::$browsers = $this->closeAllButPrimary($browsers);
         }
@@ -155,6 +156,21 @@ trait ProvidesBrowser
             $name = str_replace('\\', '_', get_class($this)).'_'.$this->getName(false);
 
             $browser->storeConsoleLog($name.'-'.$key);
+        });
+    }
+
+    /**
+     * Store the source for the given browsers.
+     *
+     * @param  \Illuminate\Support\Collection  $browsers
+     * @return void
+     */
+    protected function storeSourceFor($browsers)
+    {
+        $browsers->each(function ($browser, $key) {
+            $name = str_replace('\\', '_', get_class($this)).'_'.$this->getName(false);
+
+            $browser->storeSource($name.'-'.$key);
         });
     }
 

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -28,6 +28,8 @@ abstract class TestCase extends FoundationTestCase
 
         Browser::$storeConsoleLogAt = base_path('tests/Browser/console');
 
+        Browser::$storeSourceAt = base_path('tests/Browser/source');
+
         Browser::$userResolver = function () {
             return $this->user();
         };

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -212,7 +212,7 @@ class BrowserTest extends TestCase
         $this->assertFileExists(Browser::$storeSourceAt.'/'.$name.'.txt');
         $this->assertStringEqualsFile(Browser::$storeSourceAt.'/'.$name.'.txt', 'source content');
     }
-  
+
     public function test_can_disable_fit_on_failure()
     {
         $this->browser->fitOnFailure = true;

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -198,6 +198,20 @@ class BrowserTest extends TestCase
 
         $this->assertFileExists(Browser::$storeScreenshotsAt.'/'.$name.'.png');
     }
+
+    public function test_source()
+    {
+        $this->driver->shouldReceive('getPageSource')->andReturn('source content');
+
+        Browser::$storeSourceAt = sys_get_temp_dir();
+
+        $this->browser->storeSource(
+            $name = 'screenshot-01'
+        );
+
+        $this->assertFileExists(Browser::$storeSourceAt.'/'.$name.'.txt');
+        $this->assertStringEqualsFile(Browser::$storeSourceAt.'/'.$name.'.txt', 'source content');
+    }
 }
 
 class BrowserTestPage extends Page

--- a/tests/ProvidesBrowserTest.php
+++ b/tests/ProvidesBrowserTest.php
@@ -39,6 +39,17 @@ class ProvidesBrowserTest extends TestCase
         $this->storeConsoleLogsFor($browsers);
     }
 
+    public function test_store_source_for()
+    {
+        $browser = m::mock(stdClass::class);
+        $browser->shouldReceive('storeSource')->with(
+            'Laravel_Dusk_Tests_ProvidesBrowserTest_test_store_source_for-0'
+        );
+        $browsers = collect([$browser]);
+
+        $this->storeSourceFor($browsers);
+    }
+
     public function testData()
     {
         return [


### PR DESCRIPTION
I can't tell you how many times I've clicked on the screenshot of a failed test trying to interact with it...

This will allow us to dig through the full source code of the browser at the point in time of the failures, which can help with debugging.

---

2 questions to ask:

- Should we store the source only on failures or for all tests? Currently I'm storing it for **all** tests.
- What extension should we use for the file? For now I picked `.txt`, but I'm considering `.html`.

---

My grand master plan is to maybe proxy this code somehow so people can pull up the failure in their browser and ***actually*** interact with it.