### PR TITLE
Chnage assertAttribute to use assertStringContainsString

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -679,7 +679,7 @@ JS;
             "Did not see expected attribute [{$attribute}] within element [{$fullSelector}]."
         );
 
-        PHPUnit::assertEquals(
+        PHPUnit::assertStringContainsString(
             $value,
             $actual,
             "Expected '$attribute' attribute [{$value}] does not equal actual value [$actual]."


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR make change in assertAttribute method to assertStringContainsString instead of assertEquals.

This will provied us to assert if a class exists inside a class attribute that most of the time has more then one class separated by spaces, for example.
