### PR TITLE
[5.0] Adds the missing import for InteractsWithMouse@clickAtXPath

### DIFF
--- a/src/Concerns/InteractsWithMouse.php
+++ b/src/Concerns/InteractsWithMouse.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Dusk\Concerns;
 
-use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\Interactions\WebDriverActions;
+use Facebook\WebDriver\WebDriverBy;
 
 trait InteractsWithMouse
 {

--- a/src/Concerns/InteractsWithMouse.php
+++ b/src/Concerns/InteractsWithMouse.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Dusk\Concerns;
 
+use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\Interactions\WebDriverActions;
 
 trait InteractsWithMouse


### PR DESCRIPTION
#723 was merged but I forgot to add the `use` statement for `WebDriverBy` there.
This PR fixes it.

Sorry.