### PR TITLE
Add `assertIndeterminate` assertion for checkbox.

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -487,6 +487,26 @@ JS;
     }
 
     /**
+     * Assert that the given checkbox is not checked.
+     *
+     * @param  string  $field
+     * @param  string|null  $value
+     * @return $this
+     */
+    public function assertIndeterminate($field, $value = null)
+    {
+        $this->assertNotChecked($field, $value);
+
+        PHPUnit::assertSame(
+            'true',
+            $this->resolver->findOrFail($field)->getAttribute('indeterminate'),
+            "Checkbox [{$field}] was not in indeterminate state."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the given radio field is selected.
      *
      * @param  string  $field

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -487,7 +487,7 @@ JS;
     }
 
     /**
-     * Assert that the given checkbox is not checked.
+     * Assert that the given checkbox is indeterminate state.
      *
      * @param  string  $field
      * @param  string|null  $value

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -487,7 +487,7 @@ JS;
     }
 
     /**
-     * Assert that the given checkbox is indeterminate state.
+     * Assert that the given checkbox is in an indeterminate state.
      *
      * @param  string  $field
      * @param  string|null  $value


### PR DESCRIPTION
Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>