### PR TITLE
[5.x] Bugfix quoting for InteractsWithElements::value

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -66,7 +66,7 @@ trait InteractsWithElements
         $selector = $this->resolver->format($selector);
 
         $this->driver->executeScript(
-            "document.querySelector(" . json_encode($selector) . ").value = " . json_encode($value) . ";"
+            'document.querySelector('.json_encode($selector).').value = '.json_encode($value).';'
         );
 
         return $this;

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -66,7 +66,7 @@ trait InteractsWithElements
         $selector = $this->resolver->format($selector);
 
         $this->driver->executeScript(
-            "document.querySelector('{$selector}').value = '{$value}';"
+            "document.querySelector(" . json_encode($selector) . ").value = " . json_encode($value) . ";"
         );
 
         return $this;

--- a/tests/Concerns/InteractsWithElementsTest.php
+++ b/tests/Concerns/InteractsWithElementsTest.php
@@ -41,8 +41,8 @@ class InteractsWithElementsTest extends TestCase
     {
         parent::setUp();
 
-        $this->resolver = $this->getMockBuilder(ElementResolver::class)->onlyMethods(['findOrFail', 'format'])->disableOriginalConstructor()->getMock();
-        $this->driver = $this->getMockBuilder(RemoteWebDriver::class)->onlyMethods(['executeScript'])->disableOriginalConstructor()->getMock();
+        $this->resolver = $this->getMockBuilder(ElementResolver::class)->setMethods(['findOrFail', 'format'])->disableOriginalConstructor()->getMock();
+        $this->driver = $this->getMockBuilder(RemoteWebDriver::class)->setMethods(['executeScript'])->disableOriginalConstructor()->getMock();
 
         $this->trait = new class($this->resolver, $this->driver) {
             use InteractsWithElements;
@@ -98,13 +98,13 @@ class InteractsWithElementsTest extends TestCase
         $selector = '#nuff';
 
         /** @var RemoteWebElement|MockObject $resolver */
-        $remoteElement = $this->getMockBuilder(RemoteWebElement::class)->onlyMethods(['getAttribute'])->disableOriginalConstructor()->getMock();
+        $remoteElement = $this->getMockBuilder(RemoteWebElement::class)->setMethods(['getAttribute'])->disableOriginalConstructor()->getMock();
         $remoteElement->expects(static::once())->method('getAttribute')->with('value')->willReturn('null');
 
         $this->resolver->expects(static::once())->method('findOrFail')->with($selector)->willReturn($remoteElement);
         $this->resolver->expects(static::never())->method('format');
 
-        $this->driver = $this->getMockBuilder(RemoteWebDriver::class)->onlyMethods(['executeScript'])->disableOriginalConstructor()->getMock();
+        $this->driver = $this->getMockBuilder(RemoteWebDriver::class)->setMethods(['executeScript'])->disableOriginalConstructor()->getMock();
         $this->driver->expects(static::never())->method('executeScript');
 
         static::assertSame('null', $this->trait->value($selector));

--- a/tests/Concerns/InteractsWithElementsTest.php
+++ b/tests/Concerns/InteractsWithElementsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Laravel\Dusk\Tests\Conserns;
+
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Facebook\WebDriver\Remote\RemoteWebElement;
+use Laravel\Dusk\Concerns\InteractsWithElements;
+use Laravel\Dusk\ElementResolver;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Laravel\Dusk\Concerns\InteractsWithElements
+ */
+class InteractsWithElementsTest extends TestCase
+{
+    /** @var InteractsWithElements */
+    protected $trait;
+
+    /** @var ElementResolver|MockObject */
+    protected $resolver;
+
+    /** @var RemoteWebDriver|MockObject */
+    protected $driver;
+
+    public function dataProviderValueWithValue()
+    {
+        return [
+            ['#nuff', 'narf', 'document.querySelector("#nuff").value = "narf";'],
+            ['#nu\'ff', 'n\'arf', 'document.querySelector("#nu\'ff").value = "n\'arf";'],
+            ['#nu"ff', 'n"arf', 'document.querySelector("#nu\\"ff").value = "n\\"arf";'],
+            ["#\nuff", "\narf", 'document.querySelector("#\\nuff").value = "\\narf";'],
+            ["#\nuff\xc3\xa9", "\narf\xc3\xa9", 'document.querySelector("#\\nuff\u00e9").value = "\\narf\u00e9";'],
+            [42, false, 'document.querySelector(42).value = false;'],
+            ['a', ['x' => 'y'], 'document.querySelector("a").value = {"x":"y"};'],
+            ['a', ['y'], 'document.querySelector("a").value = ["y"];'],
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resolver = $this->getMockBuilder(ElementResolver::class)->onlyMethods(['findOrFail', 'format'])->disableOriginalConstructor()->getMock();
+        $this->driver = $this->getMockBuilder(RemoteWebDriver::class)->onlyMethods(['executeScript'])->disableOriginalConstructor()->getMock();
+
+        $this->trait = new class($this->resolver, $this->driver) {
+            use InteractsWithElements;
+
+            /** @var ElementResolver|MockObject */
+            public $resolver;
+
+            /** @var RemoteWebDriver|MockObject */
+            public $driver;
+
+            public function __construct(ElementResolver $resolver, RemoteWebDriver $driver)
+            {
+                $this->resolver = $resolver;
+                $this->driver = $driver;
+            }
+        };
+    }
+
+    protected function tearDown(): void
+    {
+        $this->trait->resolver = null;
+        $this->trait->driver = null;
+        $this->trait = null;
+
+        $this->resolver = null;
+        $this->driver = null;
+
+        parent::tearDown();
+    }
+
+    /**
+     * @covers ::value
+     * @dataProvider dataProviderValueWithValue
+     * @param mixed $selector
+     * @param mixed $value
+     * @param string $js
+     */
+    public function testValueWithValue($selector, $value, string $js)
+    {
+        $this->resolver->expects(static::never())->method('findOrFail');
+        $this->resolver->expects(static::once())->method('format')->with($selector)->willReturn($selector);
+
+        $this->driver->expects(static::once())->method('executeScript')->with($js)->willReturn(42);
+
+        static::assertSame($this->trait, $this->trait->value($selector, $value));
+    }
+
+    /**
+     * @covers ::value
+     */
+    public function testValueWithoutValue()
+    {
+        $selector = '#nuff';
+
+        /** @var RemoteWebElement|MockObject $resolver */
+        $remoteElement = $this->getMockBuilder(RemoteWebElement::class)->onlyMethods(['getAttribute'])->disableOriginalConstructor()->getMock();
+        $remoteElement->expects(static::once())->method('getAttribute')->with('value')->willReturn('null');
+
+        $this->resolver->expects(static::once())->method('findOrFail')->with($selector)->willReturn($remoteElement);
+        $this->resolver->expects(static::never())->method('format');
+
+        $this->driver = $this->getMockBuilder(RemoteWebDriver::class)->onlyMethods(['executeScript'])->disableOriginalConstructor()->getMock();
+        $this->driver->expects(static::never())->method('executeScript');
+
+        static::assertSame('null', $this->trait->value($selector));
+    }
+}


### PR DESCRIPTION
This handles JS quoting a little bit better.

We found the bug for quoting of JS by calling the method InteractsWithElements::value.
If you call this method with  following arguments
- '#selector'
- 'abc\'def'
will break the generated JS code.

Then we found this pull request: https://github.com/laravel/dusk/pull/693 
But the pull request does not fully fix this problem. If you us an value, which has an line break, then the generated JS Code will break again.

This pull request fix this completely.
No breaking changes


The value function does not correctly escape the contents of $value variable as a result if someone passes a string even with a escaped single quote, the code breaks because value is assigned using single quotes on line 69 argument passed to executeScript,
"document.querySelector('{$selector}').value = '{$value}';"

$browser->value('my\'Field', "long text\nwith line breaks");
Current output of the script:
```js
document.querySelector('my\'Field').value = 'Field
s Name';
```
Expected output of the script:
```js
document.querySelector("my'Field").value ="long text\nwith line breaks";
```

Please take also a closer look at https://github.com/laravel/dusk/pull/734