### PR TITLE
[6.x] Configurable of Laravel dusk routes enhancement

### DIFF
--- a/config/dusk.php
+++ b/config/dusk.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Dusk Path
+    |--------------------------------------------------------------------------
+    |
+    | This is the URI path where Laravel dusk will locate its internal API routes.
+    |
+    */
+
+    'path' => '_dusk',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Dusk Domain
+    |--------------------------------------------------------------------------
+    |
+    | This is the subdomain where Dusk will access its internal API routes. If this
+    | setting is null, Dusk will reside under the same domain as the
+    | application. Otherwise, this value will serve as the subdomain.
+    |
+    */
+
+    'domain' => null,
+];

--- a/src/Concerns/InteractsWithAuthentication.php
+++ b/src/Concerns/InteractsWithAuthentication.php
@@ -28,7 +28,7 @@ trait InteractsWithAuthentication
     {
         $userId = method_exists($userId, 'getKey') ? $userId->getKey() : $userId;
 
-        return $this->visit(rtrim('/_dusk/login/'.$userId.'/'.$guard, '/'));
+        return $this->visit(rtrim(route('dusk.login', ['userId' => $userId, 'guard' => $guard])));
     }
 
     /**
@@ -39,7 +39,7 @@ trait InteractsWithAuthentication
      */
     public function logout($guard = null)
     {
-        return $this->visit(rtrim('/_dusk/logout/'.$guard, '/'));
+        return $this->visit(rtrim(route('dusk.logout', ['guard' => $guard]), '/'));
     }
 
     /**
@@ -50,7 +50,7 @@ trait InteractsWithAuthentication
      */
     protected function currentUserInfo($guard = null)
     {
-        $response = $this->visit("/_dusk/user/{$guard}");
+        $response = $this->visit(route('dusk.user', ['guard' => $guard]));
 
         return json_decode(strip_tags($response->driver->getPageSource()), true);
     }

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -15,20 +15,25 @@ class DuskServiceProvider extends ServiceProvider
     public function boot()
     {
         if (! $this->app->environment('production')) {
-            Route::get('/_dusk/login/{userId}/{guard?}', [
-                'middleware' => 'web',
-                'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
-            ]);
+            Route::group(['prefix' => env('LARAVEL_DUSK_PATH', '_dusk')], function () {
+                Route::get('/login/{userId}/{guard?}', [
+                    'middleware' => 'web',
+                    'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
+                    'as' => 'dusk.login',
+                ]);
 
-            Route::get('/_dusk/logout/{guard?}', [
-                'middleware' => 'web',
-                'uses' => 'Laravel\Dusk\Http\Controllers\UserController@logout',
-            ]);
+                Route::get('/logout/{guard?}', [
+                    'middleware' => 'web',
+                    'uses' => 'Laravel\Dusk\Http\Controllers\UserController@logout',
+                    'as' => 'dusk.logout',
+                ]);
 
-            Route::get('/_dusk/user/{guard?}', [
-                'middleware' => 'web',
-                'uses' => 'Laravel\Dusk\Http\Controllers\UserController@user',
-            ]);
+                Route::get('/user/{guard?}', [
+                    'middleware' => 'web',
+                    'uses' => 'Laravel\Dusk\Http\Controllers\UserController@user',
+                    'as' => 'dusk.user',
+                ]);
+            });
         }
     }
 

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -18,21 +18,19 @@ class DuskServiceProvider extends ServiceProvider
             Route::group([
                 'prefix' => config('dusk.path'),
                 'domain' => config('dusk.domain', null),
+                'middleware' => 'web',
             ], function () {
                     Route::get('/login/{userId}/{guard?}', [
-                        'middleware' => 'web',
                         'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
                         'as' => 'dusk.login',
                     ]);
 
                     Route::get('/logout/{guard?}', [
-                        'middleware' => 'web',
                         'uses' => 'Laravel\Dusk\Http\Controllers\UserController@logout',
                         'as' => 'dusk.logout',
                     ]);
 
                     Route::get('/user/{guard?}', [
-                        'middleware' => 'web',
                         'uses' => 'Laravel\Dusk\Http\Controllers\UserController@user',
                         'as' => 'dusk.user',
                     ]);

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -15,7 +15,10 @@ class DuskServiceProvider extends ServiceProvider
     public function boot()
     {
         if (! $this->app->environment('production')) {
-            Route::group(['prefix' => env('LARAVEL_DUSK_PATH', '_dusk')], function () {
+            Route::group([
+                'prefix' => config('dusk.path'),
+                'domain' => config('dusk.domain', null),
+                ], function () {
                 Route::get('/login/{userId}/{guard?}', [
                     'middleware' => 'web',
                     'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
@@ -46,16 +49,23 @@ class DuskServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if ($this->app->runningInConsole()) {
-            $this->commands([
-                Console\InstallCommand::class,
-                Console\DuskCommand::class,
-                Console\DuskFailsCommand::class,
-                Console\MakeCommand::class,
-                Console\PageCommand::class,
-                Console\ComponentCommand::class,
-                Console\ChromeDriverCommand::class,
-            ]);
+        if (! $this->app->environment('production')) {
+            $this->mergeConfigFrom(__DIR__.'/../config/dusk.php', 'dusk');
+            $this->publishes([
+                __DIR__.'/../config/dusk.php' => config_path('dusk.php'),
+            ], 'dusk-config');
+
+            if ($this->app->runningInConsole()) {
+                $this->commands([
+                    Console\InstallCommand::class,
+                    Console\DuskCommand::class,
+                    Console\DuskFailsCommand::class,
+                    Console\MakeCommand::class,
+                    Console\PageCommand::class,
+                    Console\ComponentCommand::class,
+                    Console\ChromeDriverCommand::class,
+                ]);
+            }
         }
     }
 }

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -18,25 +18,25 @@ class DuskServiceProvider extends ServiceProvider
             Route::group([
                 'prefix' => config('dusk.path'),
                 'domain' => config('dusk.domain', null),
-                ], function () {
-                Route::get('/login/{userId}/{guard?}', [
-                    'middleware' => 'web',
-                    'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
-                    'as' => 'dusk.login',
-                ]);
+            ], function () {
+                    Route::get('/login/{userId}/{guard?}', [
+                        'middleware' => 'web',
+                        'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
+                        'as' => 'dusk.login',
+                    ]);
 
-                Route::get('/logout/{guard?}', [
-                    'middleware' => 'web',
-                    'uses' => 'Laravel\Dusk\Http\Controllers\UserController@logout',
-                    'as' => 'dusk.logout',
-                ]);
+                    Route::get('/logout/{guard?}', [
+                        'middleware' => 'web',
+                        'uses' => 'Laravel\Dusk\Http\Controllers\UserController@logout',
+                        'as' => 'dusk.logout',
+                    ]);
 
-                Route::get('/user/{guard?}', [
-                    'middleware' => 'web',
-                    'uses' => 'Laravel\Dusk\Http\Controllers\UserController@user',
-                    'as' => 'dusk.user',
-                ]);
-            });
+                    Route::get('/user/{guard?}', [
+                        'middleware' => 'web',
+                        'uses' => 'Laravel\Dusk\Http\Controllers\UserController@user',
+                        'as' => 'dusk.user',
+                    ]);
+                });
         }
     }
 

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -20,21 +20,21 @@ class DuskServiceProvider extends ServiceProvider
                 'domain' => config('dusk.domain', null),
                 'middleware' => 'web',
             ], function () {
-                    Route::get('/login/{userId}/{guard?}', [
-                        'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
-                        'as' => 'dusk.login',
-                    ]);
+                Route::get('/login/{userId}/{guard?}', [
+                    'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',
+                    'as' => 'dusk.login',
+                ]);
 
-                    Route::get('/logout/{guard?}', [
-                        'uses' => 'Laravel\Dusk\Http\Controllers\UserController@logout',
-                        'as' => 'dusk.logout',
-                    ]);
+                Route::get('/logout/{guard?}', [
+                    'uses' => 'Laravel\Dusk\Http\Controllers\UserController@logout',
+                    'as' => 'dusk.logout',
+                ]);
 
-                    Route::get('/user/{guard?}', [
-                        'uses' => 'Laravel\Dusk\Http\Controllers\UserController@user',
-                        'as' => 'dusk.user',
-                    ]);
-                });
+                Route::get('/user/{guard?}', [
+                    'uses' => 'Laravel\Dusk\Http\Controllers\UserController@user',
+                    'as' => 'dusk.user',
+                ]);
+            });
         }
     }
 


### PR DESCRIPTION
Continue declined PR https://github.com/laravel/dusk/pull/772
Resolve an issue  https://github.com/laravel/dusk/issues/773

> The issue I mean is Laravel dusk can't work with a separated backend and frontend.
> For example, frontend (SPA) is located on "example.com", backend - "api.example.com".
> Since Dusk's API internal methods will call example.com/_dusk/... methods, it is not reachable on this service.
> So I searched a way how to configure it, but currently it is not possible. Routes are hardcoded.

I improved the PR by adding config file, so in future it can be used in future for resolving issues like https://github.com/laravel/dusk/issues/393