### PR TITLE
#934 - throw an error if `assertValue()` is used with an element that does not support the `value` attribute

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -649,7 +649,15 @@ JS;
     {
         $fullSelector = $this->resolver->format($selector);
 
-        $actual = $this->resolver->findOrFail($selector)->getAttribute('value');
+        $element = $this->resolver->findOrFail($selector);
+        $tagName = $element->getTagName();
+
+        PHPUnit::assertTrue(
+            $tagName === 'textarea' || $this->supportsTheValueAttribute($tagName),
+            __FUNCTION__." cannot be used with the element [{$fullSelector}]."
+        );
+
+        $actual = $element->getAttribute('value');
 
         PHPUnit::assertEquals(
             $value,
@@ -671,7 +679,15 @@ JS;
     {
         $fullSelector = $this->resolver->format($selector);
 
-        $actual = $this->resolver->findOrFail($selector)->getAttribute('value');
+        $element = $this->resolver->findOrFail($selector);
+        $tagName = $element->getTagName();
+
+        PHPUnit::assertTrue(
+            $tagName === 'textarea' || $this->supportsTheValueAttribute($tagName),
+            __FUNCTION__." cannot be used with the element [{$fullSelector}]."
+        );
+
+        $actual = $element->getAttribute('value');
 
         PHPUnit::assertNotEquals(
             $value,
@@ -680,6 +696,28 @@ JS;
         );
 
         return $this;
+    }
+
+    /**
+     * Determine if the given element supports the 'value' attribute.
+     *
+     * @param  string  $tagName
+     * @return bool
+     */
+    public function supportsTheValueAttribute($tagName)
+    {
+        return in_array(
+            $tagName,
+            [
+                'button',
+                'input',
+                'li',
+                'meter',
+                'option',
+                'param',
+                'progress',
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
Throw an error if `assertValue()` / `assertValueIsNot()` are used with an element that does not support the `value` attribute.

Note: a `textarea` is also permitted even though it doesn't have a `value` attribute. This is because its content is still retrieved using `$textarea->getAttribute('value')`.

The list of elements that support the `value` attribute was sourced from: https://www.w3schools.com/tags/att_value.asp

---

(Previously closed PR: #935)