### PR TITLE
[6.x] Tweak `cookie()` and `plainCookie()` return types

### DIFF
--- a/src/Concerns/InteractsWithCookies.php
+++ b/src/Concerns/InteractsWithCookies.php
@@ -16,7 +16,7 @@ trait InteractsWithCookies
      * @param  string|null  $value
      * @param  int|DateTimeInterface|null  $expiry
      * @param  array  $options
-     * @return string|$this
+     * @return $this|string
      */
     public function cookie($name, $value = null, $expiry = null, array $options = [])
     {
@@ -46,7 +46,7 @@ trait InteractsWithCookies
      * @param  string|null  $value
      * @param  int|DateTimeInterface|null  $expiry
      * @param  array  $options
-     * @return string|$this
+     * @return $this|string
      */
     public function plainCookie($name, $value = null, $expiry = null, array $options = [])
     {


### PR DESCRIPTION
## Description

Chaining browser methods after `cookie()` or `plainCookie()` results in PHP IDE's displaying an error, saying that the `cookie()` and `plainCookie()` methods are returning objects but they can only return strings:

<img width="546" alt="Screen Shot 2021-10-19 at 3 15 15 PM" src="https://user-images.githubusercontent.com/6421846/137975847-24c29db5-c2b7-4e8e-a815-2c31aa11b9d1.png">

Fixing the return type to `string|$this` removes the IDE error:

<img width="471" alt="Screen Shot 2021-10-19 at 3 16 08 PM" src="https://user-images.githubusercontent.com/6421846/137975955-0eca4cce-508d-4190-b3da-497711c4597f.png">

Thanks for your time! No hard feelings on closure ❤️ 