### PR TITLE
[6.x] Support clicking the topmost element at a given pair of coordinates

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -190,6 +190,20 @@ class Browser
     }
 
     /**
+     * Click the topmost element at the given pair of coordinates.
+     *
+     * @param  int  $x
+     * @param  int  $y
+     * @return $this
+     */
+    public function clickAtPoint($x, $y)
+    {
+        $this->driver->executeScript("document.elementFromPoint({$x}, {$y}).click()");
+
+        return $this;
+    }
+
+    /**
      * Set the current page object without executing the assertions.
      *
      * @param  mixed  $page


### PR DESCRIPTION
Normally, to click on an element you would use the standard [`click()`](https://laravel.com/docs/7.x/dusk#using-the-mouse) method passing in a common CSS selector.

- `$browser->click('.selector');`

However, consider a scenario where you want to click on an overlay which more often that not appears behind or underneath another element. It is highly likely you will run into the dreaded ["element is not clickable at point..."](https://www.google.com/search?q=element+is+not+clickable+at+point+site:stackoverflow.com) error because the topmost element, such as a modal, would unintentionally receive the click rather than the overlay.

It would therefore be useful to be able to click on an element at a given pair of coordinates rather than relying on a selector. This can be achieved by utilising [`elementFromPoint()`](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/elementFromPoint) under the hood.

- `$browser->clickAtPoint(0, 0); // Included in this PR`