### PR TITLE
[7.x] Use selector to double click, and to click and hold

### DIFF
--- a/src/Concerns/InteractsWithMouse.php
+++ b/src/Concerns/InteractsWithMouse.php
@@ -85,25 +85,39 @@ trait InteractsWithMouse
     }
 
     /**
-     * Perform a mouse click and hold the mouse button down.
+     * Perform a mouse click and hold the mouse button down at the given selector.
      *
+     * @param  string|null  $selector
      * @return $this
      */
-    public function clickAndHold()
+    public function clickAndHold($selector = null)
     {
-        (new WebDriverActions($this->driver))->clickAndHold()->perform();
+        if (is_null($selector)) {
+            (new WebDriverActions($this->driver))->clickAndHold()->perform();
+        } else {
+            (new WebDriverActions($this->driver))->clickAndHold(
+                $this->resolver->findOrFail($selector)
+            )->perform();
+        }
 
         return $this;
     }
 
     /**
-     * Perform a double click at the current mouse position.
+     * Double click the element at the given selector.
      *
+     * @param  string|null  $selector
      * @return $this
      */
-    public function doubleClick()
+    public function doubleClick($selector = null)
     {
-        (new WebDriverActions($this->driver))->doubleClick()->perform();
+        if (is_null($selector)) {
+            (new WebDriverActions($this->driver))->doubleClick()->perform();
+        } else {
+            (new WebDriverActions($this->driver))->doubleClick(
+                $this->resolver->findOrFail($selector)
+            )->perform();
+        }
 
         return $this;
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds the ability to a developer use a selector with `->doubleClick()` and `->clickAndHold()`

Motivation was from Laracasts video: "Testing Your JavaScript" by @drehimself

https://laracasts.com/series/browser-testing-with-laravel-dusk/episodes/4


