### PR TITLE
[6.x] Using loginAs with id

### DIFF
--- a/src/Concerns/InteractsWithAuthentication.php
+++ b/src/Concerns/InteractsWithAuthentication.php
@@ -26,7 +26,7 @@ trait InteractsWithAuthentication
      */
     public function loginAs($userId, $guard = null)
     {
-        $userId = method_exists($userId, 'getKey') ? $userId->getKey() : $userId;
+        $userId = is_object($userId) && method_exists($userId, 'getKey') ? $userId->getKey() : $userId;
 
         return $this->visit(rtrim(route('dusk.login', ['userId' => $userId, 'guard' => $guard], $this->shouldUseAbsoluteRouteForAuthentication())));
     }


### PR DESCRIPTION
`loginAs` method allows you to pass a User eloquent model instance or an integer of user id.

starting from PHP 8.0, when passing an integer to method_exists as its first argument, PHP will throws a FatalError.

This PR fixes it by checking if `$userId` is an object first.

References:
 - https://wiki.php.net/rfc/consistent_type_errors
 - https://3v4l.org/9NImG