### PR TITLE
[6.x] fix the `fitContent()` method

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -284,7 +284,7 @@ class Browser
 
         $html = $this->driver->findElement(WebDriverBy::tagName('html'));
 
-        if (! empty($html) && ($html->getSize()->getWidth() <= 0 || $html->getSize()->getHeight() <= 0)) {
+        if (! empty($html) && $html->getSize()->getWidth() >= 0 && $html->getSize()->getHeight() >= 0) {
             $this->resize($html->getSize()->getWidth(), $html->getSize()->getHeight());
         }
 


### PR DESCRIPTION
well, my bad on this one....

In this PR of mine (https://github.com/laravel/dusk/pull/731) I screwed up the logic when flattening the conditional, and basically prevented all content fitting from occurring.

someone please double check my work on this one :sweat_smile: