### PR TITLE
[6.x] Allow to utilise browser "about:blank" page

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -175,7 +175,7 @@ class Browser
     }
 
     /**
-     * Browse to "about:blank" page.
+     * Browse to the "about:blank" page.
      *
      * @return $this
      */

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -175,6 +175,18 @@ class Browser
     }
 
     /**
+     * Browse to "about:blank" page.
+     *
+     * @return $this
+     */
+    public function blank()
+    {
+        $this->driver->navigate()->to('about:blank');
+
+        return $this;
+    }
+
+    /**
      * Set the current page object.
      *
      * @param  mixed  $page

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -39,6 +39,16 @@ class BrowserTest extends TestCase
         $browser->visit('/login');
     }
 
+    public function test_blank_page()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('navigate->to')->with('about:blank');
+        $browser = new Browser($driver);
+        Browser::$baseUrl = 'http://laravel.dev';
+
+        $browser->blank();
+    }
+
     public function test_visit_with_page_object()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
Tested:
- Chrome
- Firefox
- Safari

This would be useful to stop page to executing any ajax when completing
each test. In my case, keep seeing page error between teardown and setup
for next test when using chrome (with GUI).

![image](https://user-images.githubusercontent.com/172966/94909797-4ad64180-04d6-11eb-8634-50f238a5a064.png)

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
