### PR TITLE
Add missing tests for 6 additional existing assertions

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -121,7 +121,8 @@ trait MakesAssertions
         $actual = $decrypt ? $this->cookie($name) : $this->plainCookie($name);
 
         PHPUnit::assertEquals(
-            $value, $actual,
+            $value,
+            $actual,
             "Cookie [{$name}] had value [{$actual}], but expected [{$value}]."
         );
 
@@ -314,7 +315,8 @@ JS;
     public function assertInputValue($field, $value)
     {
         PHPUnit::assertEquals(
-            $value, $this->inputValue($field),
+            $value,
+            $this->inputValue($field),
             "Expected value [{$value}] for the [{$field}] input does not equal the actual value [{$this->inputValue($field)}]."
         );
 
@@ -331,7 +333,8 @@ JS;
     public function assertInputValueIsNot($field, $value)
     {
         PHPUnit::assertNotEquals(
-            $value, $this->inputValue($field),
+            $value,
+            $this->inputValue($field),
             "Value [{$value}] for the [{$field}] input should not equal the actual value."
         );
 
@@ -581,7 +584,8 @@ JS;
         );
 
         PHPUnit::assertEquals(
-            $value, $actual,
+            $value,
+            $actual,
             "Expected '$attribute' attribute [{$value}] does not equal actual value [$actual]."
         );
 
@@ -685,7 +689,8 @@ JS;
         $actualMessage = $this->driver->switchTo()->alert()->getText();
 
         PHPUnit::assertEquals(
-            $message, $actualMessage,
+            $message,
+            $actualMessage,
             "Expected dialog message [{$message}] does not equal actual message [{$actualMessage}]."
         );
 

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -557,9 +557,15 @@ JS;
      */
     public function assertValue($selector, $value)
     {
+        $fullSelector = $this->resolver->format($selector);
+
         $actual = $this->resolver->findOrFail($selector)->getAttribute('value');
 
-        PHPUnit::assertEquals($value, $actual);
+        PHPUnit::assertEquals(
+            $value,
+            $actual,
+            "Did not see expected value [{$value}] within element [{$fullSelector}]."
+        );
 
         return $this;
     }

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -821,7 +821,11 @@ JS;
      */
     public function assertVue($key, $value, $componentSelector = null)
     {
-        PHPUnit::assertEquals($value, $this->vueAttribute($componentSelector, $key));
+        PHPUnit::assertEquals(
+            $value,
+            $this->vueAttribute($componentSelector, $key),
+            "Did not see expected value [{$value}] at the key [{$key}]."
+        );
 
         return $this;
     }
@@ -837,7 +841,11 @@ JS;
      */
     public function assertVueIsNot($key, $value, $componentSelector = null)
     {
-        PHPUnit::assertNotEquals($value, $this->vueAttribute($componentSelector, $key));
+        PHPUnit::assertNotEquals(
+            $value,
+            $this->vueAttribute($componentSelector, $key),
+            "Saw unexpected value [{$value}] at the key [{$key}]."
+        );
 
         return $this;
     }

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -452,6 +452,32 @@ class MakesAssertionsTest extends TestCase
         $browser->assertSelectMissingOption('select[name="users"]', 1);
     }
 
