### PR TITLE
[5.x] Add ProvidesBrowser::getBrowserCallerName();

### DIFF
--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -141,7 +141,7 @@ trait ProvidesBrowser
                 $browser->fitContent();
             }
 
-            $name = str_replace('\\', '_', get_class($this)).'_'.$this->getName(false);
+            $name = str_replace('\\', '_', get_class($this)).'_'.$this->getBrowserCallerName();
 
             $browser->screenshot('failure-'.$name.'-'.$key);
         });
@@ -156,7 +156,7 @@ trait ProvidesBrowser
     protected function storeConsoleLogsFor($browsers)
     {
         $browsers->each(function ($browser, $key) {
-            $name = str_replace('\\', '_', get_class($this)).'_'.$this->getName(false);
+            $name = str_replace('\\', '_', get_class($this)).'_'.$this->getBrowserCallerName();
 
             $browser->storeConsoleLog($name.'-'.$key);
         });
@@ -199,6 +199,20 @@ trait ProvidesBrowser
         return retry(5, function () {
             return $this->driver();
         }, 50);
+    }
+
+    /**
+     * Get the browser caller name.
+     *
+     * @return string
+     */
+    protected function getBrowserCallerName()
+    {
+        if (! method_exists($this, 'getName')) {
+            throw new RuntimeException('Override getBrowserCallerName() method to use ProvidesBrowser outside of PHPUnit');
+        }
+
+        return $this->getName(false);
     }
 
     /**


### PR DESCRIPTION
This would allow better support when we need to use `laravel/dusk` outside of `PHPUnit\Framework\TestCase`.

`getName(false)` is an internal `PHPUnit\Framework\TestCase` method.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
