### PR TITLE
[6.x] add Chrome driver auto detection

### DIFF
--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -304,7 +304,7 @@ class ChromeDriverCommand extends Command
 
             preg_match('/(\d+)(\.\d+){3}/', $process->getOutput(), $matches);
 
-            if (!isset($matches[1])) {
+            if (! isset($matches[1])) {
                 continue;
             }
 

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -19,7 +19,7 @@ class ChromeDriverCommand extends Command
      */
     protected $signature = 'dusk:chrome-driver {version?}
                     {--all : Install a ChromeDriver binary for every OS}
-                    {--detect : Detect the installed Chrome/Chromium version}
+                    {--detect : Detect the installed Chrome / Chromium version}
                     {--proxy= : The proxy to download the binary through (example: "tcp://127.0.0.1:9000")}
                     {--ssl-no-verify : Bypass SSL certificate verification when installing through a proxy}';
 

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -308,10 +308,6 @@ class ChromeDriverCommand extends Command
                 continue;
             }
 
-            $this->comment(
-                sprintf('Chrome version %s detected.', $matches[0])
-            );
-
             return $matches[1];
         }
 

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -4,6 +4,7 @@ namespace Laravel\Dusk\Console;
 
 use Illuminate\Console\Command;
 use Laravel\Dusk\OperatingSystem;
+use Symfony\Component\Process\Process;
 use ZipArchive;
 
 /**
@@ -18,6 +19,7 @@ class ChromeDriverCommand extends Command
      */
     protected $signature = 'dusk:chrome-driver {version?}
                     {--all : Install a ChromeDriver binary for every OS}
+                    {--detect : Detect the installed Chrome/Chromium version}
                     {--proxy= : The proxy to download the binary through (example: "tcp://127.0.0.1:9000")}
                     {--ssl-no-verify : Bypass SSL certificate verification when installing through a proxy}';
 
@@ -103,6 +105,25 @@ class ChromeDriverCommand extends Command
     protected $directory = __DIR__.'/../../bin/';
 
     /**
+     * The default commands to detect the installed Chrome/Chromium version.
+     *
+     * @var array
+     */
+    protected $chromeCommands = [
+        'linux' => [
+            '/usr/bin/google-chrome --version',
+            '/usr/bin/chromium-browser --version',
+            '/usr/bin/google-chrome-stable --version',
+        ],
+        'mac' => [
+            '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version',
+        ],
+        'win' => [
+            'reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version',
+        ],
+    ];
+
+    /**
      * Execute the console command.
      *
      * @return void
@@ -138,6 +159,10 @@ class ChromeDriverCommand extends Command
     protected function version()
     {
         $version = $this->argument('version');
+
+        if ($this->option('detect')) {
+            $version = $this->chromeVersion(OperatingSystem::id());
+        }
 
         if (! $version) {
             return $this->latestVersion();
@@ -262,5 +287,36 @@ class ChromeDriverCommand extends Command
         $streamContext = stream_context_create($contextOptions);
 
         return file_get_contents($url, false, $streamContext);
+    }
+
+    /**
+     * Detect the installed Chrome/Chromium major version.
+     *
+     * @param string $os
+     * @return int|bool
+     */
+    protected function chromeVersion($os)
+    {
+        foreach ($this->chromeCommands[$os] as $command) {
+            $process = Process::fromShellCommandline($command);
+
+            $process->run();
+
+            preg_match('/(\d+)(\.\d+){3}/', $process->getOutput(), $matches);
+
+            if (!isset($matches[1])) {
+                continue;
+            }
+
+            $this->comment(
+                sprintf('Chrome version %s detected.', $matches[0])
+            );
+
+            return $matches[1];
+        }
+
+        $this->error('Chrome version could not be detected.');
+
+        return false;
     }
 }


### PR DESCRIPTION
Using the `--detect` flag, the command will see if it can determine the install driver version, and then install the latest of that major version.

All credit goes to @staudenmeir. This code was taken from https://github.com/staudenmeir/dusk-updater.

In our next major release, I feel like this should be the default option, and we should add a `--latest` flag to get back to the current default behavior.
