### PR TITLE
Align docblock with docs

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -881,7 +881,7 @@ JS;
     }
 
     /**
-     * Assert that the given JavaScript expression has a given value.
+     * Assert that the given JavaScript expression evaluates to the given value.
      *
      * @param  string  $expression
      * @param  mixed  $expected


### PR DESCRIPTION
See https://github.com/laravel/docs/pull/6485/commits/52b2160

```diff
-	Assert that the given JavaScript expression has a given value:
+	Assert that the given JavaScript expression evaluates to the given value:
```