### PR TITLE
[6.x] Added middleware configuration for authentication endpoints

### DIFF
--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -18,7 +18,7 @@ class DuskServiceProvider extends ServiceProvider
             Route::group(array_filter([
                 'prefix' => config('dusk.path', '_dusk'),
                 'domain' => config('dusk.domain', null),
-                'middleware' => 'web',
+                'middleware' => config('dusk.middleware', 'web'),
             ]), function () {
                 Route::get('/login/{userId}/{guard?}', [
                     'uses' => 'Laravel\Dusk\Http\Controllers\UserController@login',


### PR DESCRIPTION
In some cases, the 'web' middleware doesn't quite cut it when you're trying to authenticate against Dusk, for example:

- You have set up Laravel Fortify with custom middleware.
- You're using a multi-tenancy approach where the middleware needs to identify the tenant before authentication can take place.

The suggested configuration is optional and shouldn't break anything.

Current workaround would be to override the service provider and rewrite the routing code yourself (there are quite few lines to override though).