### PR TITLE
Add `waitForEvent()` method

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -370,7 +370,7 @@ trait WaitsForElements
                 [$target, $type]
             );
         } catch (ScriptTimeoutException $e) {
-            throw new TimeoutException("Waited {$seconds} seconds for '{$type}' event.");
+            throw new TimeoutException("Waited {$seconds} seconds for event [{$type}].");
         }
 
         return $this;

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -370,7 +370,7 @@ trait WaitsForElements
                 [$target, $type]
             );
         } catch (ScriptTimeoutException $e) {
-            throw new TimeoutException("Waited {$seconds} seconds for '${type}' event.");
+            throw new TimeoutException("Waited {$seconds} seconds for '{$type}' event.");
         }
 
         return $this;

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Closure;
 use Exception;
 use Facebook\WebDriver\Exception\NoSuchElementException;
+use Facebook\WebDriver\Exception\ScriptTimeoutException;
 use Facebook\WebDriver\Exception\TimeOutException;
 use Facebook\WebDriver\WebDriverExpectedCondition;
 use Illuminate\Support\Arr;
@@ -341,6 +342,38 @@ trait WaitsForElements
         return $this->waitForReload(function ($browser) use ($selector) {
             $browser->click($selector);
         });
+    }
+
+    /**
+     * Wait for the given event type to occur on a target.
+     *
+     * @param  string  $type
+     * @param  string|null  $target
+     * @param  int|null  $seconds
+     * @return $this
+     *
+     * @throws \Facebook\WebDriver\Exception\TimeOutException
+     */
+    public function waitForEvent($type, $target = null, $seconds = null)
+    {
+        $seconds = is_null($seconds) ? static::$waitSeconds : $seconds;
+
+        if ($target !== 'document' && $target !== 'window') {
+            $target = $this->resolver->findOrFail($target ?? '');
+        }
+
+        $this->driver->manage()->timeouts()->setScriptTimeout($seconds);
+
+        try {
+            $this->driver->executeAsyncScript(
+                'eval(arguments[0]).addEventListener(arguments[1], () => arguments[2](), { once: true });',
+                [$target, $type]
+            );
+        } catch (ScriptTimeoutException $e) {
+            throw new TimeoutException("Waited {$seconds} seconds for '${type}' event.");
+        }
+
+        return $this;
     }
 
     /**

--- a/tests/WaitsForElementsTest.php
+++ b/tests/WaitsForElementsTest.php
@@ -324,4 +324,23 @@ JS;
 
         $browser->waitForReload();
     }
+
+    public function test_wait_for_event()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('manage->timeouts->setScriptTimeout')->with(3);
+        $driver->shouldReceive('executeAsyncScript')->with(
+            'eval(arguments[0]).addEventListener(arguments[1], () => arguments[2](), { once: true });',
+            ['body form', 'submit']
+        );
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('findOrFail')
+            ->with('form')
+            ->andReturn('body form');
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->waitForEvent('submit', 'form', 3);
+    }
 }


### PR DESCRIPTION
This pull requests adds a `waitForEvent()` method to the `WaitsForElements` trait, making it available to the `Browser` class. 

It also adds a corresponding test case to `WaitsForElementsTest`.

## Explanation

```php
waitForEvent(
    string $type,
    ?string $target = null,
    ?int $seconds = null
): self
```

The `waitForEvent()` method pauses the test execution until a given event `type` occurs on a `target` element or object.

This is especially useful when working with front-end libraries like [InertiaJS](https://inertiajs.com) or [Hotwire/Turbo](https://turbo.hotwired.dev), since those libraries will trigger events that can be very helpful for automated testing. For example, clicking a link and waiting for the `inertia:navigate` event before continuing with the test.

## Usage examples

Waiting for events on DOM elements:

```php
// Targeting the body element
$browser->waitForEvent('load');

// Targeting CSS selectors
$browser->waitForEvent('load', 'img');

// Targeting scoped selectors
$browser->with('img', function ($img) {
	$img->waitForEvent('load');
});

// Targeting dusk selectors
$browser->waitForEvent('load', '@dusk-selector');
```

Waiting for events on  `document` or `window`:

```php
$browser->waitForEvent('scroll', 'document');
$browser->waitForEvent('resize', 'window');
```

Waiting for InertiaJS events:

```php
$browser->visit('/login')
	->waitForEvent('inertia:navigate', 'document');
	
$browser->press('Submit')
	->waitForEvent('inertia:finish', 'document');
```

Waiting for events with a custom timeout in seconds:

```php
$browser->waitForEvent('load', 'img.huge-image', 10);
```

## Discussion

I’m very open to suggestions on how to improve this. A few thoughts:

I’m not huge fan of the `$target` argument being either a selector or `'document'` / `'window'`, since it’s not very clearly communicated. Adding a description for `$target` in the  docblock could help, but that would be inconsistent with the rest of the Dusk codebase.

I also thought about adding different methods for differentiation:

```php
waitForEvent(string $type, ?string $selector = null);
// or…
waitForElementEvent(string $type, ?string $selector = null);

// …and…
waitForDocumentEvent(string $type);
waitForWindowEvent(string $type);
```

But in the end I opted for a single method, since I felt it still had the best developer ergonomics.

—

I see potential for more convenience methods using events, for example:

- `visitAndWaitForEvent()`
- `visitRouteAndWaitForEvent()`
- `clickLinkAndWaitForEvent()`
- `pressAndWaitForEvent()`

Should these methods be desirable in the future, maybe a dedicated `WaitsForEvents` or `InteractsWithEvents` trait would be good. 

—

Finally I’m unsure about using `eval()` in the `executeAsyncScript()` call. But I like that it makes the JavaScript code very concise since it works with object names (`document`/`window`) and element references at the same time. Also in a testing environment, I feel `eval()` is not that dramatic. Maybe it could lead to problems with content security policies, I’m not sure how Dusk/WebDriver handles those.
