### PR TITLE
[6.x] Fix the value generated when setting encrypted cookies

### DIFF
--- a/src/Concerns/InteractsWithCookies.php
+++ b/src/Concerns/InteractsWithCookies.php
@@ -79,6 +79,7 @@ trait InteractsWithCookies
     {
         if ($encrypt) {
             $prefix = CookieValuePrefix::create($name, Crypt::getKey());
+
             $value = encrypt($prefix.$value, $serialize = false);
         }
 

--- a/src/Concerns/InteractsWithCookies.php
+++ b/src/Concerns/InteractsWithCookies.php
@@ -78,7 +78,8 @@ trait InteractsWithCookies
     public function addCookie($name, $value, $expiry = null, array $options = [], $encrypt = true)
     {
         if ($encrypt) {
-            $value = encrypt($value, $serialize = false);
+            $prefix = CookieValuePrefix::create($name, Crypt::getKey());
+            $value = encrypt($prefix.$value, $serialize = false);
         }
 
         if ($expiry instanceof DateTimeInterface) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->








This PR updates the Dusk `Browser` object so that it sets encrypted cookies to match the way [laravel/framework](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Cookie/Middleware/EncryptCookies.php) does.

Without this, setting an encrypted cookie results in an invalid value that Laravel ignores:
``` php
$browser->addCookie($name, $value, $expiry = null, array $options = [], $encrypt = true);
```

For reference, this is where Laravel/Framework encrypts and decrypts cookies:
https://github.com/laravel/framework/blob/8.x/src/Illuminate/Cookie/Middleware/EncryptCookies.php#L147
https://github.com/laravel/framework/blob/8.x/src/Illuminate/Cookie/Middleware/EncryptCookies.php#L86

---

I'm not sure how to go about testing this within this package, as some of the functionality that's used to set cookies isn't available. (eg. the `encrypt` helper, Laravel's `app` object, etc).

I *have* tested this separately  in a Laravel installation by using addCookie to set an encrypted cookie, and then make a request to a page that spits out the cookies that were decrypted by the EncryptsCookies middleware.