### PR TITLE
Fix Call to undefined method [appendWithPauses]

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -154,7 +154,7 @@ trait InteractsWithElements
      */
     public function typeSlowly($field, $value, $pause = 100)
     {
-        $this->clear($field)->appendWithPauses($field, $value, $pause);
+        $this->clear($field)->appendSlowly($field, $value, $pause);
 
         return $this;
     }


### PR DESCRIPTION
Currently the method typeSlowly throws a BadMethodCallException: Call to undefined method [appendWithPauses].

The cause of this is that the typeSlowly method should be calling the appendSlowly instead of appendWithPauses.

appendWithPauses was the old name as can be seen in this commit https://github.com/laravel/dusk/pull/748/commits/4e1e3871440ae48ce8eff35781cccd1073642885

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
