### PR TITLE
[6.x] Add InteractsWithElements@typeAtXPath

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -160,6 +160,23 @@ trait InteractsWithElements
     }
 
     /**
+     * type the given value in the given field with XPath expression.
+     *
+     * @param  string  $field
+     * @param  string  $value
+     * @return $this
+     */
+    public function typeAtXPath($field, $value)
+    {
+        $this->driver
+            ->findElement(WebDriverBy::xpath($field))
+            ->clear()
+            ->sendKeys($value);
+
+        return $this;
+    }
+
+    /**
      * Type the given value in the given field without clearing it.
      *
      * @param  string  $field

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -160,16 +160,16 @@ trait InteractsWithElements
     }
 
     /**
-     * type the given value in the given field with XPath expression.
+     * type the given value in the given XPath expression.
      *
-     * @param  string  $field
+     * @param  string  $expression
      * @param  string  $value
      * @return $this
      */
-    public function typeAtXPath($field, $value)
+    public function typeAtXPath($expression, $value)
     {
         $this->driver
-            ->findElement(WebDriverBy::xpath($field))
+            ->findElement(WebDriverBy::xpath($expression))
             ->clear()
             ->sendKeys($value);
 

--- a/src/Concerns/InteractsWithMouse.php
+++ b/src/Concerns/InteractsWithMouse.php
@@ -72,7 +72,7 @@ trait InteractsWithMouse
     /**
      * Click the element at the given XPath expression.
      *
-     * @param  string  $selector
+     * @param  string  $expression
      * @return $this
      */
     public function clickAtXPath($expression)


### PR DESCRIPTION
typeByXPath() method could be useful if you want to type on the element by its XPath rather than CSS selector.

useful for #69
