### PR TITLE
Adds new assertion: assertPageIs

### DIFF
--- a/src/Concerns/MakesUrlAssertions.php
+++ b/src/Concerns/MakesUrlAssertions.php
@@ -3,6 +3,7 @@
 namespace Laravel\Dusk\Concerns;
 
 use Illuminate\Support\Arr;
+use Laravel\Dusk\Page;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\Constraint\RegularExpression;
 
@@ -216,6 +217,17 @@ trait MakesUrlAssertions
     public function assertRouteIs($route, $parameters = [])
     {
         return $this->assertPathIs(route($route, $parameters, false));
+    }
+
+    /**
+     * Assert that the current URL matches URL of the given Page.
+     *
+     * @param Page $page
+     * @return $this
+     */
+    public function assertPageIs(Page $page)
+    {
+        return $this->assertPathIs($page->url());
     }
 
     /**

--- a/tests/MakesUrlAssertionsTest.php
+++ b/tests/MakesUrlAssertionsTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Dusk\Tests;
 
 use Laravel\Dusk\Browser;
+use Laravel\Dusk\Page;
 use Laravel\Dusk\Tests\Concerns\SwapsUrlGenerator;
 use Mockery as m;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -286,6 +287,38 @@ class MakesUrlAssertionsTest extends TestCase
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString(
                 'Actual path [/test/1] does not equal expected path [/test/].',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_page_is()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('getCurrentURL')->times(4)->andReturn(
+            'http://laravel.com/test',
+            'https://www.laravel.com:80/?foo=bar',
+            'https://www.laravel.com:80/test?foo=bar',
+            'http://www.laravel.com/test?foo=bar',
+        );
+        $browser = new Browser($driver);
+
+        $homePageMock = m::mock(Page::class);
+        $testPageMock = m::mock(Page::class);
+
+        $homePageMock->shouldReceive('url')->andReturn('/');
+        $testPageMock->shouldReceive('url')->andReturn('/test');
+
+        $browser->assertPageIs($testPageMock);
+        $browser->assertPageIs($homePageMock);
+        $browser->assertPageIs($testPageMock);
+
+        try {
+            $browser->assertPageIs($homePageMock);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Actual path [/test] does not equal expected path [/]',
                 $e->getMessage()
             );
         }


### PR DESCRIPTION
Dusk Page methods make code more beautiful and readable. This PR suggests adding new assertion while working with ```Pages```: assertPageIs in order to test, that current browser url path matches the expected path of the given ```Page```. New assertion calls under the hood ```assertPathIs``` method passing path from ```url()``` method of the given Page, just like ```assertRouteIs``` does.

It helps writing test in one style, if you like how ```Pages``` work, because it is more logical to write in this way:
```
$this->browse(function (Browser $browser) {
    $browser->visit(new HomePage())
            ->assertPageIs(new HomePage());
});
```
instead of:
```
$this->browse(function (Browser $browser) {
    $browser->visit(new HomePage())
            ->assertRouteIs('home');
});
```
