### PR TITLE
Rename php-webdriver package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.1.0",
         "ext-json": "*",
         "ext-zip": "*",
-        "facebook/webdriver": "^1.7",
+        "php-webdriver/webdriver": "^1.7",
         "nesbot/carbon": "^1.20|^2.0",
         "illuminate/console": "~5.7.0|~5.8.0|^6.0|^7.0",
         "illuminate/support": "~5.7.0|~5.8.0|^6.0|^7.0",


### PR DESCRIPTION
Php-webdriver package [has been renamed](https://github.com/php-webdriver/php-webdriver/issues/730#issuecomment-575601572) and the original is now marked as abandoned.

Fixes #718