### PR TITLE
[7.x] Add support for arm64 macOS

### DIFF
--- a/src/Chrome/ChromeProcess.php
+++ b/src/Chrome/ChromeProcess.php
@@ -79,7 +79,7 @@ class ChromeProcess
      */
     protected function chromeEnvironment()
     {
-        if ($this->onIntelMac() || $this->onWindows()) {
+        if ($this->onIntelMac() || $this->onArmMac() || $this->onWindows()) {
             return [];
         }
 

--- a/src/Chrome/ChromeProcess.php
+++ b/src/Chrome/ChromeProcess.php
@@ -39,9 +39,11 @@ class ChromeProcess
         if ($this->driver) {
             $driver = $this->driver;
         } elseif ($this->onWindows()) {
-            $driver = __DIR__.'/../../bin/chromedriver-win.exe';
-        } elseif ($this->onMac()) {
-            $driver = __DIR__.'/../../bin/chromedriver-mac';
+            $driver = realpath(__DIR__.'/../../bin/chromedriver-win.exe');
+        } elseif ($this->onIntelMac()) {
+            $driver = realpath(__DIR__.'/../../bin/chromedriver-mac-intel');
+        } elseif ($this->onArmMac()) {
+            $driver = realpath(__DIR__.'/../../bin/chromedriver-mac-arm');
         } else {
             $driver = __DIR__.'/../../bin/chromedriver-linux';
         }
@@ -77,7 +79,7 @@ class ChromeProcess
      */
     protected function chromeEnvironment()
     {
-        if ($this->onMac() || $this->onWindows()) {
+        if ($this->onIntelMac() || $this->onWindows()) {
             return [];
         }
 
@@ -95,12 +97,22 @@ class ChromeProcess
     }
 
     /**
-     * Determine if Dusk is running on Mac.
+     * Determine if Dusk is running on Mac x86_64.
      *
      * @return bool
      */
-    protected function onMac()
+    protected function onIntelMac()
     {
-        return OperatingSystem::onMac();
+        return OperatingSystem::onIntelMac();
+    }
+
+    /**
+     * Determine if Dusk is running on Mac arm64.
+     *
+     * @return bool
+     */
+    protected function onArmMac()
+    {
+        return OperatingSystem::onArmMac();
     }
 }

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -58,7 +58,8 @@ class ChromeDriverCommand extends Command
      */
     protected $slugs = [
         'linux' => 'linux64',
-        'mac' => 'mac64',
+        'mac-intel' => 'mac64',
+        'mac-arm' => 'mac64_m1',
         'win' => 'win32',
     ];
 
@@ -116,7 +117,10 @@ class ChromeDriverCommand extends Command
             '/usr/bin/chromium --version',
             '/usr/bin/google-chrome-stable --version',
         ],
-        'mac' => [
+        'mac-intel' => [
+            '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version',
+        ],
+        'mac-arm' => [
             '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version',
         ],
         'win' => [

--- a/src/OperatingSystem.php
+++ b/src/OperatingSystem.php
@@ -13,7 +13,15 @@ class OperatingSystem
      */
     public static function id()
     {
-        return static::onWindows() ? 'win' : (static::onMac() ? 'mac' : 'linux');
+        if (static::onWindows()) {
+            return 'win';
+        } elseif (static::onIntelMac()) {
+            return 'mac-intel';
+        } elseif (static::onArmMac()) {
+            return 'mac-arm';
+        }
+
+        return 'linux';
     }
 
     /**
@@ -27,12 +35,22 @@ class OperatingSystem
     }
 
     /**
-     * Determine if the operating system is macOS.
+     * Determine if the operating system is macOS x86_64.
      *
      * @return bool
      */
-    public static function onMac()
+    public static function onIntelMac()
     {
-        return PHP_OS === 'Darwin';
+        return PHP_OS === 'Darwin' && php_uname('m') === 'x86_64';
+    }
+
+    /**
+     * Determine if the operating system is macOS arm64.
+     *
+     * @return bool
+     */
+    public static function onArmMac()
+    {
+        return PHP_OS === 'Darwin' && php_uname('m') === 'arm64';
     }
 }

--- a/tests/ChromeProcessTest.php
+++ b/tests/ChromeProcessTest.php
@@ -28,12 +28,21 @@ class ChromeProcessTest extends TestCase
         }
     }
 
-    public function test_build_process_for_darwin()
+    public function test_build_process_for_darwin_intel()
     {
         try {
-            (new ChromeProcessDarwin)->toProcess();
+            (new ChromeProcessDarwinIntel)->toProcess();
         } catch (RuntimeException $exception) {
-            $this->assertStringContainsString('chromedriver-mac', $exception->getMessage());
+            $this->assertStringContainsString('chromedriver-mac-intel', $exception->getMessage());
+        }
+    }
+
+    public function test_build_process_for_darwin_arm()
+    {
+        try {
+            (new ChromeProcessDarwinArm)->toProcess();
+        } catch (RuntimeException $exception) {
+            $this->assertStringContainsString('chromedriver-mac-arm', $exception->getMessage());
         }
     }
 
@@ -63,9 +72,9 @@ class ChromeProcessWindows extends ChromeProcess
     }
 }
 
-class ChromeProcessDarwin extends ChromeProcess
+class ChromeProcessDarwinIntel extends ChromeProcess
 {
-    protected function onMac()
+    protected function onIntelMac()
     {
         return true;
     }
@@ -76,9 +85,32 @@ class ChromeProcessDarwin extends ChromeProcess
     }
 }
 
+class ChromeProcessDarwinArm extends ChromeProcess
+{
+    protected function onArmMac()
+    {
+        return true;
+    }
+
+    protected function onIntelMac()
+    {
+        return false;
+    }
+
+    protected function onWindows()
+    {
+        return false;
+    }
+}
+
 class ChromeProcessLinux extends ChromeProcess
 {
-    protected function onMac()
+    protected function onArmMac()
+    {
+        return false;
+    }
+
+    protected function onIntelMac()
     {
         return false;
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is a first pass at adding support for `arm64` macOS. 

I am opening this PR in order to start the discussion, alongside with the issue I opened earlier: https://github.com/laravel/dusk/issues/868.

On top of my head, this may raise a couple issues (but there may be more):
- What if the `arm64_m1` version of ChromeDriver is not available for the targeted Chrome version? Do we want to fail or fallback?
- What if the user has a version of Chrome that is not an Universal app? I am unsure whether the `arm64` version of ChromeDriver can start an Intel process.

I have tested this locally and it seems to work fine. The benefit is huge: running our Dusk test suite went from 7m 23s down to 3m 51s on my 13-inch M1 MacBook Pro.

Thank you!