### PR TITLE
[6.x] Add `clickAndWaitForReload`

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -319,6 +319,19 @@ trait WaitsForElements
     }
 
     /**
+     * Click an element and wait for the page to reload.
+     *
+     * @param  string|null  $selector
+     * @return $this
+     */
+    public function clickAndWaitForReload($selector = null)
+    {
+        return $this->waitForReload(function ($browser) use ($selector) {
+            $browser->click($selector);
+        });
+    }
+
+    /**
      * Wait for the given callback to be true.
      *
      * @param  int|null  $seconds


### PR DESCRIPTION
This PR adds a `clickAndWaitForReload` method as syntactic sugar. I have this macro'd in my projects and use it all the time. I figured it was worth trying a PR.

If you use `dusk` attributes on elements, `clickAndWaitForReload` can be used to navigate almost the entire app. Instead of code like this:

```php
$browser->waitForReload(function (Browser $browser) use ($model) {
        $browser->click('@update-'.$model->id);
    })
    ->type('name', 'Sjors')
    ->waitForReload(function (Browser $browser) {
        $browser->click('@submit');
    });

// or

$browser->waitForReload(fn (Browser $browser) => $browser->click('@update-'.$model->id))
    ->type('name', 'Sjors')
    ->waitForReload(fn (Browser $browser) => $browser->click('@submit'));
```

You write this instead:

```php
$browser->clickAndWaitForReload('@update-'.$model->id)
    ->type('name', 'Sjors')
    ->clickAndWaitForReload('@submit');
```

This way of writing tests has worked great for me in Blade + Livewire projects.

The same kind of syntactic sugar could be added for `pressAndWaitForReload` and `clickLinkAndWaitForReload`. I don't use those methods personally so I didn't include them in this PR.

There wasn't a logical place to put this new method, so I ended up putting it next to `waitForReload`. The new method uses methods from both the `InteractsWithMouse` and `WaitsForElements` traits. Maybe a new trait called `ProvidesGreatUX` would be a good place for methods like this.

This PR doesn't include tests because I couldn't figure out how to craft a suitable mock.