### PR TITLE
[6.x] Set Component as possible variable type to phpdoc of methods with, within, elsewhere

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -457,7 +457,7 @@ class Browser
     /**
      * Execute a Closure with a scoped browser instance.
      *
-     * @param  string|Component  $selector
+     * @param  string|\Laravel\Dusk\Component  $selector
      * @param  \Closure  $callback
      * @return $this
      */
@@ -469,7 +469,7 @@ class Browser
     /**
      * Execute a Closure with a scoped browser instance.
      *
-     * @param  string|Component  $selector
+     * @param  string|\Laravel\Dusk\Component  $selector
      * @param  \Closure  $callback
      * @return $this
      */
@@ -495,7 +495,7 @@ class Browser
     /**
      * Execute a Closure outside of the current browser scope.
      *
-     * @param  string|Component  $selector
+     * @param  string|\Laravel\Dusk\Component  $selector
      * @param  \Closure  $callback
      * @return $this
      */

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -457,7 +457,7 @@ class Browser
     /**
      * Execute a Closure with a scoped browser instance.
      *
-     * @param  string  $selector
+     * @param  string|Component  $selector
      * @param  \Closure  $callback
      * @return $this
      */
@@ -469,7 +469,7 @@ class Browser
     /**
      * Execute a Closure with a scoped browser instance.
      *
-     * @param  string  $selector
+     * @param  string|Component  $selector
      * @param  \Closure  $callback
      * @return $this
      */
@@ -495,7 +495,7 @@ class Browser
     /**
      * Execute a Closure outside of the current browser scope.
      *
-     * @param  string  $selector
+     * @param  string|Component  $selector
      * @param  \Closure  $callback
      * @return $this
      */


### PR DESCRIPTION
phpstan throws an error on lines above.
PR makes possible to set `Component` class as a variable to methods `with`, `within`, `elsewhere` without hints.
