### PR TITLE
Add assertion: assertAttributeWithValue

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -771,6 +771,23 @@ JS;
     }
 
     /**
+     * Assert that there is an element with the provided attribute and attribute-value.
+     *
+     * @param  string  $attributeName
+     * @param  string  $attributeValue
+     * @return $this
+     */
+    public function assertAttributeWithValue($attributeName, $attributeValue)
+    {
+        PHPUnit::assertTrue(
+            !!($this->resolver->findByAttributeWithValue($attributeName, $attributeValue)),
+            "Did not find an element with the attribute [{$attributeName}] and attribute-value [{$attributeValue}]"
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the element matching the given selector has the given value in the provided aria attribute.
      *
      * @param  string  $selector

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -419,7 +419,8 @@ class ElementResolver
     /**
     * Attempt to find an element by an element-attribute and its value.
      *
-     * @param string $selector
+     * @param string $attributeName
+     * @param string $attributeValue
      * @return \Facebook\WebDriver\Remote\RemoteWebElement
      */
     public function findByAttributeWithValue($attributeName, $attributeValue)

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -415,4 +415,21 @@ class ElementResolver
 
         return trim($this->prefix.' '.$selector);
     }
+
+    /**
+    * Attempt to find an element by an element-attribute and its value.
+     *
+     * @param string $selector
+     * @return \Facebook\WebDriver\Remote\RemoteWebElement
+     */
+    public function findByAttributeWithValue($attributeName, $attributeValue)
+    {
+        try {
+            return $this->driver->findElement(
+                WebDriverBy::xpath("//*[@" . $attributeName . "='" . $attributeValue . "']")
+            );
+        } catch (Exception $exception) {
+            //
+        }
+    }
 }

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -635,6 +635,32 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_attribute_with_value()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getAttribute')->with('foo')->andReturn(
+            'bar'
+        );
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('findByAttributeWithValue')
+            ->with('foo', 'bar')
+            ->andReturn($element);
+
+        $browser = new Browser($driver, $resolver);
+
+        try {
+            $browser->assertAttributeWithValue('foo', 'bar');
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Did not find an element with the attribute [foo] and attribute-value [bar]',
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_data_attribute()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
This pull requests aims to make it possible to test the assertion, that there is an element with a given attribute, and a specific value for that attribute. The assertion should fail when:

1. There is no element with the specified attribute
2. When there is an element with the specified attribute, but it does not contain the specified value.

This will help developers in "marking" elements with attributes of their choice, instead of having to add ids or classes to target an element. For example, a developer could then create a `data-dusk` attribute on an element, and then target the element through `data-dusk` in their tests.
