### PR TITLE
[5.0] update `fitContent()`

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -268,6 +268,8 @@ class Browser
      */
     public function fitContent()
     {
+        $this->driver->switchTo()->defaultContent();
+
         $body = $this->driver->findElement(WebDriverBy::tagName('body'));
 
         if (! empty($body)) {


### PR DESCRIPTION
if the user is in an iframe when a failure occurs, `fitContent()` will grab the dimensions of the *iframe* body, not the *root* body that we actually want.

this change makes sure we switch back to the default scope before resizing the browser to fit the content.