### PR TITLE
[6.x] Add `assertNotPresent()` assertion

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -719,6 +719,24 @@ JS;
 
         return $this;
     }
+    
+    /**
+     * Assert that the element matching the given selector is not present.
+     *
+     * @param  string  $selector
+     * @return $this
+     */
+    public function assertNotPresent($selector)
+    {
+        $fullSelector = $this->resolver->format($selector);
+
+        PHPUnit::assertTrue(
+            is_null($this->resolver->find($selector)),
+            "Element [{$fullSelector}] is present."
+        );
+
+        return $this;
+    }
 
     /**
      * Assert that the element matching the given selector is not visible.

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -719,7 +719,7 @@ JS;
 
         return $this;
     }
-    
+
     /**
      * Assert that the element matching the given selector is not present.
      *

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -669,6 +669,37 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_not_present()
+    {
+        $driver = m::mock(stdClass::class);
+        $element = m::mock(stdClass::class);
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
+        $resolver->shouldReceive('find')->with('foo')->andReturn(
+            null,
+            null
+        );
+        $resolver->shouldReceive('format')->with('bar')->andReturn('body bar');
+        $resolver->shouldReceive('find')->with('bar')->andReturn(
+            $element,
+            null
+        );
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertNotPresent('foo');
+
+        try {
+            $browser->assertNotPresent('bar');
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Element [body bar] is present.',
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_missing_and_element_is_displayed()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
I recently ran into a use case where I needed to ensure an array of inputs would definitely submit on the page, and another array of inputs definitely were not.

`assertPresent()` was exactly what I needed, but I could not find an inverse of it.
`assertMissing()` checked that the input was visible, but some of the inputs are hidden and replaced via JavaScript, so this doesn't work.

Therefore, I added an `assertNotPresent()` assertion for this specific use-case. 
I did think of naming it `assertAbsent()` but think the distinction between this and `assertMissing()` could become confusing...

This is the relevant part of the test I wanted to write:
```php
collect($this->data['support_staff_only_fields'])->each(
    fn($field) => $browser->assertPresent("[name='{$field}']")
);
collect($this->data['franchisee_only_fields'])->each(
    fn($field) => $browser->assertNotPresent("[name='{$field}']")
);
```