### PR TITLE
[6.x] Update docblocks to clarify the type of cookie: encrypted or unencrypted

### DIFF
--- a/src/Concerns/InteractsWithCookies.php
+++ b/src/Concerns/InteractsWithCookies.php
@@ -34,7 +34,7 @@ trait InteractsWithCookies
     }
 
     /**
-     * Get or set a plain cookie's value.
+     * Get or set an unencrypted cookie's value.
      *
      * @param  string  $name
      * @param  string|null  $value

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -61,7 +61,7 @@ trait MakesAssertions
     }
 
     /**
-     * Assert that the given plain cookie is present.
+     * Assert that the given unencrypted cookie is present.
      *
      * @param  string  $name
      * @return $this
@@ -91,7 +91,7 @@ trait MakesAssertions
     }
 
     /**
-     * Assert that the given plain cookie is not present.
+     * Assert that the given unencrypted cookie is not present.
      *
      * @param  string  $name
      * @return $this
@@ -122,7 +122,7 @@ trait MakesAssertions
     }
 
     /**
-     * Assert that a cookie has a given value.
+     * Assert that an unencrypted cookie has a given value.
      *
      * @param  string  $name
      * @param  string  $value

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -42,7 +42,7 @@ trait MakesAssertions
     }
 
     /**
-     * Assert that the given cookie is present.
+     * Assert that the given encrypted cookie is present.
      *
      * @param  string $name
      * @param  bool  $decrypt
@@ -72,7 +72,7 @@ trait MakesAssertions
     }
 
     /**
-     * Assert that the given cookie is not present.
+     * Assert that the given encrypted cookie is not present.
      *
      * @param  string $name
      * @param  bool  $decrypt


### PR DESCRIPTION
Based on Taylor's formatting commit (https://github.com/laravel/docs/commit/b387c2a) I thought it would be useful to clarify the type of cookie:

 - encrypted
 - unencrypted