### PR TITLE
[7.x] Add ability to toggle headless options using --browse command options.

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -17,7 +17,8 @@ class DuskCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'dusk {--without-tty : Disable output to TTY}';
+    protected $signature = 'dusk {--without-tty : Disable output to TTY}
+                                {--browse : Display browser output instead of using headless mode}';
 
     /**
      * The console command description.
@@ -58,12 +59,21 @@ class DuskCommand extends Command
 
         $this->purgeSourceLogs();
 
-        $options = array_slice($_SERVER['argv'], $this->option('without-tty') ? 3 : 2);
+        $options = array_slice(
+            $_SERVER['argv'],
+            ($this->option('without-tty') && $this->option('browse') ? 4 : $this->option('without-tty') || $this->option('browse')) ? 3 : 2
+        );
 
         return $this->withDuskEnvironment(function () use ($options) {
+            $env = [];
+
+            if (! $this->option('browse')) {
+                $env['CI'] = true;
+            }
+
             $process = (new Process(array_merge(
                 $this->binary(), $this->phpunitArguments($options)
-            )))->setTimeout(null);
+            ), null, array_filter($env)))->setTimeout(null);
 
             try {
                 $process->setTty(! $this->option('without-tty'));

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -59,10 +59,10 @@ class DuskCommand extends Command
 
         $this->purgeSourceLogs();
 
-        $options = array_slice(
-            $_SERVER['argv'],
-            ($this->option('without-tty') && $this->option('browse') ? 4 : $this->option('without-tty') || $this->option('browse')) ? 3 : 2
-        );
+        $options = collect(array_slice($_SERVER['argv'], 2))
+            ->filter(function ($option) {
+                return ! in_array($option, ['--without-tty', '--browse']);
+            })->values()->all();
 
         return $this->withDuskEnvironment(function () use ($options) {
             $env = [];

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -31,11 +31,14 @@ abstract class DuskTestCase extends BaseTestCase
      */
     protected function driver()
     {
-        $options = (new ChromeOptions)->addArguments([
-            '--disable-gpu',
-            '--headless',
+        $options = (new ChromeOptions)->addArguments(collect([
             '--window-size=1920,1080',
-        ]);
+        ])->when(isset($_SERVER['CI']) || isset($_ENV['CI']), function ($collect) {
+            return $collect->merge([
+                '--disable-gpu',
+                '--headless',
+            ]);
+        })->all());
 
         return RemoteWebDriver::create(
             $_ENV['DUSK_DRIVER_URL'] ?? 'http://localhost:9515',


### PR DESCRIPTION
This follows GitHub Action environment where `CI=true` is always available.

* By default, `php artisan dusk` will run as headless by appending CI=true environment.
* This is equivalent to `CI=true vendor/bin/phpunit -c phpunit.xml` (users not using artisan dusk will see this as a breaking change).
* By adding `--browse`, the command will run by opening a browser

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>