### PR TITLE
[6.x] Add Browser::elsewhereWhenAvailable().

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -519,6 +519,20 @@ class Browser
     }
 
     /**
+     * Execute a Closure outside of the current browser scope when the selector is available.
+     *
+     * @param  string  $selector
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function elsewhereWhenAvailable($selector, Closure $callback)
+    {
+        return $this->elsewhere('', function ($browser) use ($selector, $callback) {
+            $this->whenAvailable($selector, $callback);
+        });
+    }
+
+    /**
      * Set the current component state.
      *
      * @param  \Laravel\Dusk\Component  $component


### PR DESCRIPTION
This will allows following to be refactored:

### Before

```php
        $browser->click('@filter-selector')
                    ->elsewhere('', function ($browser) use ($value) {
                        $browser->whenAvailable('@per-page-select', function ($browser) use ($value) {
                            $browser->select('', $value);
                        });
                    })
                    ->pause(250);
```


### After

```php
        $browser->click('@filter-selector')
                    ->elsewhereWhenAvailable('@per-page-select', function ($browser) use ($value) {
                        $browser->select('', $value);
                    })
                    ->pause(250);
``` 

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
