### PR TITLE
Add new assertion `assertAttributeContains()`

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -659,6 +659,34 @@ JS;
     }
 
     /**
+     * Assert that the element matching the given selector contains the given value in the provided attribute.
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertAttributeContains($selector, $attribute, $value)
+    {
+        $fullSelector = $this->resolver->format($selector);
+
+        $actual = $this->resolver->findOrFail($selector)->getAttribute($attribute);
+
+        PHPUnit::assertNotNull(
+            $actual,
+            "Did not see expected attribute [{$attribute}] within element [{$fullSelector}]."
+        );
+
+        PHPUnit::assertStringContainsString(
+            $value,
+            $actual,
+            "Expected '$attribute' attribute [{$value}] is not part of the value [$actual]."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the element matching the given selector has the given value in the provided aria attribute.
      *
      * @param  string  $selector

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -523,6 +523,46 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_attribute_contains()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getAttribute')->with('bar')->andReturn(
+            'class-a class-b',
+            null,
+            'class-1 class-2'
+        );
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('Foo');
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertAttributeContains('foo', 'bar', 'class-b');
+
+        try {
+            $browser->assertAttributeContains('foo', 'bar', 'class-b');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Did not see expected attribute [bar] within element [Foo].',
+                $e->getMessage()
+            );
+        }
+
+        try {
+            $browser->assertAttributeContains('foo', 'bar', 'class-b');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                "Expected 'bar' attribute [class-b] is not part of the value [class-1 class-2].",
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_data_attribute()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
RE: PR #926

The new `assertAttributeContains()` compliments the existing [`assertAttribute()`](https://laravel.com/docs/8.x/dusk#assert-attribute).

(Tests included ✅)

---

ℹ️ **Failing StyleCI check (docblock spacing for a method I haven't changed) is fixed in my previous PR #929**