### PR TITLE
[6.x] Fix DuskCommand syntax mistake

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -129,7 +129,7 @@ class DuskCommand extends Command
      */
     protected function env()
     {
-        if ($this->option('browse') && ! isset($_ENV('CI')) && ! isset($_SERVER['CI'])) {
+        if ($this->option('browse') && ! isset($_ENV['CI']) && ! isset($_SERVER['CI'])) {
             return ['DUSK_HEADLESS_DISABLED' => true];
         }
     }


### PR DESCRIPTION
Now that I've actually tested the `--browse` feature in a sample app, fix a stupid syntax error I introduced in: https://github.com/laravel/dusk/pull/870

It would be good to get test coverage on `DuskCommand` but it may require:
* disabling `$this->withDuskEnvironment()`
* using Mockery static namespace overloading (eh) because the `Symfony\Component\Process\Process`  object isn't resolved from Laravel's container.
