### PR TITLE
[6.x] Fix logout() when using AuthenticateSession and default guard

### DIFF
--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -56,9 +56,11 @@ class UserController
      */
     public function logout($guard = null)
     {
-        Auth::guard($guard ?: config('auth.defaults.guard'))->logout();
+        $guard = $guard ?: config('auth.defaults.guard');
 
-        Session::forget('password_hash_'.($guard ?: config('auth.defaults.guard')));
+        Auth::guard($guard)->logout();
+
+        Session::forget('password_hash_'.$guard);
     }
 
     /**


### PR DESCRIPTION
Fix was attempted by #826, but the string concatenation is wrong and it never uses the default guard.
