### PR TITLE
Allow passing mixed to assertVue and assertVueIsNot

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -875,16 +875,18 @@ JS;
      * Assert that the Vue component's attribute at the given key has the given value.
      *
      * @param  string  $key
-     * @param  string  $value
+     * @param  mixed  $value
      * @param  string|null  $componentSelector
      * @return $this
      */
     public function assertVue($key, $value, $componentSelector = null)
     {
+        $formattedValue = json_encode($value);
+
         PHPUnit::assertEquals(
             $value,
             $this->vueAttribute($componentSelector, $key),
-            "Did not see expected value [{$value}] at the key [{$key}]."
+            "Did not see expected value [{$formattedValue}] at the key [{$key}]."
         );
 
         return $this;
@@ -894,16 +896,18 @@ JS;
      * Assert that a given Vue component data property does not match the given value.
      *
      * @param  string  $key
-     * @param  string  $value
+     * @param  mixed  $value
      * @param  string|null  $componentSelector
      * @return $this
      */
     public function assertVueIsNot($key, $value, $componentSelector = null)
     {
+        $formattedValue = json_encode($value);
+
         PHPUnit::assertNotEquals(
             $value,
             $this->vueAttribute($componentSelector, $key),
-            "Saw unexpected value [{$value}] at the key [{$key}]."
+            "Saw unexpected value [{$formattedValue}] at the key [{$key}]."
         );
 
         return $this;

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -889,7 +889,30 @@ class MakesAssertionsTest extends TestCase
             $browser->assertVue('foo', 'bar', 'foo');
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString(
-                'Did not see expected value [bar] at the key [foo].',
+                'Did not see expected value ["bar"] at the key [foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_vue_with_array()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('executeScript')->andReturn(['john', 'jane']);
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('@vue-component')->andReturn('body foo');
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertVue('users', ['john', 'jane'], '@vue-component');
+
+        try {
+            $browser->assertVue('users', ['john'], '@vue-component');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Did not see expected value [["john"]] at the key [users].',
                 $e->getMessage()
             );
         }
@@ -919,7 +942,30 @@ class MakesAssertionsTest extends TestCase
             $browser->assertVueIsNot('foo', 'foo', 'foo');
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString(
-                'Saw unexpected value [foo] at the key [foo].',
+                'Saw unexpected value ["foo"] at the key [foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_vue_is_not_with_array()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('executeScript')->andReturn(['john', 'jane']);
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('@vue-component')->andReturn('body foo');
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertVueIsNot('users', ['jane', 'john'], '@vue-component');
+
+        try {
+            $browser->assertVueIsNot('users', ['john', 'jane'], '@vue-component');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Saw unexpected value [["john","jane"]] at the key [users].',
                 $e->getMessage()
             );
         }


### PR DESCRIPTION
This addresses the issues #845 and #850.
The `assertVue` (and `assertVueIsNot`) method have a DocBlock that declared that the expected value must be of type `string`. However, Vue component data can contain data of any type that JavaScript supports. The PHPUnit `assertEquals` check also supports these types.

I often want to use `assertVue` to check if arrays or objects in Vue are in the desired state. So far, there are many use cases (like empty arrays, arrays with nested arrays, or objects) that are not supported yet by the available assertions in Dusk.

This PR therefore allows passing `mixed` values to `assertVue` and `assertVueIsNot`. The error message is now set up by JSON-encoding the expected value.