### PR TITLE
[6.x] Do not resize to zero

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -296,7 +296,7 @@ class Browser
 
         $html = $this->driver->findElement(WebDriverBy::tagName('html'));
 
-        if (! empty($html) && $html->getSize()->getWidth() >= 0 && $html->getSize()->getHeight() >= 0) {
+        if (! empty($html) && $html->getSize()->getWidth() > 0 && $html->getSize()->getHeight() > 0) {
             $this->resize($html->getSize()->getWidth(), $html->getSize()->getHeight());
         }
 


### PR DESCRIPTION
At the moment fitContent will be able to resize to zero and thus making assertions basically useless. There was a PR that fixed this https://github.com/laravel/dusk/pull/730 but https://github.com/laravel/dusk/pull/815 seemed to have re-introduced it.

Fixes https://github.com/laravel/dusk/issues/856