### PR TITLE
[5.x] PHPUnit 9 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,17 @@ jobs:
       matrix:
         php: [7.1, 7.2, 7.3, 7.4]
         laravel: [5.7.*, 5.8.*, ^6.0, ^7.0]
-        phpunit: [^7.5, ^8.0, ^9.0]
+        phpunit: [^7.5, ^8.0]
+        include:
+          - php: 7.2.29
+            laravel: ^7.0
+            phpunit: ^9.0
+          - php: 7.3
+            laravel: ^7.0
+            phpunit: ^9.0
+          - php: 7.4
+            laravel: ^7.0
+            phpunit: ^9.0
         exclude:
           - php: 7.1
             laravel: 5.7.*
@@ -35,9 +45,6 @@ jobs:
           - php: 7.1
             laravel: ^7.0
             phpunit: ^8.0
-          - php: 7.1
-            laravel: ^7.0
-            phpunit: ^9.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,18 +15,23 @@ jobs:
       matrix:
         php: [7.1, 7.2, 7.3, 7.4]
         laravel: [5.7.*, 5.8.*, ^6.0, ^7.0]
-        phpunit: [^7.5, ^8.0]
-        include:
-          - php: 7.2.29
-            laravel: ^7.0
-            phpunit: ^9.0
-          - php: 7.3
-            laravel: ^7.0
-            phpunit: ^9.0
-          - php: 7.4
-            laravel: ^7.0
-            phpunit: ^9.0
+        phpunit: [^7.5, ^8.0, ^9.0]
         exclude:
+          - php: 7.1
+            laravel: 5.7.*
+            phpunit: ^9.0
+          - php: 7.2
+            laravel: 5.7.*
+            phpunit: ^9.0
+          - php: 7.1
+            laravel: 5.8.*
+            phpunit: ^9.0
+          - php: 7.1
+            laravel: 5.9.*
+            phpunit: ^9.0
+          - php: 7.2
+            laravel: 5.9.*
+            phpunit: ^9.0
           - php: 7.1
             laravel: 5.7.*
             phpunit: ^8.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         php: [7.1, 7.2, 7.3, 7.4]
         laravel: [5.7.*, 5.8.*, ^6.0, ^7.0]
-        phpunit: [^7.5, ^8.0]
+        phpunit: [^7.5, ^8.0, ^9.0]
         exclude:
           - php: 7.1
             laravel: 5.7.*
@@ -35,6 +35,9 @@ jobs:
           - php: 7.1
             laravel: ^7.0
             phpunit: ^8.0
+          - php: 7.1
+            laravel: ^7.0
+            phpunit: ^9.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,11 +26,26 @@ jobs:
           - php: 7.1
             laravel: 5.8.*
             phpunit: ^9.0
+          - php: 7.2
+            laravel: 5.8.*
+            phpunit: ^9.0
           - php: 7.1
             laravel: 5.9.*
             phpunit: ^9.0
           - php: 7.2
             laravel: 5.9.*
