### PR TITLE
[5.x] Lock php-webdriver constraints for now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.1.0",
         "ext-json": "*",
         "ext-zip": "*",
-        "php-webdriver/webdriver": "^1.7",
+        "php-webdriver/webdriver": "^1.7 <1.8",
         "nesbot/carbon": "^1.20|^2.0",
         "illuminate/console": "~5.7.0|~5.8.0|^6.0|^7.0",
         "illuminate/support": "~5.7.0|~5.8.0|^6.0|^7.0",


### PR DESCRIPTION
This locks the constraints for now until the php-webdriver issues are fixed.