### PR TITLE
[6.x] assertVue*() methods support Vue 3 composition API

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -1102,9 +1102,14 @@ JS;
 
         return $this->driver->executeScript(
             "var el = document.querySelector('".$fullSelector."');".
-            "return typeof el.__vue__ === 'undefined' ".
-                '? JSON.parse(JSON.stringify(el.__vueParentComponent.ctx)).'.$key.
-                ': el.__vue__.'.$key
+            "if (typeof el.__vue__ !== 'undefined')".
+            '    return el.__vue.'.$key.';'.
+            'try {'.
+            '    var attr = el.__vueParentComponent.ctx.'.$key.';'.
+            "    if (typeof attr !== 'undefined')".
+            '        return attr;'.
+            '} catch (e) {}'.
+            'return el.__vueParentComponent.setupState.'.$key.';'
         );
     }
 }

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -1018,10 +1018,15 @@ class MakesAssertionsTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('executeScript')
             ->with(
-                'var el = document.querySelector(\'body foo\');'.
-                "return typeof el.__vue__ === 'undefined' ".
-                    '? JSON.parse(JSON.stringify(el.__vueParentComponent.ctx)).foo'.
-                    ': el.__vue__.foo'
+                "var el = document.querySelector('body foo');".
+                "if (typeof el.__vue__ !== 'undefined')".
+                '    return el.__vue.foo;'.
+                'try {'.
+                '    var attr = el.__vueParentComponent.ctx.foo;'.
+                "    if (typeof attr !== 'undefined')".
+                '        return attr;'.
+                '} catch (e) {}'.
+                'return el.__vueParentComponent.setupState.foo;'
             )
             ->twice()
             ->andReturn('foo');
@@ -1071,10 +1076,15 @@ class MakesAssertionsTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('executeScript')
             ->with(
-                'var el = document.querySelector(\'body foo\');'.
-                "return typeof el.__vue__ === 'undefined' ".
-                    '? JSON.parse(JSON.stringify(el.__vueParentComponent.ctx)).foo'.
-                    ': el.__vue__.foo'
+                "var el = document.querySelector('body foo');".
+                "if (typeof el.__vue__ !== 'undefined')".
+                '    return el.__vue.foo;'.
+                'try {'.
+                '    var attr = el.__vueParentComponent.ctx.foo;'.
+                "    if (typeof attr !== 'undefined')".
+                '        return attr;'.
+                '} catch (e) {}'.
+                'return el.__vueParentComponent.setupState.foo;'
             )
             ->twice()
             ->andReturn('foo');
@@ -1125,9 +1135,14 @@ class MakesAssertionsTest extends TestCase
         $driver->shouldReceive('executeScript')
             ->with(
                 'var el = document.querySelector(\'body [dusk="vue-component"]\');'.
-                "return typeof el.__vue__ === 'undefined' ".
-                    '? JSON.parse(JSON.stringify(el.__vueParentComponent.ctx)).name'.
-                    ': el.__vue__.name'
+                "if (typeof el.__vue__ !== 'undefined')".
+                '    return el.__vue.name;'.
+                'try {'.
+                '    var attr = el.__vueParentComponent.ctx.name;'.
+                "    if (typeof attr !== 'undefined')".
+                '        return attr;'.
+                '} catch (e) {}'.
+                'return el.__vueParentComponent.setupState.name;'
             )
             ->once()
             ->andReturn(['john']);


### PR DESCRIPTION
> Sample app with Breeze components to test these changes: https://github.com/derekmd/vue3-dusk-test/commit/b111b4850a149087ec05d37ab47b3227533fa63b

Methods `assertVue()`, `assertVueIsNot`, `assertVueContains`, and `assertVueDoesNotContain` can fail in apps using Vue 3's newer composition API.

When fetching a component prop, attempt these paths:

1. `el.__vue__.key`
   * Vue 2
2. `el.__vueParentComponent.ctx.key`
   * Vue 3 options API
   * Vue 3 composition API for `definedProps()`
3. `el.__vueParentComponent.setupState.key` _[added in this PR]_
   * Vue 3 composition API `reactive()`, `computed()`, or any other `<script setup>` variables.

If the `ctx` key is undefined, the `setupState` fallback is attempted. Wrap in a try/catch for attempts to access undefined nested props like `el.__vueParentComponent.ctx.form.email` with no defined `el.__vueParentComponent.ctx.form`.

---

This also fixes https://github.com/laravel/dusk/issues/968 by removing JSON serialization of `el.__vueParentComponent.ctx`. When I submitted PR https://github.com/laravel/dusk/pull/834, the `JSON.parse(JSON.stringify(...))` snippet was taken from a forum post I read about the Vue 3 equivalent of Vue 2's `el.__vue__`. The JSON transformation evaluates Vue prop getters and strips functions for a simple cloned payload. e..g,

![console-log-ctx](https://user-images.githubusercontent.com/823566/159936736-b413348a-76fe-46e8-a69c-5b1016b01574.png)

This wouldn't be needed when fetching one component prop at runtime. It maybe cleaned up the output of `console.log(JSON.parse(JSON.stringify(el.__vueParentComponent.ctx)))` if any developer edits `vendor/laravel/dusk/src/Concerns/MakeAssertions.php` method `vueAttribute()` in debug dump desperation. Otherwise I don't see a reason to keep this in place. Removing this now won't affect passing test suite assertions of existing Laravel apps.