### PR TITLE
[6.x] fix choosing random elements on <select>

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -216,7 +216,7 @@ trait InteractsWithElements
 
         $options = $element->findElements(WebDriverBy::cssSelector('option:not([disabled])'));
 
-        if (is_null($value)) {
+        if (func_num_args() === 1) {
             $options[array_rand($options)]->click();
         } else {
             if (is_bool($value)) {


### PR DESCRIPTION
### Problem

The browser `select()` method will currently choose a random option from a `<select>` input if the second parameter evaluates to `null`.  This normally works fine if it is used like:

```php
$user = (new UserFactory)->make();

$browser->visit('/user/create')
    ->name('name', $user->name)
    ->select('status');
```

However, it becomes problematic when a second argument is passed that **_evaluates_** as `null`.

```php
$user = (new UserFactory)->make([
    'status' => $faker->optional()->randomElement(['active', 'inactive']),
]);

$browser->visit('/user/create')
    ->name('name', $user->name)
    ->select('status', $user->status);
```

In this scenario, if `$user->status` is `null`, we actually want the `<select>` to not be set, but instead it will select a random `<option>`.

It also makes it more difficult to edit a value from a selected option to a `null` option.

```php
(new UserFactory)->create([
    'status' => 'active',
]);

$user = (new UserFactory)->make([
    'status' => null,
]);

$browser->visit('/user/1/edit')
    ->name('name', $user->name)
    ->select('status', $user->status);
```

This will again select a random `<option>`, when we really want the value to be cleared out.

### Solution

This PR will switch from checking if the second argument is `null`, to checking if it was even passed.

This will select a random option:

```php
$browser->select('status');
```

while this will specifically try to select an option whose value evaluates to an empty string:

```php
$browser->select('status', null);
```

I go back and forth on if this is a breaking change or a bug fix. If we go by the documentation (https://laravel.com/docs/8.x/dusk#using-forms), this is a bug fix.  If you guys deem it as a BC, and can resend to master.