### PR TITLE
Store source code and store console log on test fail

### DIFF
--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -146,7 +146,11 @@ trait ProvidesBrowser
 
             $name = $this->getCallerName();
 
-            $browser->screenshot('failure-'.$name.'-'.$key);
+            $file = 'failure-'.$name.'-'.$key;
+
+            $browser->screenshot($file);
+            $browser->storeSource($file);
+            $browser->storeConsoleLog($file);
         });
     }
 


### PR DESCRIPTION
I think it gives more flexibility for debugging our test cases when it fails. If we save the full DOM and the console messages it helps us debug easier the tests, screenshots tells nothing what would be the problem in my oppinion.