### PR TITLE
[6.x] Add setInputValue alias

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -73,6 +73,18 @@ trait InteractsWithElements
     }
 
     /**
+     * Directly get or set the value attribute of an input field.
+     *
+     * @param  string  $selector
+     * @param  string  $value
+     * @return $this
+     */
+    public function setInputValue($selector, $value)
+    {
+        return $this->value($selector, $value);
+    }
+
+    /**
      * Get the text of the element matching the given selector.
      *
      * @param  string  $selector

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -73,7 +73,7 @@ trait InteractsWithElements
     }
 
     /**
-     * Directly get or set the value attribute of an input field.
+     * Directly set the value attribute of an input field.
      *
      * @param  string  $selector
      * @param  string  $value

--- a/tests/Concerns/InteractsWithElementsTest.php
+++ b/tests/Concerns/InteractsWithElementsTest.php
@@ -91,6 +91,19 @@ class InteractsWithElementsTest extends TestCase
     }
 
     /**
+     * @dataProvider dataProviderValueWithValue
+     */
+    public function testSetInputValue($selector, $value, string $js)
+    {
+        $this->resolver->expects(static::never())->method('findOrFail');
+        $this->resolver->expects(static::once())->method('format')->with($selector)->willReturn($selector);
+
+        $this->driver->expects(static::once())->method('executeScript')->with($js)->willReturn(42);
+
+        static::assertSame($this->trait, $this->trait->setInputValue($selector, $value));
+    }
+
+    /**
      * @covers ::value
      */
     public function testValueWithoutValue()


### PR DESCRIPTION
This PR adds a `setInputValue` alias that makes it easier to discover this functionality. Setting input values directly is especially useful when working with date inputs in React applications. Typing the date in an input can cause weird problems.

The method is currently very difficult to discover inside your IDE. Any search for "input" or "set" won't yield any results. Only by thoroughly reading the documentation you can find out you're supposed to use the `value` method. (I only discovered it while I was making the `setInputValue` method for this PR).


Before:
![image](https://user-images.githubusercontent.com/7202674/104884857-548d9300-5967-11eb-96e5-15858c01b38a.png)

After:
![image](https://user-images.githubusercontent.com/7202674/104884812-450e4a00-5967-11eb-8917-2d2774483eb0.png)
