### PR TITLE
[6.x] Support executing closures outside of the current selector scope

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -481,6 +481,32 @@ class Browser
     }
 
     /**
+     * Execute a Closure outside of the current browser scope.
+     *
+     * @param  string  $selector
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function elsewhere($selector, Closure $callback)
+    {
+        $browser = new static(
+            $this->driver, new ElementResolver($this->driver, 'body ' . $selector)
+        );
+
+        if ($this->page) {
+            $browser->onWithoutAssert($this->page);
+        }
+
+        if ($selector instanceof Component) {
+            $browser->onComponent($selector, $this->resolver);
+        }
+
+        call_user_func($callback, $browser);
+
+        return $this;
+    }
+
+    /**
      * Set the current component state.
      *
      * @param  \Laravel\Dusk\Component  $component

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -135,6 +135,19 @@ class BrowserTest extends TestCase
         });
     }
 
+    public function test_elsewhere_method()
+    {
+        $driver = m::mock(stdClass::class);
+        $browser = new Browser($driver);
+
+        $browser->with('prefix', function ($browser) {
+            $browser->elsewhere('.my-class', function($browser) {
+                $this->assertInstanceof(Browser::class, $browser);
+                $this->assertEquals('body .my-class', $browser->resolver->prefix);
+            });
+        });
+    }
+
     public function test_page_macros()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
There are scenarios, particularly when writing logic to encapsulate components that don't necessarily have a linear structure in the dom, that you might want to run certain logic outside of your current selector scope. This function simply executes a closure outside of the current scope.

Consider the following html generated from a js component from a popular react framework:
```html
<div class="mui-select">
   <label>My Label</label>
   <div>...input display</div>
</div>

... other portions of the page

<div class="mui-menu">
  <ul>
     <li class="select-option">1</li>
     <li class="select-option">2</li>
     <li class="select-option">3</li>
  </ul>
</div>
```

To interact with this component before you had to do something like this: 

```php
public function selectFromDropdown(Browser $browser, string $value)
{ 
    $prefix = $browser->resolver->prefix;
    $browser->resolver->prefix = "";
    $browser->within('.mui-menu', function ($browser) use ($value) {
           // do unscoped stuff
     });
    $browser->resolver->prefix = $prefix;
}
```

Now the code will look something like this:

```php
public function selectFromDropdown(Browser $browser, string $value)
{ 
    $browser->elsewhere('.mui-menu', function ($browser) use ($value) {
        // do unscoped stuff 
    }); 
}
```


Closes #783 