### PR TITLE
[6.x] Update `scrollTo` to work without JQuery

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -366,12 +366,10 @@ class Browser
      */
     public function scrollTo($selector)
     {
-        $this->ensurejQueryIsAvailable();
-
         $selector = addslashes($this->resolver->format($selector));
 
-        $this->driver->executeScript("jQuery(\"html, body\").animate({scrollTop: jQuery(\"$selector\").offset().top}, 0);");
-
+        $this->driver->executeScript("window.scrollBy(0, document.querySelector(\"$selector\").getBoundingClientRect().top)");
+        
         return $this;
     }
 

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -369,7 +369,7 @@ class Browser
         $selector = addslashes($this->resolver->format($selector));
 
         $this->driver->executeScript("window.scrollBy(0, document.querySelector(\"$selector\").getBoundingClientRect().top)");
-        
+
         return $this;
     }
 


### PR DESCRIPTION
I want to use `scrollTo` without adding JQuery to my website front-end.
This script works without JQuery.