### PR TITLE
[6.x] Pass ssl-no-verify option into latestVersion of ChromeDriver install

### DIFF
--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -166,7 +166,7 @@ class ChromeDriverCommand extends Command
     protected function latestVersion()
     {
         $streamOptions = [];
-        
+
         if ($this->option('ssl-no-verify')) {
             $streamOptions = [
                 'ssl' => [

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -168,9 +168,9 @@ class ChromeDriverCommand extends Command
         $streamOptions = [];
         if ($this->option('ssl-no-verify')) {
             $streamOptions = [
-                "ssl" => [
-                    "verify_peer"      => false,
-                    "verify_peer_name" => false,
+                'ssl' => [
+                    'verify_peer'      => false,
+                    'verify_peer_name' => false,
                 ],
             ];
         }

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -166,10 +166,11 @@ class ChromeDriverCommand extends Command
     protected function latestVersion()
     {
         $streamOptions = [];
+        
         if ($this->option('ssl-no-verify')) {
             $streamOptions = [
                 'ssl' => [
-                    'verify_peer'      => false,
+                    'verify_peer' => false,
                     'verify_peer_name' => false,
                 ],
             ];

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -165,7 +165,17 @@ class ChromeDriverCommand extends Command
      */
     protected function latestVersion()
     {
-        return trim(file_get_contents($this->latestVersionUrl));
+        $streamOptions = [];
+        if ($this->option('ssl-no-verify')) {
+            $streamOptions = [
+                "ssl" => [
+                    "verify_peer"      => false,
+                    "verify_peer_name" => false,
+                ],
+            ];
+        }
+
+        return trim(file_get_contents($this->latestVersionUrl, false, stream_context_create($streamOptions)));
     }
 
     /**


### PR DESCRIPTION
This pull request addresses #793 .  The --ssl-no-verify option currently doesn't apply to the "latestVersion" call when installing the chrome driver.  This causes a failure with ssl proxies which cause ssl verification issues.

The fix:

Build an ssl verification option and pass it into the file_get_contents call for latest version.  Note: This has been tested on my local (with SSL verification on and off) and appears to work.

Tests:

I do not see any tests for this file in the repo.  I can add tests, but I want to make sure it is necessary first.  Please let me know if tests are needed for this issue.

Thank you,

Matt


