### PR TITLE
[6.x] Add Dusk command argument --browse

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -18,7 +18,7 @@ class DuskCommand extends Command
      * @var string
      */
     protected $signature = 'dusk
-                {--browse : Display browser output instead of using headless mode}
+                {--browse : Open a browser instead of using headless mode}
                 {--without-tty : Disable output to TTY}';
 
     /**

--- a/src/Console/DuskFailsCommand.php
+++ b/src/Console/DuskFailsCommand.php
@@ -10,7 +10,7 @@ class DuskFailsCommand extends DuskCommand
      * @var string
      */
     protected $signature = 'dusk:fails 
-                {--browse : Display browser output instead of using headless mode}
+                {--browse : Open a browser instead of using headless mode}
                 {--without-tty : Disable output to TTY}';
 
     /**

--- a/src/Console/DuskFailsCommand.php
+++ b/src/Console/DuskFailsCommand.php
@@ -9,7 +9,9 @@ class DuskFailsCommand extends DuskCommand
      *
      * @var string
      */
-    protected $signature = 'dusk:fails {--without-tty : Disable output to TTY}';
+    protected $signature = 'dusk:fails 
+                {--browse : Display browser output instead of using headless mode}
+                {--without-tty : Disable output to TTY}';
 
     /**
      * The console command description.

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -56,6 +56,6 @@ abstract class DuskTestCase extends BaseTestCase
     protected function hasHeadlessDisabled()
     {
         return isset($_SERVER['DUSK_HEADLESS_DISABLED']) ||
-            isset($_ENV['DUSK_HEADLESS_DISABLED']);
+               isset($_ENV['DUSK_HEADLESS_DISABLED']);
     }
 }

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -31,11 +31,14 @@ abstract class DuskTestCase extends BaseTestCase
      */
     protected function driver()
     {
-        $options = (new ChromeOptions)->addArguments([
-            '--disable-gpu',
-            '--headless',
+        $options = (new ChromeOptions)->addArguments(collect([
             '--window-size=1920,1080',
-        ]);
+        ])->unless($this->hasHeadlessDisabled(), function ($items) {
+            return $items->merge([
+                '--disable-gpu',
+                '--headless',
+            ]);
+        })->all());
 
         return RemoteWebDriver::create(
             $_ENV['DUSK_DRIVER_URL'] ?? 'http://localhost:9515',
@@ -43,5 +46,16 @@ abstract class DuskTestCase extends BaseTestCase
                 ChromeOptions::CAPABILITY, $options
             )
         );
+    }
+
+    /**
+     * Determine whether the Dusk command has disabled headless mode.
+     *
+     * @return bool
+     */
+    protected function hasHeadlessDisabled()
+    {
+        return isset($_SERVER['DUSK_HEADLESS_DISABLED']) ||
+            isset($_ENV['DUSK_HEADLESS_DISABLED']);
     }
 }


### PR DESCRIPTION
### For existing Laravel apps to start using the `--browse` argument they need to run `php artisan dusk:install`. This updates the `tests/DuskTestCase.php` stub class in their app's code base.

This is a merge-ready implementation of https://github.com/laravel/dusk/pull/864 started by @crynobone.

During local dev, Chromedriver headless mode can be disabled by calling:

```
php artisan dusk --browse
```

or

```
php artisan dusk:fails --browse
```

When Chromedriver's failing test screenshot doesn't capture enough, this allows devs to further debug by showing the live browser window while tests run.

> When environment variable `CI` is set, the `--browse` argument is ignored and headless mode is always used. This variable is configured by most CI services (GitHub Actions, CircleCI, TravisCI, etc.) and no windowing system is available in those OS environments so Google Chrome cannot be opened.