### PR TITLE
[6.x] Add `waitUntilEnabled` and `waitUntilDisabled`

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -242,6 +242,42 @@ trait WaitsForElements
     }
 
     /**
+     * Wait until an element is enabled.
+     *
+     * @param  string  $selector
+     * @param  int|null  $seconds
+     * @return $this
+     */
+    public function waitUntilEnabled($selector, $seconds = null)
+    {
+        $message = $this->formatTimeOutMessage('Waited %s seconds for element to be enabled', $selector);
+
+        $this->waitUsing($seconds, 100, function () use ($selector) {
+            return $this->resolver->findOrFail($selector)->isEnabled();
+        }, $message);
+
+        return $this;
+    }
+
+    /**
+     * Wait until an element is disabled.
+     *
+     * @param  string  $selector
+     * @param  int|null  $seconds
+     * @return $this
+     */
+    public function waitUntilDisabled($selector, $seconds = null)
+    {
+        $message = $this->formatTimeOutMessage('Waited %s seconds for element to be disabled', $selector);
+
+        $this->waitUsing($seconds, 100, function () use ($selector) {
+            return ! $this->resolver->findOrFail($selector)->isEnabled();
+        }, $message);
+
+        return $this;
+    }
+
+    /**
      * Wait for a JavaScript dialog to open.
      *
      * @param  int|null  $seconds

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -181,6 +181,42 @@ trait WaitsForElements
     }
 
     /**
+     * Wait until an element is enabled.
+     *
+     * @param  string  $selector
+     * @param  int|null  $seconds
+     * @return $this
+     */
+    public function waitUntilEnabled($selector, $seconds = null)
+    {
+        $message = $this->formatTimeOutMessage('Waited %s seconds for element to be enabled', $selector);
+
+        $this->waitUsing($seconds, 100, function () use ($selector) {
+            return $this->resolver->findOrFail($selector)->isEnabled();
+        }, $message);
+
+        return $this;
+    }
+
+    /**
+     * Wait until an element is disabled.
+     *
+     * @param  string  $selector
+     * @param  int|null  $seconds
+     * @return $this
+     */
+    public function waitUntilDisabled($selector, $seconds = null)
+    {
+        $message = $this->formatTimeOutMessage('Waited %s seconds for element to be disabled', $selector);
+
+        $this->waitUsing($seconds, 100, function () use ($selector) {
+            return ! $this->resolver->findOrFail($selector)->isEnabled();
+        }, $message);
+
+        return $this;
+    }
+
+    /**
      * Wait until the given script returns true.
      *
      * @param  string  $script
@@ -237,42 +273,6 @@ trait WaitsForElements
         $this->waitUsing($seconds, 100, function () use ($key, $value, $componentSelector) {
             return $value != $this->vueAttribute($componentSelector, $key);
         });
-
-        return $this;
-    }
-
-    /**
-     * Wait until an element is enabled.
-     *
-     * @param  string  $selector
-     * @param  int|null  $seconds
-     * @return $this
-     */
-    public function waitUntilEnabled($selector, $seconds = null)
-    {
-        $message = $this->formatTimeOutMessage('Waited %s seconds for element to be enabled', $selector);
-
-        $this->waitUsing($seconds, 100, function () use ($selector) {
-            return $this->resolver->findOrFail($selector)->isEnabled();
-        }, $message);
-
-        return $this;
-    }
-
-    /**
-     * Wait until an element is disabled.
-     *
-     * @param  string  $selector
-     * @param  int|null  $seconds
-     * @return $this
-     */
-    public function waitUntilDisabled($selector, $seconds = null)
-    {
-        $message = $this->formatTimeOutMessage('Waited %s seconds for element to be disabled', $selector);
-
-        $this->waitUsing($seconds, 100, function () use ($selector) {
-            return ! $this->resolver->findOrFail($selector)->isEnabled();
-        }, $message);
 
         return $this;
     }

--- a/tests/WaitsForElementsTest.php
+++ b/tests/WaitsForElementsTest.php
@@ -151,4 +151,26 @@ class WaitsForElementsTest extends TestCase
             $this->assertSame('Waited 1 seconds for text [Discount: 20%].', $e->getMessage());
         }
     }
+
+    public function test_wait_for_an_element_to_be_enabled()
+    {
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('isEnabled')->andReturn(true);
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('findOrFail')->with('#button')->andReturn($element);
+        $browser = new Browser(new stdClass, $resolver);
+
+        $browser->waitUntilEnabled('#button', 1);
+    }
+
+    public function test_wait_for_an_element_to_be_disabled()
+    {
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('isEnabled')->andReturn(false);
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('findOrFail')->with('#button')->andReturn($element);
+        $browser = new Browser(new stdClass, $resolver);
+
+        $browser->waitUntilDisabled('#button', 1);
+    }
 }


### PR DESCRIPTION
This PR adds methods for waiting until an element is enabled or disabled.

These methods are especially useful when using `wire:loading.attr="disabled"` on Livewire buttons:

```html
<x-button wire:click="generateExport"
          wire:loading.attr="disabled"
          dusk="generate-export"
>Export</x-button>
```

```php
$browser->click('@generate-export')
    ->assertDisabled('@generate-export')
    ->waitUntilEnabled('@generate-export')
    ...
```
