### PR TITLE
[5.0] Fit content to `<html>` instead of `<body>`

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -270,10 +270,10 @@ class Browser
     {
         $this->driver->switchTo()->defaultContent();
 
-        $body = $this->driver->findElement(WebDriverBy::tagName('body'));
+        $html = $this->driver->findElement(WebDriverBy::tagName('html'));
 
-        if (! empty($body)) {
-            $this->resize($body->getSize()->getWidth(), $body->getSize()->getHeight());
+        if (! empty($html)) {
+            $this->resize($html->getSize()->getWidth(), $html->getSize()->getHeight());
         }
 
         return $this;


### PR DESCRIPTION
most browsers apply a margin of 8px to the `<body>` tag automatically. it's very common for most CSS frameworks to "normalize" this to zero, which is why for most people the <body> size and the <html> size are the same.

since it's not the case for everyone, we can use the <html> size here instead.

I had run across this randomly in some tests, but didn't think anyone else would actually come across this, so I left it alone, but I guess we can update it now.

This is most likely the solution for #719 