### PR TITLE
[5.x] add "waitUntilMissingText"

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -71,6 +71,25 @@ trait WaitsForElements
     }
 
     /**
+     * Wait for the given text to be removed.
+     *
+     * @param  string  $text
+     * @param  int  $seconds
+     * @return $this
+     * @throws \Facebook\WebDriver\Exception\TimeOutException
+     */
+    public function waitUntilMissingText($text, $seconds = null)
+    {
+        $text = Arr::wrap($text);
+
+        $message = $this->formatTimeOutMessage('Waited %s seconds for removal of text', implode("', '", $text));
+
+        return $this->waitUsing($seconds, 100, function () use ($text) {
+            return ! Str::contains($this->resolver->findOrFail('')->getText(), $text);
+        }, $message);
+    }
+
+    /**
      * Wait for the given text to be visible.
      *
      * @param  array|string  $text

--- a/tests/WaitsForElementsTest.php
+++ b/tests/WaitsForElementsTest.php
@@ -95,6 +95,19 @@ class WaitsForElementsTest extends TestCase
         $browser->waitForText('Discount: 20%');
     }
 
+    public function test_can_wait_for_text_to_go_missing()
+    {
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getText')
+            ->times(3)
+            ->andReturn('Discount: 20%', 'Discount: 20%', 'SOLD OUT!');
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('findOrFail')->with('')->andReturn($element);
+        $browser = new Browser(new stdClass, $resolver);
+
+        $browser->waitUntilMissingText('Discount: 20%');
+    }
+
     public function test_wait_for_text_failure_message_containing_a_percent_character()
     {
         $element = m::mock(stdClass::class);


### PR DESCRIPTION
I'm using `waitForText` to ensure a modal has opened. But after closing the modal, there is no opposite method to wait until the modal has disappeared.