### PR TITLE
Fix unicode support in appendSlowly method

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -185,7 +185,7 @@ trait InteractsWithElements
      */
     public function appendSlowly($field, $value, $pause = 100)
     {
-        foreach (str_split($value) as $char) {
+        foreach (preg_split('//u', $value, -1, PREG_SPLIT_NO_EMPTY) as $char) {
             $this->append($field, $char)->pause($pause);
         }
 


### PR DESCRIPTION
Currently, if we use for example Cyrillic symbols in `typeSlowly` or `appendSlowly` methods, they are processed with `str_split` function, which does not correctly processes unicode characters.

```php 
str_split('Образец')
```
will return:

```php
array:14 [
  0 => b"Ð"
  1 => b"ž"
  2 => b"Ð"
  3 => b"±"
  4 => b"Ñ"
  5 => b"€"
  6 => b"Ð"
  7 => b"°"
  8 => b"Ð"
  9 => b"·"
  10 => b"Ð"
  11 => b"µ"
  12 => b"Ñ"
  13 => b"†"
]
```
After that, web-driver will send the `sendKeysToElement` command with parameters similar as follows: "�" instead of `{"text":"О",":id": ...}`

Server will respond to this request with the following exception: "**invalid argument: missing command parameters**".

Replacing `str_split` with `mb_str_split` (PHP >= 7.4) or with `preg_split('\\u', ...)` fix this issue.

```php
preg_split('//u', 'Образец', -1, PREG_SPLIT_NO_EMPTY)

=> array:7 [
  0 => "О"
  1 => "б"
  2 => "р"
  3 => "а"
  4 => "з"
  5 => "е"
  6 => "ц"
]
```

And server will receive correct command parameters:
`sendKeysToElement || {"text":"\u0430",":id": ...}`