### PR TITLE
[5.0] Cast boolean values to appropriate string

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -187,6 +187,11 @@ trait InteractsWithElements
         if (is_null($value)) {
             $options[array_rand($options)]->click();
         } else {
+            
+            if (is_bool($value)) {
+                $value = $value ? '1' : '0';
+            }
+            
             foreach ($options as $option) {
                 if ((string) $option->getAttribute('value') === (string) $value) {
                     $option->click();

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -187,7 +187,6 @@ trait InteractsWithElements
         if (is_null($value)) {
             $options[array_rand($options)]->click();
         } else {
-            
             if (is_bool($value)) {
                 $value = $value ? '1' : '0';
             }


### PR DESCRIPTION
boolean `true` cast to a string is "1", while boolean `false` cast to a string is an empty string.

If you try to select an element that your model has set as `false` it will most likely fail because the value of your `<option>` will not be an empty string

```php
class Site extends Model
{
    $casts = [
        'enabled' => 'boolean',
    ];
}

$browser->select('enabled', $site->enabled);
```

```blade
 <select name="enabled">
    @foreach(['no', 'yes'] as $key => $option)
        <option value="{{ $key }}">{{ ucwords($option) }}</option>
    @endforeach
</select>
```