### PR TITLE
Fixes link assertion with single or double quote

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -45,9 +45,10 @@ trait InteractsWithElements
     {
         $this->ensurejQueryIsAvailable();
 
-        $selector = addslashes(trim($this->resolver->format("{$element}:contains({$link}):visible")));
+        $selector = addslashes(trim($this->resolver->format("{$element}")));
+        $link = str_replace("'", "\\\\'", $link);
 
-        $this->driver->executeScript("jQuery.find(\"{$selector}\")[0].click();");
+        $this->driver->executeScript("jQuery.find(`{$selector}:contains({$link}):visible`)[0].click();");
 
         return $this;
     }

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -46,6 +46,7 @@ trait InteractsWithElements
         $this->ensurejQueryIsAvailable();
 
         $selector = addslashes(trim($this->resolver->format("{$element}")));
+
         $link = str_replace("'", "\\\\'", $link);
 
         $this->driver->executeScript("jQuery.find(`{$selector}:contains('{$link}'):visible`)[0].click();");

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -48,7 +48,7 @@ trait InteractsWithElements
         $selector = addslashes(trim($this->resolver->format("{$element}")));
         $link = str_replace("'", "\\\\'", $link);
 
-        $this->driver->executeScript("jQuery.find(`{$selector}:contains({$link}):visible`)[0].click();");
+        $this->driver->executeScript("jQuery.find(`{$selector}:contains('{$link}'):visible`)[0].click();");
 
         return $this;
     }

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -355,10 +355,11 @@ trait MakesAssertions
     {
         $this->ensurejQueryIsAvailable();
 
-        $selector = addslashes(trim($this->resolver->format("a:contains('{$link}')")));
+        $selector = addslashes(trim($this->resolver->format('a')));
+        $link = str_replace("'", "\\\\'", $link);
 
         $script = <<<JS
-            var link = jQuery.find("{$selector}");
+            var link = jQuery.find(`{$selector}:contains('{$link}')`);
             return link.length > 0 && jQuery(link).is(':visible');
 JS;
 

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -356,6 +356,7 @@ trait MakesAssertions
         $this->ensurejQueryIsAvailable();
 
         $selector = addslashes(trim($this->resolver->format('a')));
+
         $link = str_replace("'", "\\\\'", $link);
 
         $script = <<<JS

--- a/tests/WaitsForElementsTest.php
+++ b/tests/WaitsForElementsTest.php
@@ -257,13 +257,13 @@ class WaitsForElementsTest extends TestCase
     {
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('executeScript')
-            ->times(2)
+            ->times(3)
             ->andReturnTrue();
 
         $link = 'https://laravel.com/docs/8.x/dusk';
 
         $script = <<<JS
-            var link = jQuery.find("body a:contains(\'{$link}\')");
+            var link = jQuery.find("body a:contains(\"{$link}\")");
             return link.length > 0 && jQuery(link).is(':visible');
 JS;
 

--- a/tests/WaitsForElementsTest.php
+++ b/tests/WaitsForElementsTest.php
@@ -263,7 +263,7 @@ class WaitsForElementsTest extends TestCase
         $link = 'https://laravel.com/docs/8.x/dusk';
 
         $script = <<<JS
-            var link = jQuery.find("body a:contains(\"{$link}\")");
+            var link = jQuery.find(`body a:contains('{$link}')`);
             return link.length > 0 && jQuery(link).is(':visible');
 JS;
 


### PR DESCRIPTION
Notice the issue when Faker generates a name with single-quote, e.g: `Ozella O'Reilly`. Also, ensure it can handle text with double-quote.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>