### PR TITLE
[6.x] Add Vue 3 support to the assertVue*() methods

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -876,7 +876,10 @@ JS;
         $fullSelector = $this->resolver->format($componentSelector);
 
         return $this->driver->executeScript(
-            "return document.querySelector('".$fullSelector."').__vue__.".$key
+            "var el = document.querySelector('".$fullSelector."');".
+            "return typeof el.__vue__ === 'undefined' ".
+                '? JSON.parse(JSON.stringify(el.__vueParentComponent.ctx)).'.$key.
+                ': el.__vue__.'.$key
         );
     }
 

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -346,6 +346,24 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_vue_contains_formats_vue_prop_query()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('executeScript')
+            ->with(
+                'var el = document.querySelector(\'body [dusk="vue-component"]\');'.
+                "return typeof el.__vue__ === 'undefined' ".
+                    '? JSON.parse(JSON.stringify(el.__vueParentComponent.ctx)).name'.
+                    ': el.__vue__.name'
+            )
+            ->once()
+            ->andReturn(['john']);
+
+        $browser = new Browser($driver);
+
+        $browser->assertVueContains('name', 'john', '@vue-component');
+    }
+
     public function test_assert_vue_contains()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
Fixes: https://github.com/laravel/dusk/issues/832

Vue 3 no longer adds a `__vue__` property to DOM nodes to allow querying for props. Instead the `__vueParentComponent` must be inspected. Its 'ctx' property is an object containing the:

* passed in component props
* `data()` defined within the component
* any computed props

The above three items would be checked by Laravel Dusk to assert `v-model` value bindings.

When Dusk is looking up the Vue prop value of a DOM node, it will first look for a Vue 2 `__vue__` property, then fallback to `__vueParentComponent.ctx` for Vue 3.