### PR TITLE
[6.x] Added waitForTextIn Function

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -111,6 +111,25 @@ trait WaitsForElements
     }
 
     /**
+     * Wait for the given text to be visible inside the given selector.
+     *
+     * @param  string  $selector
+     * @param  array|string  $text
+     * @param  int  $seconds
+     * @return $this
+     *
+     * @throws \Facebook\WebDriver\Exception\TimeOutException
+     */
+    public function waitForTextIn($selector, $text, $seconds = null)
+    {
+        $message = 'Waited %s seconds for text "'.$text.'" in selector '.$selector;
+
+        return $this->waitUsing($seconds, 100, function () use ($selector, $text) {
+            return $this->assertSeeIn($selector, $text);
+        }, $message);
+    }
+
+    /**
      * Wait for the given link to be visible.
      *
      * @param  string  $link


### PR DESCRIPTION
Added Method to wait for text in selector.

```php
public function waitForTextIn($selector, $text, $seconds = null)

```
Example usage:

```php
$this->browse(function(Browser $browser) use($user){
    $browser->loginAs($user)
        ->visit('/datatable')
        ->waitForTextIn('@datatableColStatus', STATUS_DONE, 60);
});
```