### PR TITLE
Using the assertSame to make assert equals strict

### DIFF
--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -82,7 +82,7 @@ class BrowserTest extends TestCase
 
         $browser->with('prefix', function ($browser) {
             $this->assertInstanceof(Browser::class, $browser);
-            $this->assertEquals('body prefix', $browser->resolver->prefix);
+            $this->assertSame('body prefix', $browser->resolver->prefix);
         });
     }
 
@@ -99,7 +99,7 @@ class BrowserTest extends TestCase
 
         $browser->with('prefix', function ($browser) use ($page) {
             $this->assertInstanceof(Browser::class, $browser);
-            $this->assertEquals('body prefix', $browser->resolver->prefix);
+            $this->assertSame('body prefix', $browser->resolver->prefix);
             $this->assertEquals($page, $browser->page);
             $this->assertFalse($page->asserted);
         });
@@ -112,7 +112,7 @@ class BrowserTest extends TestCase
 
         $browser->within('prefix', function ($browser) {
             $this->assertInstanceof(Browser::class, $browser);
-            $this->assertEquals('body prefix', $browser->resolver->prefix);
+            $this->assertSame('body prefix', $browser->resolver->prefix);
         });
     }
 
@@ -129,7 +129,7 @@ class BrowserTest extends TestCase
 
         $browser->within('prefix', function ($browser) use ($page) {
             $this->assertInstanceof(Browser::class, $browser);
-            $this->assertEquals('body prefix', $browser->resolver->prefix);
+            $this->assertSame('body prefix', $browser->resolver->prefix);
             $this->assertEquals($page, $browser->page);
             $this->assertFalse($page->asserted);
         });
@@ -143,7 +143,7 @@ class BrowserTest extends TestCase
         $browser->with('prefix', function ($browser) {
             $browser->elsewhere('.my-class', function ($browser) {
                 $this->assertInstanceof(Browser::class, $browser);
-                $this->assertEquals('body .my-class', $browser->resolver->prefix);
+                $this->assertSame('body .my-class', $browser->resolver->prefix);
             });
         });
     }

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -36,13 +36,13 @@ class ComponentTest extends TestCase
         $browser = new Browser($driver);
 
         $browser->within($component = new TestComponent, function ($browser) {
-            $this->assertEquals('body #component-root', $browser->resolver->prefix);
+            $this->assertSame('body #component-root', $browser->resolver->prefix);
 
             $browser->within($nested = new TestNestedComponent, function ($browser) {
-                $this->assertEquals('body #component-root #nested-root', $browser->resolver->prefix);
+                $this->assertSame('body #component-root #nested-root', $browser->resolver->prefix);
 
                 $browser->with('prefix', function ($browser) {
-                    $this->assertEquals('body #component-root #nested-root prefix', $browser->resolver->prefix);
+                    $this->assertSame('body #component-root #nested-root prefix', $browser->resolver->prefix);
                 });
             });
         });
@@ -94,7 +94,7 @@ class ComponentTest extends TestCase
         $component->selector = '@dusk-hook-root';
 
         $browser->within($component, function ($browser) {
-            $this->assertEquals('body [dusk="dusk-hook-root"]', $browser->resolver->prefix);
+            $this->assertSame('body [dusk="dusk-hook-root"]', $browser->resolver->prefix);
         });
     }
 
@@ -107,7 +107,7 @@ class ComponentTest extends TestCase
         $component->selector = '@component-alias';
 
         $browser->within($component, function ($browser) {
-            $this->assertEquals('body #component-alias', $browser->resolver->prefix);
+            $this->assertSame('body #component-alias', $browser->resolver->prefix);
         });
     }
 

--- a/tests/Concerns/InteractsWithElementsTest.php
+++ b/tests/Concerns/InteractsWithElementsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Dusk\Tests\Conserns;
+namespace Laravel\Dusk\Tests\Concerns;
 
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\RemoteWebElement;

