### PR TITLE
Fix DevToolsActivePort file doesn't exist when Dusk run as "root"

### DIFF
--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -33,6 +33,7 @@ abstract class DuskTestCase extends BaseTestCase
     {
         $options = (new ChromeOptions)->addArguments(collect([
             '--window-size=1920,1080',
+            '--no-sandbox',
         ])->unless($this->hasHeadlessDisabled(), function ($items) {
             return $items->merge([
                 '--disable-gpu',


### PR DESCRIPTION
This happens when Dusk is running in an environment with the user "root" because Chrome doesn't allow running as "root" without `--no-sandbox`.

See : https://crbug.com/638180

![error](https://user-images.githubusercontent.com/37969970/133303749-1c42a22d-b063-4064-88c1-b6fa1bf5943a.png)
