### PR TITLE
[6.x] Fix "pest" option does not exist on dusk:fails command

### DIFF
--- a/src/Console/DuskFailsCommand.php
+++ b/src/Console/DuskFailsCommand.php
@@ -9,9 +9,10 @@ class DuskFailsCommand extends DuskCommand
      *
      * @var string
      */
-    protected $signature = 'dusk:fails 
+    protected $signature = 'dusk:fails
                 {--browse : Open a browser instead of using headless mode}
-                {--without-tty : Disable output to TTY}';
+                {--without-tty : Disable output to TTY}
+                {--pest : Run the tests using Pest}';
 
     /**
      * The console command description.


### PR DESCRIPTION
This is to fix the [#920] issue.

This is because the $signature property of the parent class is overridden by the child class for which the "pest" option is missing.

See :
https://github.com/laravel/dusk/blob/6.x/src/Console/DuskCommand.php#L102
https://github.com/laravel/dusk/blob/6.x/src/Console/DuskCommand.php#L20
https://github.com/laravel/dusk/blob/6.x/src/Console/DuskFailsCommand.php#L12