### PR TITLE
[6.x] Allow to fill form fields targeted by their label

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -86,9 +86,17 @@ class ElementResolver
             return $element;
         }
 
-        return $this->firstOrFail([
-            "input[name='{$field}']", "textarea[name='{$field}']", $field,
-        ]);
+        $selectors = [
+            "input[name='{$field}']", "textarea[name='{$field}']", $field
+        ];
+
+        if (! is_null($label = $this->findLabelByText($field))) {
+            if (! is_null($id = $label->getAttribute('for'))) {
+                array_unshift($selectors, '#' . $id);
+            }
+        }
+
+        return $this->firstOrFail($selectors);
     }
 
     /**
@@ -303,6 +311,21 @@ class ElementResolver
     {
         foreach ($this->all('button') as $element) {
             if (Str::contains($element->getText(), $button)) {
+                return $element;
+            }
+        }
+    }
+
+    /**
+     * Resolve the element for a given label by text.
+     *
+     * @param  string $label
+     * @return \Facebook\WebDriver\Remote\RemoteWebElement|null
+     */
+    protected function findLabelByText($label)
+    {
+        foreach ($this->all('label') as $element) {
+            if (Str::contains($element->getText(), $label)) {
                 return $element;
             }
         }

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -87,12 +87,12 @@ class ElementResolver
         }
 
         $selectors = [
-            "input[name='{$field}']", "textarea[name='{$field}']", $field
+            "input[name='{$field}']", "textarea[name='{$field}']", $field,
         ];
 
         if (! is_null($label = $this->findLabelByText($field))) {
             if (! is_null($id = $label->getAttribute('for'))) {
-                array_unshift($selectors, '#' . $id);
+                array_unshift($selectors, '#'.$id);
             }
         }
 
@@ -319,7 +319,7 @@ class ElementResolver
     /**
      * Resolve the element for a given label by text.
      *
-     * @param  string $label
+     * @param  string  $label
      * @return \Facebook\WebDriver\Remote\RemoteWebElement|null
      */
     protected function findLabelByText($label)

--- a/tests/ElementResolverTest.php
+++ b/tests/ElementResolverTest.php
@@ -35,6 +35,21 @@ class ElementResolverTest extends TestCase
         $this->assertSame('foo', $resolver->resolveForTyping('foo'));
     }
 
+    public function test_resolve_for_typing_via_label()
+    {
+        $labelElement = m::mock(stdClass::class, 'label');
+        $labelElement->shouldReceive('getText')->andReturn('Laravel');
+        $labelElement->shouldReceive('getAttribute')->with('for')->andReturn('testing');
+
+        $driver = m::mock(stdClass::class, 'driver');
+        $driver->shouldReceive('findElements')->andReturn([$labelElement]);
+        $driver->shouldReceive('findElement')->times(3)->andThrow(new \Exception);
+        $driver->shouldReceive('findElement')->andReturn('Dusk');
+
+        $resolver = new ElementResolver($driver);
+        $this->assertSame('Dusk', $resolver->resolveForTyping('Laravel'));
+    }
+
     public function test_resolve_for_selection_resolves_by_id()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
given the following markup

```html
<label for="testing">Laravel</label>
<input id="testing" type="text" />
```

one can now write a more semantic test like

```php
$browser->type("Laravel", "Dusk");
```

instead of having to target form fields by name or id

```php
$browser->type("testing", "Dusk");
```

there's method's like `assertSee()` which validate visible text on the page so, in line with that, it should be possible to fill fields using their labels.