### PR TITLE
[5.x] Add assert attribute methods

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -549,6 +549,33 @@ JS;
     }
 
     /**
+     * Assert that the element at the given selector has the given attribute value.
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertAttribute($selector, $attribute, $value)
+    {
+        $fullSelector = $this->resolver->format($selector);
+
+        $actual = $this->resolver->findOrFail($selector)->getAttribute($attribute);
+
+        PHPUnit::assertNotNull(
+            $actual,
+            "Did not see expected attribute [{$attribute}] within element [{$fullSelector}]."
+        );
+
+        PHPUnit::assertEquals(
+            $value, $actual,
+            "Expected '$attribute' attribute [{$value}] does not equal actual value [$actual]."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the element with the given selector is visible.
      *
      * @param  string  $selector

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -576,6 +576,19 @@ JS;
     }
 
     /**
+     * Assert that the element at the given selector has the given data attribute value.
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertDataAttribute($selector, $attribute, $value)
+    {
+        return $this->assertAttribute($selector, 'data-' . $attribute, $value);
+    }
+
+    /**
      * Assert that the element with the given selector is visible.
      *
      * @param  string  $selector

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -589,6 +589,19 @@ JS;
     }
 
     /**
+     * Assert that the element at the given selector has the given aria attribute value.
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertAriaAttribute($selector, $attribute, $value)
+    {
+        return $this->assertAttribute($selector, 'aria-' . $attribute, $value);
+    }
+
+    /**
      * Assert that the element with the given selector is visible.
      *
      * @param  string  $selector

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -90,6 +90,43 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_data_attribute()
+    {
+        $driver = m::mock(stdClass::class);
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getAttribute')->with('data-bar')->andReturn(
+            'joe',
+            null,
+            'sue'
+        );
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('Foo');
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertDataAttribute('foo', 'bar', 'joe');
+
+        try {
+            $browser->assertDataAttribute('foo', 'bar', 'joe');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                "Did not see expected attribute [data-bar] within element [Foo].",
+                $e->getMessage()
+            );
+        }
+
+        try {
+            $browser->assertDataAttribute('foo', 'bar', 'joe');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                "Expected 'data-bar' attribute [joe] does not equal actual value [sue].",
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_present()
     {
         $driver = m::mock(stdClass::class);

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -53,6 +53,43 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_attribute()
+    {
+        $driver = m::mock(stdClass::class);
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getAttribute')->with('bar')->andReturn(
+            'joe',
+            null,
+            'sue'
+        );
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('Foo');
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertAttribute('foo', 'bar', 'joe');
+
+        try {
+            $browser->assertAttribute('foo', 'bar', 'joe');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                "Did not see expected attribute [bar] within element [Foo].",
+                $e->getMessage()
+            );
+        }
+
+        try {
+            $browser->assertAttribute('foo', 'bar', 'joe');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                "Expected 'bar' attribute [joe] does not equal actual value [sue].",
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_present()
     {
         $driver = m::mock(stdClass::class);

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -127,6 +127,43 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_aria_attribute()
+    {
+        $driver = m::mock(stdClass::class);
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getAttribute')->with('aria-bar')->andReturn(
+            'joe',
+            null,
+            'sue'
+        );
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('Foo');
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertAriaAttribute('foo', 'bar', 'joe');
+
+        try {
+            $browser->assertAriaAttribute('foo', 'bar', 'joe');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                "Did not see expected attribute [aria-bar] within element [Foo].",
+                $e->getMessage()
+            );
+        }
+
+        try {
+            $browser->assertAriaAttribute('foo', 'bar', 'joe');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                "Expected 'aria-bar' attribute [joe] does not equal actual value [sue].",
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_present()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
At the moment the only attribute we can check is the `value` attribute using the `asserValue`. This PR adds three new methods: `assertAttribute()`, `assertDataAttribute()` and `assertAriaAttribute().

I admit in my use case I would only need `assertAriaAttribute()`, but I think all three would be useful methods.

### Use case

I have a CRUD page where the button to add an item is a simple plus icon

![Screenshot from 2020-03-19 11-42-56](https://user-images.githubusercontent.com/11234160/77064133-d2df7880-69d6-11ea-92a9-9b30aba220c3.png)

Because it's just an icon, I use the `aria-label` attribute.

I want to test that not only the button is visible, but also that is has the correct attribute, but also that it contains the correct value.

