### PR TITLE
[6.x] Add assertScript()

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -868,4 +868,23 @@ JS;
             "return document.querySelector('".$fullSelector."').__vue__.".$key
         );
     }
+
+    /**
+     * Assert that the given JavaScript expression has a given value.
+     *
+     * @param  string  $expression
+     * @param  mixed  $expected
+     * @return $this
+     */
+    public function assertScript($expression, $expected = true)
+    {
+        $expression = Str::start($expression, 'return ');
+
+        PHPUnit::assertEquals(
+            $expected, $this->driver->executeScript($expression),
+            "JavaScript expression [{$expression}] mismatched."
+        );
+
+        return $this;
+    }
 }

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -389,4 +389,35 @@ class MakesAssertionsTest extends TestCase
             );
         }
     }
+
+    public function test_assert_script()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('executeScript')->withArgs(['return 1==1'])->andReturn(true);
+        $driver->shouldReceive('executeScript')->withArgs(['return 1==1'])->andReturn(true);
+        $driver->shouldReceive('executeScript')->withArgs(['return 1==2'])->andReturn(false);
+        $driver->shouldReceive('executeScript')->withArgs(["return 'some string'"])->andReturn('some string');
+
+        $resolver = m::mock(stdClass::class);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertScript('return 1==1');
+        $browser->assertScript('1==1');
+        $browser->assertScript("'some string'", 'some string');
+
+        try {
+            $browser->assertScript('1==2');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'JavaScript expression [return 1==2] mismatched.',
+                $e->getMessage()
+            );
+            $this->assertStringContainsString(
+                'Failed asserting that false matches expected true.',
+                $e->getMessage()
+            );
+        }
+    }
 }


### PR DESCRIPTION
This PR adds the ability to make assertions against JavaScript with `assertScript()`

It always ensures that the expression is prefixed with `return` and expects a truthy result

For different expectations, the 2nd parameter can be passed.

[Realworld use cases from livewire](https://github.com/livewire/livewire/search?q=assertScript)