### PR TITLE
[5.x] Adds typeWithPauses(), appendWithPauses() methods

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -143,7 +143,7 @@ trait InteractsWithElements
 
         return $this;
     }
-    
+
     /**
      * Type the given value in the given field with pauses.
      *

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -143,6 +143,21 @@ trait InteractsWithElements
 
         return $this;
     }
+    
+    /**
+     * Type the given value in the given field with pauses.
+     *
+     * @param  string  $field
+     * @param  string  $value
+     * @param  int  $pause
+     * @return $this
+     */
+    public function typeWithPauses($field, $value, $pause = 100)
+    {
+        $this->clear($field)->appendWithPauses($field, $value, $pause);
+
+        return $this;
+    }
 
     /**
      * Type the given value in the given field without clearing it.
@@ -154,6 +169,23 @@ trait InteractsWithElements
     public function append($field, $value)
     {
         $this->resolver->resolveForTyping($field)->sendKeys($value);
+
+        return $this;
+    }
+
+    /**
+     * Type the given value in the given field with pauses without clearing it.
+     *
+     * @param  string  $field
+     * @param  string  $value
+     * @param  int  $pause
+     * @return $this
+     */
+    public function appendWithPauses($field, $value, $pause = 100)
+    {
+        foreach (str_split($value) as $char) {
+            $this->append($field, $char)->pause($pause);
+        }
 
         return $this;
     }

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -145,14 +145,14 @@ trait InteractsWithElements
     }
 
     /**
-     * Type the given value in the given field with pauses.
+     * Type the given value in the given field slowly.
      *
      * @param  string  $field
      * @param  string  $value
      * @param  int  $pause
      * @return $this
      */
-    public function typeWithPauses($field, $value, $pause = 100)
+    public function typeSlowly($field, $value, $pause = 100)
     {
         $this->clear($field)->appendWithPauses($field, $value, $pause);
 
@@ -174,14 +174,14 @@ trait InteractsWithElements
     }
 
     /**
-     * Type the given value in the given field with pauses without clearing it.
+     * Type the given value in the given field slowly without clearing it.
      *
      * @param  string  $field
      * @param  string  $value
      * @param  int  $pause
      * @return $this
      */
-    public function appendWithPauses($field, $value, $pause = 100)
+    public function appendSlowly($field, $value, $pause = 100)
     {
         foreach (str_split($value) as $char) {
             $this->append($field, $char)->pause($pause);


### PR DESCRIPTION
These methods allow you to type/append the values to the fields with pauses.

After the merging of this PR you'll be able to replace this:
```
->tap(function (Browser $browser) {
    foreach (str_split('+1 (202) 555-5555') as $char) {
        $browser->append('mobile', $char)->pause(100);
    }
})
```

With this:

```
->typeWithPauses('mobile', '+1 (202) 555-5555')
```

Motivation: https://github.com/laravel/dusk/issues/558#issuecomment-426462292