### PR TITLE
[6.x] Use release target branch in changelog compare URL

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           latest-version: ${{ github.event.release.tag_name }}
           release-notes: ${{ github.event.release.body }}
+          compare-url-target-revision: ${{ github.event.release.target_commitish }}
 
       - name: Commit updated CHANGELOG
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
Use the target branch of a release in the compare URL when updating the changelog through GitHub Actions.