### PR TITLE
[6.x] Uses Pest if available

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -88,11 +88,15 @@ class DuskCommand extends Command
      */
     protected function binary()
     {
+        $command = class_exists(\Pest\Laravel\PestServiceProvider::class)
+            ? 'vendor/pestphp/pest/bin/pest'
+            : 'vendor/phpunit/phpunit/phpunit';
+
         if ('phpdbg' === PHP_SAPI) {
-            return [PHP_BINARY, '-qrr', 'vendor/phpunit/phpunit/phpunit'];
+            return [PHP_BINARY, '-qrr', $command];
         }
 
-        return [PHP_BINARY, 'vendor/phpunit/phpunit/phpunit'];
+        return [PHP_BINARY, $command];
     }
 
     /**


### PR DESCRIPTION
In the future, if people install **Pest** in their Laravel applications, they most likely want to use it in their dusk tests too.

This pull request magically uses Pest if available, otherwise, it uses the default PHPUnit command.

Let me know if you prefer something more customizable like a config or something.