### PR TITLE
Update phpdotenv requirement to ^5.0 for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/console": "^4.3|^5.0",
         "symfony/finder": "^4.3|^5.0",
         "symfony/process": "^4.3|^5.0",
-        "vlucas/phpdotenv": "^3.0|^4.0"
+        "vlucas/phpdotenv": "^3.0|^4.0|^5.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
Laravel 8 includes Vance's phpdotenv update at 5+

```
"vlucas/phpdotenv": "^5.0",
```

We need to update this requirement from the current `^3.0|^4.0`