--- a/tests/ElementResolverTest.php
+++ b/tests/ElementResolverTest.php
@@ -19,7 +19,7 @@ class ElementResolverTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('findElement')->once()->andReturn('foo');
         $resolver = new ElementResolver($driver);
-        $this->assertEquals('foo', $resolver->resolveForTyping('#foo'));
+        $this->assertSame('foo', $resolver->resolveForTyping('#foo'));
     }
 
     public function test_resolve_for_typing_falls_back_to_selectors_without_id()
@@ -27,7 +27,7 @@ class ElementResolverTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('findElement')->once()->andReturn('foo');
         $resolver = new ElementResolver($driver);
-        $this->assertEquals('foo', $resolver->resolveForTyping('foo'));
+        $this->assertSame('foo', $resolver->resolveForTyping('foo'));
     }
 
     public function test_resolve_for_selection_resolves_by_id()
@@ -35,7 +35,7 @@ class ElementResolverTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('findElement')->once()->andReturn('foo');
         $resolver = new ElementResolver($driver);
-        $this->assertEquals('foo', $resolver->resolveForSelection('#foo'));
+        $this->assertSame('foo', $resolver->resolveForSelection('#foo'));
     }
 
     public function test_resolve_for_selection_falls_back_to_selectors_without_id()
@@ -43,7 +43,7 @@ class ElementResolverTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('findElement')->once()->andReturn('foo');
         $resolver = new ElementResolver($driver);
-        $this->assertEquals('foo', $resolver->resolveForSelection('foo'));
+        $this->assertSame('foo', $resolver->resolveForSelection('foo'));
     }
 
     public function test_resolve_for_radio_selection_resolves_by_id()
@@ -51,7 +51,7 @@ class ElementResolverTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('findElement')->once()->andReturn('foo');
         $resolver = new ElementResolver($driver);
-        $this->assertEquals('foo', $resolver->resolveForRadioSelection('#foo'));
+        $this->assertSame('foo', $resolver->resolveForRadioSelection('#foo'));
     }
 
     public function test_resolve_for_radio_selection_falls_back_to_selectors_without_id()
@@ -59,7 +59,7 @@ class ElementResolverTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('findElement')->once()->andReturn('foo');
         $resolver = new ElementResolver($driver);
-        $this->assertEquals('foo', $resolver->resolveForRadioSelection('foo', 'value'));
+        $this->assertSame('foo', $resolver->resolveForRadioSelection('foo', 'value'));
     }
 
     public function test_resolve_for_radio_selection_throws_exception_without_id_and_without_value()
@@ -77,7 +77,7 @@ class ElementResolverTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('findElement')->once()->andReturn('foo');
         $resolver = new ElementResolver($driver);
-        $this->assertEquals('foo', $resolver->resolveForChecking('#foo'));
+        $this->assertSame('foo', $resolver->resolveForChecking('#foo'));
     }
 
     public function test_resolve_for_checking_falls_back_to_selectors_without_id()
@@ -85,7 +85,7 @@ class ElementResolverTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('findElement')->once()->andReturn('foo');
         $resolver = new ElementResolver($driver);
-        $this->assertEquals('foo', $resolver->resolveForChecking('foo'));
+        $this->assertSame('foo', $resolver->resolveForChecking('foo'));
     }
 
     public function test_resolve_for_attachment_resolves_by_id()
@@ -93,7 +93,7 @@ class ElementResolverTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('findElement')->once()->andReturn('foo');
         $resolver = new ElementResolver($driver);
-        $this->assertEquals('foo', $resolver->resolveForAttachment('#foo'));
+        $this->assertSame('foo', $resolver->resolveForAttachment('#foo'));
     }
 
     public function test_resolve_for_attachment_falls_back_to_selectors_without_id()
@@ -101,7 +101,7 @@ class ElementResolverTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('findElement')->once()->andReturn('foo');
         $resolver = new ElementResolver($driver);
