### PR TITLE
Add Chromium path for Debian 10

### DIFF
--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -113,6 +113,7 @@ class ChromeDriverCommand extends Command
         'linux' => [
             '/usr/bin/google-chrome --version',
             '/usr/bin/chromium-browser --version',
+            '/usr/bin/chromium --version',
             '/usr/bin/google-chrome-stable --version',
         ],
         'mac' => [


### PR DESCRIPTION
On my freshly installed Debian 10, `apt install chromium` create the executable in `/usr/bin/chromium`.
