### PR TITLE
Include a `select` when determining an input's value from the value attribute

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -411,7 +411,7 @@ JS;
     {
         $element = $this->resolver->resolveForTyping($field);
 
-        return in_array($element->getTagName(), ['input', 'textarea'])
+        return in_array($element->getTagName(), ['input', 'textarea', 'select'])
                         ? $element->getAttribute('value')
                         : $element->getText();
     }


### PR DESCRIPTION
https://github.com/laravel/dusk/pull/942#issuecomment-952963166

Include a `select` when determining an input's value from the value attribute. This is similar to the change already merged in PR #942.