### PR TITLE
Add new assertion `assertValueIsNot()`

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -631,6 +631,28 @@ JS;
     }
 
     /**
+     * Assert that the element matching the given selector does not have the given value.
+     *
+     * @param  string  $selector
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertValueIsNot($selector, $value)
+    {
+        $fullSelector = $this->resolver->format($selector);
+
+        $actual = $this->resolver->findOrFail($selector)->getAttribute('value');
+
+        PHPUnit::assertNotEquals(
+            $value,
+            $actual,
+            "Saw unexpected value [{$value}] within element [{$fullSelector}]."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the element matching the given selector has the given value in the provided attribute.
      *
      * @param  string  $selector

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -462,8 +462,7 @@ class MakesAssertionsTest extends TestCase
         $driver = m::mock(stdClass::class);
 
         $element = m::mock(RemoteWebElement::class);
-        $element->shouldReceive('getAttribute')
-            ->andReturn('bar');
+        $element->shouldReceive('getAttribute')->andReturn('bar');
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
@@ -478,6 +477,31 @@ class MakesAssertionsTest extends TestCase
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString(
                 'Did not see expected value [foo] within element [body foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_value_is_not()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element = m::mock(RemoteWebElement::class);
+        $element->shouldReceive('getAttribute')->andReturn('bar');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertValueIsNot('foo', 'foo');
+
+        try {
+            $browser->assertValueIsNot('foo', 'bar');
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Saw unexpected value [bar] within element [body foo].',
                 $e->getMessage()
             );
         }


### PR DESCRIPTION
The new `assertValueIsNot()` compliments the existing [`assertValue()`](https://laravel.com/docs/8.x/dusk#assert-value).

This is similar to the existing pattern of having [`assertInputValue()`](https://laravel.com/docs/8.x/dusk#assert-input-value) and [`assertInputValueIsNot()`](https://laravel.com/docs/8.x/dusk#assert-input-value-is-not).

(Tests included ✅)