-        $this->assertEquals('foo', $resolver->resolveForAttachment('foo'));
+        $this->assertSame('foo', $resolver->resolveForAttachment('foo'));
     }
 
     public function test_resolve_for_field_resolves_by_id()
@@ -109,7 +109,7 @@ class ElementResolverTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('findElement')->once()->andReturn('foo');
         $resolver = new ElementResolver($driver);
-        $this->assertEquals('foo', $resolver->resolveForField('#foo'));
+        $this->assertSame('foo', $resolver->resolveForField('#foo'));
     }
 
     public function test_resolve_for_field_falls_back_to_selectors_without_id()
@@ -117,30 +117,30 @@ class ElementResolverTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('findElement')->once()->andReturn('foo');
         $resolver = new ElementResolver($driver);
-        $this->assertEquals('foo', $resolver->resolveForField('foo'));
+        $this->assertSame('foo', $resolver->resolveForField('foo'));
     }
 
     public function test_format_correctly_formats_selectors()
     {
         $resolver = new ElementResolver(new stdClass);
-        $this->assertEquals('body #modal', $resolver->format('#modal'));
+        $this->assertSame('body #modal', $resolver->format('#modal'));
 
         $resolver = new ElementResolver(new stdClass, 'prefix');
-        $this->assertEquals('prefix #modal', $resolver->format('#modal'));
+        $this->assertSame('prefix #modal', $resolver->format('#modal'));
 
         $resolver = new ElementResolver(new stdClass, 'prefix');
         $resolver->pageElements(['@modal' => '#modal']);
-        $this->assertEquals('prefix #modal', $resolver->format('@modal'));
+        $this->assertSame('prefix #modal', $resolver->format('@modal'));
 
         $resolver = new ElementResolver(new stdClass, 'prefix');
         $resolver->pageElements([
             '@modal' => '#first',
             '@modal-second' => '#second',
         ]);
-        $this->assertEquals('prefix #first', $resolver->format('@modal'));
-        $this->assertEquals('prefix #second', $resolver->format('@modal-second'));
-        $this->assertEquals('prefix #first-third', $resolver->format('@modal-third'));
-        $this->assertEquals('prefix [dusk="missing-element"]', $resolver->format('@missing-element'));
+        $this->assertSame('prefix #first', $resolver->format('@modal'));
+        $this->assertSame('prefix #second', $resolver->format('@modal-second'));
+        $this->assertSame('prefix #first-third', $resolver->format('@modal-third'));
+        $this->assertSame('prefix [dusk="missing-element"]', $resolver->format('@missing-element'));
     }
 
     public function test_find_by_id_with_colon()
@@ -154,6 +154,6 @@ class ElementResolverTest extends TestCase
         $method->setAccessible(true);
         $result = $method->invoke($resolver, '#frmLogin:strCustomerLogin_userID');
 
-        $this->assertEquals('foo', $result);
+        $this->assertSame('foo', $result);
     }
 }

--- a/tests/WaitsForElementsTest.php
+++ b/tests/WaitsForElementsTest.php
@@ -25,7 +25,7 @@ class WaitsForElementsTest extends TestCase
             //
         }
 
-        $this->assertEquals(2, floor(microtime(true) - $then));
+        $this->assertSame(2.0, floor(microtime(true) - $then));
     }
 
     public function test_default_wait_time_can_be_overridden()
@@ -43,7 +43,7 @@ class WaitsForElementsTest extends TestCase
             //
         }
 
-        $this->assertEquals(0, floor(microtime(true) - $then));
+        $this->assertSame(0.0, floor(microtime(true) - $then));
     }
 
     public function test_wait_using()
@@ -120,7 +120,7 @@ class WaitsForElementsTest extends TestCase
             $browser->waitForText('Discount: 20%', 1);
             $this->fail('waitForText() did not timeout.');
         } catch (TimeOutException $e) {
-            $this->assertEquals('Waited 1 seconds for text [Discount: 20%].', $e->getMessage());
+            $this->assertSame('Waited 1 seconds for text [Discount: 20%].', $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assertion equals checking strict.