### PR TITLE
[6.x] Move commands to boot method

### DIFF
--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -36,17 +36,7 @@ class DuskServiceProvider extends ServiceProvider
                 ]);
             });
         }
-    }
 
-    /**
-     * Register any package services.
-     *
-     * @return void
-     *
-     * @throws \Exception
-     */
-    public function register()
-    {
         if ($this->app->runningInConsole()) {
             $this->commands([
                 Console\InstallCommand::class,


### PR DESCRIPTION
Booting of commands belongs in the boot method of a service provider.