### PR TITLE
Allow calling `assertValue()` on elements which don't support the `value` attribute

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -417,6 +417,32 @@ JS;
     }
 
     /**
+     * Get the value of the given selector.
+     *
+     * @param  string  $selector
+     * @return string
+     */
+    public function elementValue($selector)
+    {
+        $element = $this->resolver->findOrFail($selector);
+
+        $elementsSupportingTheValueAttribute = [
+            'button',
+            'input',
+            'li',
+            'meter',
+            'option',
+            'param',
+            'progress',
+            'textarea',
+        ];
+
+        return in_array($element->getTagName(), $elementsSupportingTheValueAttribute)
+                        ? $element->getAttribute('value')
+                        : $element->getText();
+    }
+
+    /**
      * Assert that the given input field is present.
      *
      * @param  string  $field
@@ -649,11 +675,9 @@ JS;
     {
         $fullSelector = $this->resolver->format($selector);
 
-        $actual = $this->resolver->findOrFail($selector)->getAttribute('value');
-
         PHPUnit::assertEquals(
             $value,
-            $actual,
+            $this->elementValue($selector),
             "Did not see expected value [{$value}] within element [{$fullSelector}]."
         );
 
@@ -671,11 +695,9 @@ JS;
     {
         $fullSelector = $this->resolver->format($selector);
 
-        $actual = $this->resolver->findOrFail($selector)->getAttribute('value');
-
         PHPUnit::assertNotEquals(
             $value,
-            $actual,
+            $this->elementValue($selector),
             "Saw unexpected value [{$value}] within element [{$fullSelector}]."
         );
 


### PR DESCRIPTION
### Reasoning

Similar to [`assertInputValue()`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/MakesAssertions.php#L375) and its use of [`inputValue()`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/MakesAssertions.php#L410), I opted to create `elementValue()`, which for [a list of supported elements](https://www.w3schools.com/tags/att_value.asp) will retrieve the `value` attribute. If not it will fallback to calling [`getText()`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/MakesAssertions.php#L416) on the element in the same way `inputValue()` currently works.

### Considerations

1. One scenario that is currently not possible before this PR, and continues not to be possible is a user wishing to use `assertValue()` against, for example, an `li` element and expecting to test against text between its tags. Because an `li` element supports the `value` attribute, using `assertValue()` cannot ever cover this scenario.
1. Although a `textarea` doesn't have a `value` attribute, its content is still retrieved using `$textarea->getAttribute('value')`. 
   - See https://github.com/laravel/dusk/issues/633#issuecomment-477286834 and PR https://github.com/laravel/dusk/pull/237.

### Why not use `inputValue()` and extend [the list of supported elements](https://github.com/laravel/dusk/blob/6.x/src/Concerns/MakesAssertions.php#L414)?

- This method calls `resolveForTyping()` but not all elements that support the `value` attribute allow typing.
- Although it would work, `inputValue()` expects a variable called `$field` yet it would be passed `$selector`. This to me is messy.

### Alternative Approaches

1. Add an additional assertion within `assertValue()` and `assertValueIsNot()` to check that someone is using these methods against an element that supports the `value` attribute. If not, throw an error.
1. Do nothing - this means users could inadvertently be calling `assertValue()` against an element such as a `div`:

   ```php
   // <div class="foo"></div>

   $browser->assertValue('.foo', ''); // true

   // <div class="foo">bar</div>

   $browser->assertValue('.foo', ''); // true
   ```