### PR TITLE
Added responsiveScreenShots method

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -40,6 +40,39 @@ class Browser
     public static $storeScreenshotsAt;
 
     /**
+     * These are the most common screen sizes to use for responsive screenshots.
+     * These will trigger all of tailwind's default breakpoints.
+     *
+     * @var array
+     */
+    public static $responsiveScreenSizes = [
+        'xs' => [
+            'width' => 360,
+            'height' => 640,
+        ],
+        'sm' => [
+            'width' => 640,
+            'height' => 360,
+        ],
+        'md' => [
+            'width' => 768,
+            'height' => 1024,
+        ],
+        'lg' => [
+            'width' => 1024,
+            'height' => 768,
+        ],
+        'xl' => [
+            'width' => 1280,
+            'height' => 1024,
+        ],
+        '2xl' => [
+            'width' => 1536,
+            'height' => 864,
+        ],
+    ];
+
+    /**
      * The directory that will contain any console logs.
      *
      * @var string
@@ -392,6 +425,26 @@ class Browser
         }
 
         $this->driver->takeScreenshot($filePath);
+
+        return $this;
+    }
+
+    /**
+     * Take a series of screenshots at different browser sizes to emulate different devices.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function responsiveScreenShots($name)
+    {
+        if (substr($name, -1) !== '/') {
+            $name .= '-';
+        }
+
+        foreach (static::$responsiveScreenSizes as $device => $size) {
+            $this->resize($size['width'], $size['height'])
+                ->screenshot("$name$device");
+        }
 
         return $this;
     }


### PR DESCRIPTION
- Method uses some default screen sizes which will trigger all tailwind breakpoints.
- Allows the end user to quickly test views for all breakpoints.
- Users can alter the default screen sizes to fit their needs.
- Screenshots will be saved with the provided name -device **_e.g. "screenshot-xs.png"_**
- If the provided name is a directory (ends with "/"), saved name will be directory/device **_e.g. "dashboard/xs.png"_**

It wasn't possible to write tests for this feature as it makes use of the resize method.