### PR TITLE
Chnage assertAttribute to use assertStringContainsString

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -679,7 +679,7 @@ JS;
             "Did not see expected attribute [{$attribute}] within element [{$fullSelector}]."
         );
 
-        PHPUnit::assertEquals(
+        PHPUnit::assertStringContainsString(
             $value,
             $actual,
             "Expected '$attribute' attribute [{$value}] does not equal actual value [$actual]."


### PR DESCRIPTION
This PR make change in assertAttribute method to assertStringContainsString instead of assertEquals.

This will provide us to assert if a class exists inside a class attribute that most of the time has more than one class separated by spaces, for example.