### PR TITLE
[5.x] Update minimum webdriver version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.1.0",
         "ext-json": "*",
         "ext-zip": "*",
-        "php-webdriver/webdriver": "^1.7 <1.8",
+        "php-webdriver/webdriver": "^1.8.1",
         "nesbot/carbon": "^1.20|^2.0",
         "illuminate/console": "~5.7.0|~5.8.0|^6.0|^7.0",
         "illuminate/support": "~5.7.0|~5.8.0|^6.0|^7.0",


### PR DESCRIPTION
The issues are fixed so we can remove the constraint and require a new minimum version.