### PR TITLE
[6.x] Support waiting for URLs with `waitForLocation`

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -160,7 +160,9 @@ trait WaitsForElements
     {
         $message = $this->formatTimeOutMessage('Waited %s seconds for location', $path);
 
-        return $this->waitUntil("window.location.pathname == '{$path}'", $seconds, $message);
+        return Str::startsWith($path, ['http://', 'https://'])
+            ? $this->waitUntil('`${location.protocol}//${location.host}${location.pathname}` == \''.$path.'\'', $seconds, $message)
+            : $this->waitUntil("window.location.pathname == '{$path}'", $seconds, $message);
     }
 
     /**

--- a/tests/WaitsForElementsTest.php
+++ b/tests/WaitsForElementsTest.php
@@ -83,6 +83,24 @@ class WaitsForElementsTest extends TestCase
         $browser->waitForLocation('/home');
     }
 
+    public function test_can_wait_for_a_url_location()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('executeScript')->with('return `${location.protocol}//${location.host}${location.pathname}` == \'http://example.com/home\';')->andReturnTrue();
+        $browser = new Browser($driver);
+
+        $browser->waitForLocation('http://example.com/home');
+    }
+
+    public function test_can_wait_for_a_ssl_url_location()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('executeScript')->with('return `${location.protocol}//${location.host}${location.pathname}` == \'https://example.com/home\';')->andReturnTrue();
+        $browser = new Browser($driver);
+
+        $browser->waitForLocation('https://example.com/home');
+    }
+
     public function test_can_wait_for_route()
     {
         $this->swapUrlGenerator();


### PR DESCRIPTION
One of my projects has a model that returns a dynamic URL. In my test, I want Dusk to click a link, and then wait for that location. The test looks something like this:

```php
$browser->click('@visit-'.$model->id)
    ->waitForLocation($model->detail_page_url)
    ...
```

The code above doesn't work, because `$model->detail_page_url` returns a full URL, but `waitForLocation` can only wait for paths (`/some-path`). This PR updates `waitForLocation` so it can also wait for full URLs. There is currently no method to wait for a URL.

I've chosen to use `${location.protocol}//${location.host}${location.pathname}` to get the current URL (taken from this [StackOverflow answer](https://stackoverflow.com/a/5817566/7032830)). This way query parameters and fragment identifiers (`#`) in the current URL are ignored.
