### PR TITLE
Fixes for class imports

### DIFF
--- a/src/Console/stubs/page.stub
+++ b/src/Console/stubs/page.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
-use Laravel\Dusk\Page;
 use Laravel\Dusk\Browser;
+use Laravel\Dusk\Page;
 
 class DummyClass extends Page
 {

--- a/src/Console/stubs/page.stub
+++ b/src/Console/stubs/page.stub
@@ -2,6 +2,7 @@
 
 namespace DummyNamespace;
 
+use Laravel\Dusk\Page;
 use Laravel\Dusk\Browser;
 
 class DummyClass extends Page


### PR DESCRIPTION
When using `php artisan dusk:page` command a new class will be created without `Laravel\Dusk\Page` import. This fixes it.