### PR TITLE
[5.0] Add InteractsWithMouse@clickByXPath

### DIFF
--- a/src/Concerns/InteractsWithMouse.php
+++ b/src/Concerns/InteractsWithMouse.php
@@ -53,6 +53,21 @@ trait InteractsWithMouse
 
         return $this;
     }
+    
+    /**
+     * Click the element at the given XPath expression.
+     *
+     * @param  string  $selector
+     * @return $this
+     */
+    public function clickByXPath($expression)
+    {
+        $this->driver
+            ->findElement(WebDriverBy::xpath($expression))
+            ->click();
+
+        return $this;
+    }
 
     /**
      * Perform a mouse click and hold the mouse button down.

--- a/src/Concerns/InteractsWithMouse.php
+++ b/src/Concerns/InteractsWithMouse.php
@@ -53,7 +53,7 @@ trait InteractsWithMouse
 
         return $this;
     }
-    
+
     /**
      * Click the element at the given XPath expression.
      *


### PR DESCRIPTION
`clickByXPath()` method could be useful if you want to click on the element by its XPath rather than CSS selector.

Resolves #69 