### PR TITLE
[6.x] Add new assertions `assertSeeEmptyTextIn()` and `assertDontSeeEmptyTextIn()`

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -206,6 +206,46 @@ trait MakesAssertions
     }
 
     /**
+     * Assert that the given selector has no text.
+     *
+     * @param  string  $selector
+     * @return $this
+     */
+    public function assertSeeEmptyTextIn($selector)
+    {
+        $fullSelector = $this->resolver->format($selector);
+
+        $element = $this->resolver->findOrFail($selector);
+
+        PHPUnit::assertTrue(
+            $element->getText() === '',
+            "Did not see expected text [''] within element [{$fullSelector}]."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given selector has some text.
+     *
+     * @param  string  $selector
+     * @return $this
+     */
+    public function assertDontSeeEmptyTextIn($selector)
+    {
+        $fullSelector = $this->resolver->format($selector);
+
+        $element = $this->resolver->findOrFail($selector);
+
+        PHPUnit::assertTrue(
+            $element->getText() !== '',
+            "Saw unexpected text [''] within element [{$fullSelector}]."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the given JavaScript expression evaluates to the given value.
      *
      * @param  string  $expression

--- a/tests/Concerns/InteractsWithElementsTest.php
+++ b/tests/Concerns/InteractsWithElementsTest.php
@@ -76,9 +76,9 @@ class InteractsWithElementsTest extends TestCase
     /**
      * @covers ::value
      * @dataProvider dataProviderValueWithValue
-     * @param mixed $selector
-     * @param mixed $value
-     * @param string $js
+     * @param mixed  $selector
+     * @param mixed  $value
+     * @param string  $js
      */
     public function testValueWithValue($selector, $value, string $js)
     {

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -1118,6 +1118,84 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_see_empty_text_in_element_with_empty_text()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getText')->andReturn('');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertSeeEmptyTextIn('foo');
+    }
+
+    public function test_assert_see_empty_text_in_element_without_empty_text()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getText')->andReturn('foo');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
+        $browser = new Browser($driver, $resolver);
+
+        try {
+            $browser->assertSeeEmptyTextIn('foo');
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Did not see expected text [\'\'] within element [body foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_dont_see_empty_text_in_element_with_empty_text()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getText')->andReturn('');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
+        $browser = new Browser($driver, $resolver);
+
+        try {
+            $browser->assertDontSeeEmptyTextIn('foo');
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Saw unexpected text [\'\'] within element [body foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_dont_see_empty_text_in_element_without_empty_text()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getText')->andReturn('foo');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertDontSeeEmptyTextIn('foo');
+    }
+
     public function test_assert_source_has()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
Sometimes it is helpful to check that a selector has some text (or conversely has no text) particularly when the value of the text is dynamically populated. This means it's less about asserting what the value of the text is but rather that there is some text (i.e. the contents of the selector is not empty).

This is where `assertSeeEmptyTextIn()` and `assertDontSeeEmptyTextIn()` comes into play.