### PR TITLE
[6.0] Update ElementResolver.php

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -87,7 +87,7 @@ class ElementResolver
         }
 
         return $this->firstOrFail([
-            $field, "input[name='{$field}']", "textarea[name='{$field}']",
+            "input[name='{$field}']", "textarea[name='{$field}']", $field,
         ]);
     }
 
@@ -106,7 +106,7 @@ class ElementResolver
         }
 
         return $this->firstOrFail([
-            $field, "select[name='{$field}']",
+            "select[name='{$field}']", $field,
         ]);
     }
 
@@ -155,7 +155,7 @@ class ElementResolver
         }
 
         return $this->firstOrFail([
-            $field, "input[type=radio][name='{$field}'][value='{$value}']",
+            "input[type=radio][name='{$field}'][value='{$value}']", $field,
         ]);
     }
 
@@ -185,7 +185,7 @@ class ElementResolver
         }
 
         return $this->firstOrFail([
-            $field, $selector,
+            $selector, $field,
         ]);
     }
 
@@ -204,7 +204,7 @@ class ElementResolver
         }
 
         return $this->firstOrFail([
-            $field, "input[type=file][name='{$field}']",
+            "input[type=file][name='{$field}']", $field,
         ]);
     }
 
@@ -223,8 +223,8 @@ class ElementResolver
         }
 
         return $this->firstOrFail([
-            $field, "input[name='{$field}']", "textarea[name='{$field}']",
-            "select[name='{$field}']", "button[name='{$field}']",
+            "input[name='{$field}']", "textarea[name='{$field}']",
+            "select[name='{$field}']", "button[name='{$field}']", $field,
         ]);
     }
 


### PR DESCRIPTION
### Problem

If a Dusk form input name matches an HTML tag, it will cause issues.

```html
<html>
<head>
<link></link>
</head>
<body>
     <input name="link" />
</body>
</html>
```

```php
$browser->type('link', 'https://laravel.com');
```

The web driver will match the `<link>` element, not the `<input>` element, and the user will get the confusing "element not interactable" error message.

The current work around for this is to use an ID selector:

```php
$browser->type('#link', 'https://laravel.com');
```

### Solution

If we move the generic `$field` selector to the end of our `firstOrFail` list, the appropriate form elements will get priority to be selected.

In fact, our [documentation](https://laravel.com/docs/6.x/dusk#using-forms) explains the selection this way as well.

### 5.0 or 6.0

I was very tempted to send this to 5.0, but ultimately decided on master.  It was never documented that it would look for a tag of the field name, and I can't imagine anyone would target a non-interactible element to send input to, but the behavior of the code is changed.

If you guys feel it doesn't constitute a breaking change, I can re-target.