### PR TITLE
[7.x] Drop PHP 7.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,18 +9,14 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    
+
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
+        php: [7.3, 7.4, 8.0]
         laravel: [^6.0, ^7.0, ^8.0]
         phpunit: [^8.4, ^9.0]
         exclude:
-          - php: 7.2
-            phpunit: ^9.0
-          - php: 7.2
-            laravel: ^8.0
           - php: 8.0
             phpunit: ^7.5
           - php: 8.0

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.3|^8.0",
         "ext-json": "*",
         "ext-zip": "*",
         "php-webdriver/webdriver": "^1.9.0",


### PR DESCRIPTION
This drops support for PHP 7.2 which isn't maintained anymore.