### PR TITLE
[6.x] Add dusk route prefix

### DIFF
--- a/src/Concerns/InteractsWithAuthentication.php
+++ b/src/Concerns/InteractsWithAuthentication.php
@@ -28,7 +28,7 @@ trait InteractsWithAuthentication
     {
         $userId = method_exists($userId, 'getKey') ? $userId->getKey() : $userId;
 
-        return $this->visit(rtrim('/_dusk/login/'.$userId.'/'.$guard, '/'));
+        return $this->visit(rtrim(route('dusk.login', ['userId' => $userId, 'guard' => $guard])));
     }
 
     /**
@@ -39,7 +39,7 @@ trait InteractsWithAuthentication
      */
     public function logout($guard = null)
     {
-        return $this->visit(rtrim('/_dusk/logout/'.$guard, '/'));
+        return $this->visit(rtrim(route('dusk.logout', ['guard' => $guard]), '/'));
     }
 
     /**
@@ -50,7 +50,7 @@ trait InteractsWithAuthentication
      */
     protected function currentUserInfo($guard = null)
     {
-        $response = $this->visit("/_dusk/user/{$guard}");
+        $response = $this->visit(route('dusk.user', ['guard' => $guard]));
 
         return json_decode(strip_tags($response->driver->getPageSource()), true);
     }

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -15,20 +15,25 @@ class DuskServiceProvider extends ServiceProvider
     public function boot()
     {
         if (! $this->app->environment('production')) {
-            Route::get('/_dusk/login/{userId}/{guard?}', [
-                'middleware' => 'web',
-                'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
-            ]);
+            Route::group(['prefix' => env('LARAVEL_DUSK_PATH', '_dusk')], function () {
+                Route::get('/login/{userId}/{guard?}', [
+                    'middleware' => 'web',
+                    'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
+                    'as' => 'dusk.login',
+                ]);
 
-            Route::get('/_dusk/logout/{guard?}', [
-                'middleware' => 'web',
-                'uses' => 'Laravel\Dusk\Http\Controllers\UserController@logout',
-            ]);
+                Route::get('/logout/{guard?}', [
+                    'middleware' => 'web',
+                    'uses' => 'Laravel\Dusk\Http\Controllers\UserController@logout',
+                    'as' => 'dusk.logout',
+                ]);
 
-            Route::get('/_dusk/user/{guard?}', [
-                'middleware' => 'web',
-                'uses' => 'Laravel\Dusk\Http\Controllers\UserController@user',
-            ]);
+                Route::get('/user/{guard?}', [
+                    'middleware' => 'web',
+                    'uses' => 'Laravel\Dusk\Http\Controllers\UserController@user',
+                    'as' => 'dusk.user',
+                ]);
+            });
         }
     }
 


### PR DESCRIPTION
The PR allows to set route prefix using `LARAVEL_DUSK_PATH` env parameter instead of hardcoding one as `_dusk`. 
I was inspired of that because our project is SPA application, so most requests should go to an `/api` prefix. 