### PR TITLE
[7.x] Drop PHPUnit v8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,7 @@ jobs:
       matrix:
         php: [7.3, 7.4, 8.0]
         laravel: [^8.0]
-        phpunit: [^8.4, ^9.0]
-        exclude:
-          - php: 8.0
-            phpunit: ^8.4
+        phpunit: [^9.0]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }}
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^8.4|^9.0"
+        "phpunit/phpunit": "^9.0"
     },
     "suggest": {
         "ext-pcntl": "Used to gracefully terminate Dusk when tests are running."


### PR DESCRIPTION
This PR drops support for PHPUnit v8 which is unmaintained as of next week.