### PR TITLE
[6.x] Add CookieValuePrefix detection for encrypted cookies in InteractsWit…

### DIFF
--- a/src/Concerns/InteractsWithCookies.php
+++ b/src/Concerns/InteractsWithCookies.php
@@ -4,6 +4,8 @@ namespace Laravel\Dusk\Concerns;
 
 use DateTimeInterface;
 use Facebook\WebDriver\Exception\NoSuchCookieException;
+use Illuminate\Cookie\CookieValuePrefix;
+use Illuminate\Support\Facades\Crypt;
 
 trait InteractsWithCookies
 {
@@ -29,7 +31,10 @@ trait InteractsWithCookies
         }
 
         if ($cookie) {
-            return decrypt(rawurldecode($cookie['value']), $unserialize = false);
+            $decryptedValueCookieValue = decrypt(rawurldecode($cookie['value']), $unserialize = false);
+            $hasValuePrefix = strpos($decryptedValueCookieValue, CookieValuePrefix::create($name, Crypt::getKey())) === 0;
+
+            return ($hasValuePrefix) ? CookieValuePrefix::remove($decryptedValueCookieValue) : $decryptedValueCookieValue;
         }
     }
 


### PR DESCRIPTION
**Issue:** Laravel prefixes cookie values when being encrypted. 

The dusk InteractsWithCookie trait does not have any of this prefix logic. Because of this `$browser->cookie('cookieKey')` would return the prefixed value and not the actual value.

**Example:**
When calling `$browser->cookie('myCookieKey');` on an encrypted cookie you would get the following value (from the cookie function on the browser object):
`45093d44140e0247922e316851885c13445a6fcd|MYCOOKIEVALUE`
In our tests we expected this cookie value to be unprefixed.
`MYCOOKIEVALUE`

The prefix is set by laravel in the Encrypt function of `Illuminate\Cookie\Middleware\EncryptCookies`

```
    /**
     * Encrypt the cookies on an outgoing response.
     *
     * @param  \Symfony\Component\HttpFoundation\Response  $response
     * @return \Symfony\Component\HttpFoundation\Response
     */
    protected function encrypt(Response $response)
    {
        foreach ($response->headers->getCookies() as $cookie) {
            if ($this->isDisabled($cookie->getName())) {
                continue;
            }

            $response->headers->setCookie($this->duplicate(
                $cookie,
                $this->encrypter->encrypt(
                    CookieValuePrefix::create($cookie->getName(), $this->encrypter->getKey()).$cookie->getValue(),
                    static::serialized($cookie->getName())
                )
            ));
        }

        return $response;
    }
```

**Fix:** This fix checks if the decrypted cookie value contains a prefix. In case the value is prefixed the prefix will be removed.