### PR TITLE
Make `DuskCommand` compatible with Pest

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -20,7 +20,7 @@ class DuskCommand extends Command
     protected $signature = 'dusk
                 {--browse : Open a browser instead of using headless mode}
                 {--without-tty : Disable output to TTY}
-                {--pest : Run the Dusk tests for the application with Pest}';
+                {--pest : Run the Dusk tests using Pest}';
 
     /**
      * The console command description.

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -19,7 +19,8 @@ class DuskCommand extends Command
      */
     protected $signature = 'dusk
                 {--browse : Open a browser instead of using headless mode}
-                {--without-tty : Disable output to TTY}';
+                {--without-tty : Disable output to TTY}
+                {--pest : Run the Dusk tests for the application with Pest}';
 
     /**
      * The console command description.
@@ -96,11 +97,17 @@ class DuskCommand extends Command
      */
     protected function binary()
     {
-        if ('phpdbg' === PHP_SAPI) {
-            return [PHP_BINARY, '-qrr', 'vendor/phpunit/phpunit/phpunit'];
+        $binaryPath = 'vendor/phpunit/phpunit/phpunit';
+
+        if ($this->option('pest')) {
+            $binaryPath = 'vendor/pestphp/pest/bin/pest';
         }
 
-        return [PHP_BINARY, 'vendor/phpunit/phpunit/phpunit'];
+        if ('phpdbg' === PHP_SAPI) {
+            return [PHP_BINARY, '-qrr', $binaryPath];
+        }
+
+        return [PHP_BINARY, $binaryPath];
     }
 
     /**
@@ -112,7 +119,7 @@ class DuskCommand extends Command
     protected function phpunitArguments($options)
     {
         $options = array_values(array_filter($options, function ($option) {
-            return ! Str::startsWith($option, '--env=');
+            return ! Str::startsWith($option, ['--env=', '--pest']);
         }));
 
         if (! file_exists($file = base_path('phpunit.dusk.xml'))) {

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -20,7 +20,7 @@ class DuskCommand extends Command
     protected $signature = 'dusk
                 {--browse : Open a browser instead of using headless mode}
                 {--without-tty : Disable output to TTY}
-                {--pest : Run the Dusk tests using Pest}';
+                {--pest : Run the tests using Pest}';
 
     /**
      * The console command description.


### PR DESCRIPTION
This PR introduces a flag will allow  Pest to be used, so Dusk tests can be written with the Pest syntax.