### PR TITLE
[6.x] Fix for cookie assertions

### DIFF
--- a/src/Concerns/InteractsWithCookies.php
+++ b/src/Concerns/InteractsWithCookies.php
@@ -3,6 +3,7 @@
 namespace Laravel\Dusk\Concerns;
 
 use DateTimeInterface;
+use Facebook\WebDriver\Exception\NoSuchCookieException;
 
 trait InteractsWithCookies
 {
@@ -21,7 +22,13 @@ trait InteractsWithCookies
             return $this->addCookie($name, $value, $expiry, $options);
         }
 
-        if ($cookie = $this->driver->manage()->getCookieNamed($name)) {
+        try {
+            $cookie = $this->driver->manage()->getCookieNamed($name);
+        } catch (NoSuchCookieException $e) {
+            $cookie = null;
+        }
+
+        if ($cookie) {
             return decrypt(rawurldecode($cookie['value']), $unserialize = false);
         }
     }
@@ -41,7 +48,13 @@ trait InteractsWithCookies
             return $this->addCookie($name, $value, $expiry, $options, false);
         }
 
-        if ($cookie = $this->driver->manage()->getCookieNamed($name)) {
+        try {
+            $cookie = $this->driver->manage()->getCookieNamed($name);
+        } catch (NoSuchCookieException $e) {
+            $cookie = null;
+        }
+
+        if ($cookie) {
             return rawurldecode($cookie['value']);
         }
     }


### PR DESCRIPTION
Starting with version 1.8.0 of the web driver a [NoSuchCookieException](https://github.com/php-webdriver/php-webdriver/blob/master/lib/WebDriverOptions.php#L98) is thrown when there are no matching cookies and isW3cCompliant is true.

This exception prevents the cookie assertions (assertHasCookie, assertHasPlainCookie, assertCookieMissing, assertPlainCookieMissing, assertCookieValue and assertPlainCookieValue) from behaving as expected.