### PR TITLE
[6.x] Fix resolver format() replacing a fragment of selector

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -405,9 +405,15 @@ class ElementResolver
             return strlen($key);
         })->toArray();
 
-        $selector = str_replace(
-            array_keys($sortedElements), array_values($sortedElements), $originalSelector = $selector
-        );
+        $originalSelector = $selector;
+
+        if (is_string($selector)) {
+            $selector = array_key_exists($selector, $sortedElements) ? $sortedElements[$selector] : $selector;
+        } else {
+            $selector = str_replace(
+                array_keys($sortedElements), array_values($sortedElements), $originalSelector
+            );
+        }
 
         if (Str::startsWith($selector, '@') && $selector === $originalSelector) {
             $selector = '[dusk="'.explode('@', $selector)[1].'"]';

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -94,7 +94,7 @@ class ComponentTest extends TestCase
 
         $browser->resolver->elements = [
             'title' => '.title-class',
-            'subtitle' => '.subtitle-class'
+            'subtitle' => '.subtitle-class',
         ];
 
         $browser->within($component, function ($browser) {

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -85,6 +85,24 @@ class ComponentTest extends TestCase
         });
     }
 
+    public function test_component_element_alias_formatter()
+    {
+        $driver = m::mock(stdClass::class);
+        $browser = new Browser($driver);
+
+        $component = new TestComponent;
+
+        $browser->resolver->elements = [
+            'title' => '.title-class',
+            'subtitle' => '.subtitle-class'
+        ];
+
+        $browser->within($component, function ($browser) {
+            $this->assertEquals('body #component-root .title-class', $browser->resolver->format('title'));
+            $this->assertEquals('body #component-root .subtitle-class', $browser->resolver->format('subtitle'));
+        });
+    }
+
     public function test_root_selector_can_be_dusk_hook()
     {
         $driver = m::mock(stdClass::class);

--- a/tests/ElementResolverTest.php
+++ b/tests/ElementResolverTest.php
@@ -144,7 +144,7 @@ class ElementResolverTest extends TestCase
         $resolver = new ElementResolver(new stdClass, 'prefix');
         $resolver->pageElements([
             'title' => '.title-class',
-            'subtitle' => '.subtitle-class'
+            'subtitle' => '.subtitle-class',
         ]);
         $this->assertEquals('prefix .title-class', $resolver->format('title'));
         $this->assertEquals('prefix .subtitle-class', $resolver->format('subtitle'));

--- a/tests/ElementResolverTest.php
+++ b/tests/ElementResolverTest.php
@@ -139,8 +139,15 @@ class ElementResolverTest extends TestCase
         ]);
         $this->assertEquals('prefix #first', $resolver->format('@modal'));
         $this->assertEquals('prefix #second', $resolver->format('@modal-second'));
-        $this->assertEquals('prefix #first-third', $resolver->format('@modal-third'));
         $this->assertEquals('prefix [dusk="missing-element"]', $resolver->format('@missing-element'));
+
+        $resolver = new ElementResolver(new stdClass, 'prefix');
+        $resolver->pageElements([
+            'title' => '.title-class',
+            'subtitle' => '.subtitle-class'
+        ]);
+        $this->assertEquals('prefix .title-class', $resolver->format('title'));
+        $this->assertEquals('prefix .subtitle-class', $resolver->format('subtitle'));
     }
 
     public function test_find_by_id_with_colon()


### PR DESCRIPTION
The PR addresses an issue #799 where resolver->format() replaces the part of selector matching the element shortcut.
What that means is when there's a 'registered' element with the key (for example "title"), any occurrence of that key ("title") in other elements selector would be replaced with the key's value, like
```
'title' => '[data-testid=title]',
'subtitle' => '[data-testid=subtitle]',
```
The 'subtitle' element selector would resolve to `[data-testid=sub[data-testid=title]]`, thus triggering "Invalid selector" error.

There's a logic added to check whether $selector is a string or not, as it can be an instance of the Component.
Updated/added tests for the relevant functionality.