### PR TITLE
[6.x] automatically capture source code on failure

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -10,6 +10,13 @@ use PHPUnit\Framework\Assert as PHPUnit;
 trait MakesAssertions
 {
     /**
+     * Indicates the browser has made an assertion about the source code of the page.
+     *
+     * @var bool
+     */
+    public $makesSourceAssertion = false;
+
+    /**
      * Assert that the page title is the given value.
      *
      * @param  string  $title
@@ -205,6 +212,8 @@ trait MakesAssertions
      */
     public function assertSourceHas($code)
     {
+        $this->makesSourceAssertion = true;
+
         PHPUnit::assertTrue(
             Str::contains($this->driver->getPageSource(), $code),
             "Did not find expected source code [{$code}]"
@@ -221,6 +230,8 @@ trait MakesAssertions
      */
     public function assertSourceMissing($code)
     {
+        $this->makesSourceAssertion = true;
+
         PHPUnit::assertFalse(
             Str::contains($this->driver->getPageSource(), $code),
             "Found unexpected source code [{$code}]"

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -68,10 +68,12 @@ trait ProvidesBrowser
             $callback(...$browsers->all());
         } catch (Exception $e) {
             $this->captureFailuresFor($browsers);
+            $this->storeSourceLogsFor($browsers);
 
             throw $e;
         } catch (Throwable $e) {
             $this->captureFailuresFor($browsers);
+            $this->storeSourceLogsFor($browsers);
 
             throw $e;
         } finally {
@@ -159,6 +161,23 @@ trait ProvidesBrowser
             $name = $this->getCallerName();
 
             $browser->storeConsoleLog($name.'-'.$key);
+        });
+    }
+
+    /**
+     * Store the source code for the given browsers.
+     *
+     * @param  \Illuminate\Support\Collection  $browsers
+     * @return void
+     */
+    protected function storeSourceLogsFor($browsers)
+    {
+        $browsers->each(function ($browser, $key) {
+            if (property_exists($browser, 'makesSourceAssertion') && $browser->makesSourceAssertion) {
+                $name = $this->getCallerName();
+
+                $browser->storeSource($name.'-'.$key);
+            }
         });
     }
 

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -56,6 +56,8 @@ class DuskCommand extends Command
 
         $this->purgeConsoleLogs();
 
+        $this->purgeSourceLogs();
+
         $options = array_slice($_SERVER['argv'], $this->option('without-tty') ? 3 : 2);
 
         return $this->withDuskEnvironment(function () use ($options) {
@@ -152,6 +154,28 @@ class DuskCommand extends Command
         $files = Finder::create()->files()
             ->in($path)
             ->name('*.log');
+
+        foreach ($files as $file) {
+            @unlink($file->getRealPath());
+        }
+    }
+
+    /**
+     * Purge the source logs.
+     *
+     * @return void
+     */
+    protected function purgeSourceLogs()
+    {
+        $path = base_path('tests/Browser/source');
+
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $files = Finder::create()->files()
+                       ->in($path)
+                       ->name('*.txt');
 
         foreach ($files as $file) {
             @unlink($file->getRealPath());


### PR DESCRIPTION
If an assertion has been made against the source code, capture the source code for analysis.

In #707 I added the ability to store the source code from the Browser.

#705 was my original attempt where I stored the source code after every test. This was closed with the thought being storing the source for every test was excessive.

This PR finds a good middle ground, and will only automatically store the source on **failures** where **an assertion against the source has been made**.

That means either the `assertSourceHas()` or `assertSourceMissing()` assertions must be called for the source to be auto-stored.
