### PR TITLE
Start maximized enabled

### DIFF
--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -32,7 +32,7 @@ abstract class DuskTestCase extends BaseTestCase
     protected function driver()
     {
         $options = (new ChromeOptions)->addArguments(collect([
-            '--window-size=1920,1080',
+            $this->hasStartMaximizedEnabled() ? '--start-maximized' : '--window-size=1920,1080',
         ])->unless($this->hasHeadlessDisabled(), function ($items) {
             return $items->merge([
                 '--disable-gpu',
@@ -57,5 +57,16 @@ abstract class DuskTestCase extends BaseTestCase
     {
         return isset($_SERVER['DUSK_HEADLESS_DISABLED']) ||
                isset($_ENV['DUSK_HEADLESS_DISABLED']);
+    }
+
+    /**
+     * Determine if the browser window maximization was set.
+     *
+     * @return bool
+     */
+    protected function hasStartMaximizedEnabled()
+    {
+        return isset($_SERVER['DUSK_START_MAXIMIZED']) ||
+        isset($_ENV['DUSK_START_MAXIMIZED']);
     }
 }

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -67,6 +67,6 @@ abstract class DuskTestCase extends BaseTestCase
     protected function hasStartMaximizedEnabled()
     {
         return isset($_SERVER['DUSK_START_MAXIMIZED']) ||
-        isset($_ENV['DUSK_START_MAXIMIZED']);
+               isset($_ENV['DUSK_START_MAXIMIZED']);
     }
 }


### PR DESCRIPTION
I have added the `hasStartMaximizedEnabled` function to the `DuskTestCase` which checks for the existence of the `DUSK_START_MAXIMIZED` parameter, which enables the maximization of the browser window for all tests (or defaults to the full hd resolution like before).

I think this option will be useful for developers who work on higher resolutions (2K, 4K...) and who, like me, end up putting `$browser->maximize();` in every single one of their tests...but would now be enable this option globally.