+    public function test_assert_value()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element = m::mock(RemoteWebElement::class);
+        $element->shouldReceive('getAttribute')
+            ->andReturn('bar');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertValue('foo', 'bar');
+
+        try {
+            $browser->assertValue('foo', 'foo');
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Did not see expected value [foo] within element [body foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_attribute()
     {
         $driver = m::mock(stdClass::class);

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -865,6 +865,66 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_vue()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('executeScript')
+            ->with(
+                'var el = document.querySelector(\'body foo\');'.
+                "return typeof el.__vue__ === 'undefined' ".
+                    '? JSON.parse(JSON.stringify(el.__vueParentComponent.ctx)).foo'.
+                    ': el.__vue__.foo'
+            )
+            ->once()
+            ->andReturn('foo');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertVue('foo', 'foo', 'foo');
+
+        try {
+            $browser->assertVue('foo', 'bar', 'foo');
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Did not see expected value [bar] at the key [foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_vue_is_not()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('executeScript')
+            ->with(
+                'var el = document.querySelector(\'body foo\');'.
+                "return typeof el.__vue__ === 'undefined' ".
+                    '? JSON.parse(JSON.stringify(el.__vueParentComponent.ctx)).foo'.
+                    ': el.__vue__.foo'
+            )
+            ->once()
+            ->andReturn('foo');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertVueIsNot('foo', 'bar', 'foo');
+
+        try {
+            $browser->assertVueIsNot('foo', 'foo', 'foo');
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Saw unexpected value [foo] at the key [foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_vue_contains_formats_vue_prop_query()
     {
         $driver = m::mock(stdClass::class);

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -455,15 +455,18 @@ class MakesAssertionsTest extends TestCase
     public function test_assert_attribute()
     {
         $driver = m::mock(stdClass::class);
+
         $element = m::mock(stdClass::class);
         $element->shouldReceive('getAttribute')->with('bar')->andReturn(
             'joe',
             null,
             'sue'
         );
+
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('Foo');
         $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
         $browser = new Browser($driver, $resolver);
 
         $browser->assertAttribute('foo', 'bar', 'joe');
@@ -492,15 +495,18 @@ class MakesAssertionsTest extends TestCase
     public function test_assert_data_attribute()
     {
         $driver = m::mock(stdClass::class);
+
         $element = m::mock(stdClass::class);
         $element->shouldReceive('getAttribute')->with('data-bar')->andReturn(
             'joe',
             null,
             'sue'
         );
+
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('Foo');
         $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
         $browser = new Browser($driver, $resolver);
 
         $browser->assertDataAttribute('foo', 'bar', 'joe');
@@ -529,15 +535,18 @@ class MakesAssertionsTest extends TestCase
     public function test_assert_aria_attribute()
     {
         $driver = m::mock(stdClass::class);
+
         $element = m::mock(stdClass::class);
         $element->shouldReceive('getAttribute')->with('aria-bar')->andReturn(
             'joe',
             null,
             'sue'
         );
+
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('Foo');
         $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
         $browser = new Browser($driver, $resolver);
 
         $browser->assertAriaAttribute('foo', 'bar', 'joe');
@@ -671,11 +680,13 @@ class MakesAssertionsTest extends TestCase
     public function test_assert_enabled()
     {
         $driver = m::mock(stdClass::class);
+
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('resolveForField->isEnabled')->andReturn(
             true,
             false
         );
+
         $browser = new Browser($driver, $resolver);
 
         $browser->assertEnabled('foo');
@@ -694,11 +705,13 @@ class MakesAssertionsTest extends TestCase
     public function test_assert_disabled()
     {
         $driver = m::mock(stdClass::class);
+
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('resolveForField->isEnabled')->andReturn(
             false,
             true
         );
+
         $browser = new Browser($driver, $resolver);
 
         $browser->assertDisabled('foo');
@@ -725,6 +738,7 @@ class MakesAssertionsTest extends TestCase
             true,
             false
         );
+
         $browser = new Browser($driver, $resolver);
 
         $browser->assertButtonEnabled('Press me');
@@ -738,11 +752,13 @@ class MakesAssertionsTest extends TestCase
         $this->expectExceptionMessage("Expected button [Press me] to be disabled, but it wasn't.");
 
         $driver = m::mock(stdClass::class);
+
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('resolveForButtonPress->isEnabled')->twice()->andReturn(
             false,
             true
         );
+
         $browser = new Browser($driver, $resolver);
 
         $browser->assertButtonDisabled('Cant press me');
@@ -757,8 +773,10 @@ class MakesAssertionsTest extends TestCase
             true,
             false
         );
+
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('resolveForField')->with('foo')->andReturn('element');
+
         $browser = new Browser($driver, $resolver);
 
         $browser->assertFocused('foo');
@@ -781,8 +799,10 @@ class MakesAssertionsTest extends TestCase
             false,
             true
         );
+
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('resolveForField')->with('foo')->andReturn('element');
+
         $browser = new Browser($driver, $resolver);
 
         $browser->assertNotFocused('foo');

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -703,6 +703,27 @@ class MakesAssertionsTest extends TestCase
         $browser->assertMissing('foo');
     }
 
+    public function test_assert_dialog_opened()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('switchTo->alert->getText')->andReturn('foo');
+
+        $resolver = m::mock(stdClass::class);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertDialogOpened('foo');
+
+        try {
+            $browser->assertDialogOpened('bar');
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Expected dialog message [bar] does not equal actual message [foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_enabled()
     {
         $driver = m::mock(stdClass::class);

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -1159,4 +1159,58 @@ class MakesAssertionsTest extends TestCase
             );
         }
     }
+
+    public function test_assert_input_value()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getTagName')->andReturn('input');
+        $element->shouldReceive('getAttribute')->andReturn('bar');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('resolveForTyping')
+            ->with('foo')
+            ->andReturn($element);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertInputValue('foo', 'bar');
+
+        try {
+            $browser->assertInputValue('foo', 'foo');
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Expected value [foo] for the [foo] input does not equal the actual value [bar].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_input_value_is_not()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getTagName')->andReturn('input');
+        $element->shouldReceive('getAttribute')->andReturn('bar');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('resolveForTyping')
+            ->with('foo')
+            ->andReturn($element);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertInputValueIsNot('foo', 'foo');
+
+        try {
+            $browser->assertInputValueIsNot('foo', 'bar');
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Value [bar] for the [foo] input should not equal the actual value.',
+                $e->getMessage()
+            );
+        }
+    }
 }


### PR DESCRIPTION
- Add test for [`assertValue()`](https://laravel.com/docs/8.x/dusk#assert-value)
- Add test for [`assertDialogOpened()`](https://laravel.com/docs/8.x/dusk#assert-dialog-opened)
- Add tests for [`assertVue()`](https://laravel.com/docs/8.x/dusk#assert-vue) / [`assertVueIsNot()`](https://laravel.com/docs/8.x/dusk#assert-vue-is-not)
- Add tests for [`assertInputValue()`](https://laravel.com/docs/8.x/dusk#assert-input-value) / [`assertInputValueIsNot()`](https://laravel.com/docs/8.x/dusk#assert-input-value-is-not)

---

- Customise error messages returned by
  - `assertValue()`
  - `assertVue()` / `assertVueIsNot()`