### PR TITLE
[5.0] Update `fitContent()`

### DIFF
--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -137,6 +137,8 @@ trait ProvidesBrowser
     protected function captureFailuresFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
+            $browser->driver->switchTo()->defaultContent();
+
             if (property_exists($browser, 'fitOnFailure') && $browser->fitOnFailure) {
                 $browser->fitContent();
             }


### PR DESCRIPTION
if the user is in an iframe when a failure occurs, `fitContent()` will grab the dimensions of the *iframe* body, not the *root* body that we actually want.

this change makes sure we switch back to the default scope before resizing the browser to fit the content.

I played around with a couple different places to place this, and ended up here. Other options were:

https://github.com/laravel/dusk/blob/5.0/src/Browser.php#L271
https://github.com/laravel/dusk/blob/5.0/src/Concerns/ProvidesBrowser.php#L141

Open to discussion if this should be moved, since I don't use Iframes, but I'm pretty sure in any of these 3 spots it behaves basically identically.

this fixes #715 