### PR TITLE
[5.0] add ability to store source from browser

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -391,6 +391,7 @@ class Browser
                 sprintf('%s/%s.txt', rtrim(static::$storeSourceAt, '/'), $name), $source
             );
         }
+
         return $this;
     }
 

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -47,6 +47,13 @@ class Browser
     public static $storeConsoleLogAt;
 
     /**
+     * The directory that will contain any source files.
+     *
+     * @var string
+     */
+    public static $storeSourceAt;
+
+    /**
      * The browsers that support retrieving logs.
      *
      * @var array
@@ -366,6 +373,24 @@ class Browser
             }
         }
 
+        return $this;
+    }
+
+    /**
+     * Store the source with the given name.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function source($name)
+    {
+        $source = $this->driver->getPageSource();
+
+        if (! empty($source)) {
+            file_put_contents(
+                sprintf('%s/%s.txt', rtrim(static::$storeSourceAt, '/'), $name), $source
+            );
+        }
         return $this;
     }
 

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -28,6 +28,8 @@ abstract class TestCase extends FoundationTestCase
 
         Browser::$storeConsoleLogAt = base_path('tests/Browser/console');
 
+        Browser::$storeSourceAt = base_path('tests/Browser/source');
+
         Browser::$userResolver = function () {
             return $this->user();
         };

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -214,6 +214,17 @@ class BrowserTest extends TestCase
 
         $this->assertTrue($this->browser->fitOnFailure);
     }
+
+    public function test_source()
+    {
+        $this->driver->shouldReceive('getPageSource')->andReturn('source content');
+        Browser::$storeSourceAt = sys_get_temp_dir();
+        $this->browser->source(
+            $name = 'screenshot-01'
+        );
+        $this->assertFileExists(Browser::$storeSourceAt.'/'.$name.'.txt');
+        $this->assertStringEqualsFile(Browser::$storeSourceAt.'/'.$name.'.txt', 'source content');
+    }
 }
 
 class BrowserTestPage extends Page


### PR DESCRIPTION
This is a resubmission of #705 

I still think there is value in automatically storing the source on failures, but since that was declined this PR just adds the ability to store the source on demand.