### PR TITLE
[6.x] Trim trailing slash

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -54,7 +54,7 @@ abstract class TestCase extends FoundationTestCase
      */
     protected function baseUrl()
     {
-        return config('app.url');
+        return rtrim(config('app.url'), '/');
     }
 
     /**


### PR DESCRIPTION
Because we recently removed support for `//` urls in Laravel, trailing slashes in APP_URL don't work anymore (nor should they). This will trim the trailing slash from the base url before setting it.

Fixes https://github.com/laravel/dusk/issues/763