+            phpunit: ^9.0
+          - php: 7.1
+            laravel: ^6.0
+            phpunit: ^9.0
+          - php: 7.2
+            laravel: ^6.0
+            phpunit: ^9.0
+          - php: 7.1
+            laravel: ^7.0
+            phpunit: ^9.0
+          - php: 7.2
+            laravel: ^7.0
             phpunit: ^9.0
           - php: 7.1
             laravel: 5.7.*

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.5|^8.0"
+        "phpunit/phpunit": "^7.5|^8.0|^9.0"
     },
     "suggest": {
         "ext-pcntl": "Used to gracefully terminate Dusk when tests are running."

--- a/src/Concerns/MakesUrlAssertions.php
+++ b/src/Concerns/MakesUrlAssertions.php
@@ -6,10 +6,6 @@ use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\Constraint\RegularExpression;
 
-/**
- * Trait MakesUrlAssertions.
- * @property \Facebook\WebDriver\Remote\RemoteWebDriver $driver
- */
 trait MakesUrlAssertions
 {
     /**

--- a/src/Concerns/MakesUrlAssertions.php
+++ b/src/Concerns/MakesUrlAssertions.php
@@ -7,8 +7,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\Constraint\RegularExpression;
 
 /**
- * Trait MakesUrlAssertions
- * @package Laravel\Dusk\Concerns
+ * Trait MakesUrlAssertions.
  * @property \Facebook\WebDriver\Remote\RemoteWebDriver $driver
  */
 trait MakesUrlAssertions

--- a/src/Concerns/MakesUrlAssertions.php
+++ b/src/Concerns/MakesUrlAssertions.php
@@ -127,7 +127,7 @@ trait MakesUrlAssertions
     {
         $pattern = str_replace('\*', '.*', preg_quote($port, '/'));
 
-        $actual = parse_url($this->driver->getCurrentURL(), PHP_URL_PORT) ?? '';
+        $actual = (string) parse_url($this->driver->getCurrentURL(), PHP_URL_PORT) ?? '';
 
         PHPUnit::assertThat(
             $actual, new RegularExpression('/^'.$pattern.'$/u'),

--- a/src/Concerns/MakesUrlAssertions.php
+++ b/src/Concerns/MakesUrlAssertions.php
@@ -4,7 +4,13 @@ namespace Laravel\Dusk\Concerns;
 
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert as PHPUnit;
+use PHPUnit\Framework\Constraint\RegularExpression;
 
+/**
+ * Trait MakesUrlAssertions
+ * @package Laravel\Dusk\Concerns
+ * @property \Facebook\WebDriver\Remote\RemoteWebDriver $driver
+ */
 trait MakesUrlAssertions
 {
     /**
@@ -27,10 +33,10 @@ trait MakesUrlAssertions
             Arr::get($segments, 'path', '')
         );
 
-        PHPUnit::assertRegExp(
-            '/^'.$pattern.'$/u', $currentUrl,
+        PHPUnit::assertThat(
+            $currentUrl, new RegularExpression('/^'.$pattern.'$/u'),
             "Actual URL [{$this->driver->getCurrentURL()}] does not equal expected URL [{$url}]."
-        );
+            );
 
         return $this;
     }
@@ -47,8 +53,8 @@ trait MakesUrlAssertions
 
         $actual = parse_url($this->driver->getCurrentURL(), PHP_URL_SCHEME) ?? '';
 
-        PHPUnit::assertRegExp(
-            '/^'.$pattern.'$/u', $actual,
+        PHPUnit::assertThat(
+            $actual, new RegularExpression('/^'.$pattern.'$/u'),
             "Actual scheme [{$actual}] does not equal expected scheme [{$pattern}]."
         );
 
@@ -85,8 +91,8 @@ trait MakesUrlAssertions
 
         $actual = parse_url($this->driver->getCurrentURL(), PHP_URL_HOST) ?? '';
 
-        PHPUnit::assertRegExp(
-            '/^'.$pattern.'$/u', $actual,
+        PHPUnit::assertThat(
+            $actual, new RegularExpression('/^'.$pattern.'$/u'),
             "Actual host [{$actual}] does not equal expected host [{$pattern}]."
         );
 
@@ -123,8 +129,8 @@ trait MakesUrlAssertions
 
         $actual = parse_url($this->driver->getCurrentURL(), PHP_URL_PORT) ?? '';
 
-        PHPUnit::assertRegExp(
-            '/^'.$pattern.'$/u', $actual,
+        PHPUnit::assertThat(
+            $actual, new RegularExpression('/^'.$pattern.'$/u'),
             "Actual port [{$actual}] does not equal expected port [{$pattern}]."
         );
 
@@ -161,8 +167,8 @@ trait MakesUrlAssertions
 
         $actualPath = parse_url($this->driver->getCurrentURL(), PHP_URL_PATH) ?? '';
 
-        PHPUnit::assertRegExp(
-            '/^'.$pattern.'$/u', $actualPath,
+        PHPUnit::assertThat(
+            $actualPath, new RegularExpression('/^'.$pattern.'$/u'),
             "Actual path [{$actualPath}] does not equal expected path [{$path}]."
         );
 
@@ -217,8 +223,8 @@ trait MakesUrlAssertions
 
         $actualFragment = (string) parse_url($this->driver->executeScript('return window.location.href;'), PHP_URL_FRAGMENT);
 
-        PHPUnit::assertRegExp(
-            '/^'.str_replace('\*', '.*', $pattern).'$/u', $actualFragment,
+        PHPUnit::assertThat(
+            $actualFragment, new RegularExpression('/^'.str_replace('\*', '.*', $pattern).'$/u'),
             "Actual fragment [{$actualFragment}] does not equal expected fragment [{$fragment}]."
         );
 


### PR DESCRIPTION
PHPUnit >= 9.1 deprecated the method assertRegExp instead of new one assertMatchesRegularExpression.