### PR TITLE
Update phpunit.xml stub to PHPUnit 9.3.0 format

### DIFF
--- a/stubs/phpunit.xml
+++ b/stubs/phpunit.xml
@@ -13,14 +13,4 @@
             <directory suffix="Test.php">./tests/Browser</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./app</directory>
-        </whitelist>
-    </filter>
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./app</directory>
-        </include>
-    </coverage>
 </phpunit>

--- a/stubs/phpunit.xml
+++ b/stubs/phpunit.xml
@@ -18,4 +18,9 @@
             <directory suffix=".php">./app</directory>
         </whitelist>
     </filter>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./app</directory>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
PHPUnit 9.3.0 changed coverage filtering from `filter` tag to `coverage` tag. This pull request adds `coverage` element to `phpunit.xml` stub, so that both older and newer versions of PHPUnit has valid coverage configuration. Once dependencies go past phpunit@^9.3, `filter` element can be removed.
This change introduces `element not expected` warnings on all PHPUnit versions.  I believe it's not harmful as PHPUnit ignores unrecognized tags.
Of course, there should be a better way to gracefully deprecate older PHPUnit versions. I'd be glad if someone suggests one.

Closes #810 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
