### PR TITLE
[6.x] Add `waitForInput`

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -148,6 +148,18 @@ trait WaitsForElements
     }
 
     /**
+     * Wait for an input field to become visible.
+     *
+     * @param  string  $field
+     * @param  int|null  $seconds
+     * @return $this
+     */
+    public function waitForInput($field, $seconds = null)
+    {
+        return $this->waitFor("input[name='{$field}'], textarea[name='{$field}'], select[name='{$field}']", $seconds);
+    }
+
+    /**
      * Wait for the given location.
      *
      * @param  string  $path
@@ -214,18 +226,6 @@ trait WaitsForElements
         }, $message);
 
         return $this;
-    }
-
-    /**
-     * Wait for an input field to become visible.
-     *
-     * @param  string  $field
-     * @param  int|null  $seconds
-     * @return $this
-     */
-    public function waitForInput($field, $seconds = null)
-    {
-        return $this->waitFor("input[name='{$field}'], textarea[name='{$field}'], select[name='{$field}']", $seconds);
     }
 
     /**

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -217,6 +217,18 @@ trait WaitsForElements
     }
 
     /**
+     * Wait for an input field to become visible.
+     *
+     * @param  string  $field
+     * @param  int|null  $seconds
+     * @return $this
+     */
+    public function waitForInput($field, $seconds = null)
+    {
+        return $this->waitFor("input[name='{$field}'], textarea[name='{$field}'], select[name='{$field}']", $seconds);
+    }
+
+    /**
      * Wait until the given script returns true.
      *
      * @param  string  $script


### PR DESCRIPTION
This PR adds a `waitForInput` method that waits for an input field by name. This PR is similar to https://github.com/laravel/dusk/pull/914.

I have some flaky tests in CI that very sometimes fail to type in a text input. The tests look something like this:
```php
->clickAndWaitForReload('@edit-'.$user->id)
->type('name', 'Sjors')
```

The new `waitForInput` method can solve this:

```php
->clickAndWaitForReload('@edit-'.$user->id)
->waitForInput('name')
->type('name', 'Sjors')
```

I haven't added any tests. I still can't figure out how to craft a mock that calls itself.
