### PR TITLE
[7.x] Add Dusk command argument --browse

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -17,7 +17,9 @@ class DuskCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'dusk {--without-tty : Disable output to TTY}';
+    protected $signature = 'dusk
+                {--browse : Display browser output instead of using headless mode}
+                {--without-tty : Disable output to TTY}';
 
     /**
      * The console command description.
@@ -58,12 +60,16 @@ class DuskCommand extends Command
 
         $this->purgeSourceLogs();
 
-        $options = array_slice($_SERVER['argv'], $this->option('without-tty') ? 3 : 2);
+        $options = collect($_SERVER['argv'])
+            ->slice(2)
+            ->diff(['--browse', '--without-tty'])
+            ->values()
+            ->all();
 
         return $this->withDuskEnvironment(function () use ($options) {
             $process = (new Process(array_merge(
                 $this->binary(), $this->phpunitArguments($options)
-            )))->setTimeout(null);
+            ), null, $this->env()))->setTimeout(null);
 
             try {
                 $process->setTty(! $this->option('without-tty'));
@@ -118,6 +124,18 @@ class DuskCommand extends Command
         }
 
         return array_merge(['-c', $file], $options);
+    }
+
+    /**
+     * Get the PHP binary environment variables.
+     *
+     * @return array|null
+     */
+    protected function env()
+    {
+        if ($this->option('browse') && ! isset($_ENV('CI')) && ! isset($_SERVER['CI'])) {
+            return ['DUSK_HEADLESS_DISABLED' => true];
+        }
     }
 
     /**

--- a/src/Console/DuskFailsCommand.php
+++ b/src/Console/DuskFailsCommand.php
@@ -9,7 +9,9 @@ class DuskFailsCommand extends DuskCommand
      *
      * @var string
      */
-    protected $signature = 'dusk:fails {--without-tty : Disable output to TTY}';
+    protected $signature = 'dusk:fails 
+                {--browse : Display browser output instead of using headless mode}
+                {--without-tty : Disable output to TTY}';
 
     /**
      * The console command description.

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -31,11 +31,14 @@ abstract class DuskTestCase extends BaseTestCase
      */
     protected function driver()
     {
-        $options = (new ChromeOptions)->addArguments([
-            '--disable-gpu',
-            '--headless',
+        $options = (new ChromeOptions)->addArguments(collect([
             '--window-size=1920,1080',
-        ]);
+        ])->unless($this->hasHeadlessDisabled(), function ($items) {
+            return $items->merge([
+                '--disable-gpu',
+                '--headless',
+            ]);
+        })->all());
 
         return RemoteWebDriver::create(
             $_ENV['DUSK_DRIVER_URL'] ?? 'http://localhost:9515',
@@ -43,5 +46,16 @@ abstract class DuskTestCase extends BaseTestCase
                 ChromeOptions::CAPABILITY, $options
             )
         );
+    }
+
+    /**
+     * Determine whether the Dusk command has disabled headless mode.
+     *
+     * @return bool
+     */
+    protected function hasHeadlessDisabled()
+    {
+        return isset($_SERVER['DUSK_HEADLESS_DISABLED']) ||
+            isset($_ENV['DUSK_HEADLESS_DISABLED']);
     }
 }


### PR DESCRIPTION
Alternate implementation of https://github.com/laravel/dusk/pull/864 as requested by Taylor.

Chromedriver headless mode can be disabled by calling:

```
php artisan dusk --browse
```

This allows devs to debug on desktop, showing the browser window as tests run. After upgrading to laravel/dusk 7.x, apps will need to reinstall the updated stub to use the `--browse` argument.

Differences in this implementation:

* shows in the code that headless mode is the default behavior, both in CI and _during local dev_
  * the other pull request sets `$env['CI'] = true` when Dusk is being run on laptop/desktop machines
* allows custom `DuskTestCase` stub classes to look for the presence of `--browse` rather than detecting its absence when choosing headless mode. Since Laravel Dusk <= 6.x stubs don't have this argument, it causes logic issues for 3rd-party packages that support many versions of Dusk.

Environment variable `DUSK_HEADLESS_DISABLED` could shortened but that's the best descriptive name I can currently think of.