### PR TITLE
[6.x] Try clicking all elements before throwing `ElementClickInterceptedException`

### DIFF
--- a/src/Concerns/InteractsWithMouse.php
+++ b/src/Concerns/InteractsWithMouse.php
@@ -6,7 +6,6 @@ use Facebook\WebDriver\Exception\ElementClickInterceptedException;
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\Interactions\WebDriverActions;
 use Facebook\WebDriver\WebDriverBy;
-use InvalidArgumentException;
 
 trait InteractsWithMouse
 {

--- a/src/Concerns/InteractsWithMouse.php
+++ b/src/Concerns/InteractsWithMouse.php
@@ -64,7 +64,7 @@ trait InteractsWithMouse
             }
         }
 
-        throw $e ?? new NoSuchElementException("Unable to locate element with selector $selector.");
+        throw $e ?? new NoSuchElementException("Unable to locate element with selector [{$selector}].");
     }
 
     /**

--- a/src/Concerns/InteractsWithMouse.php
+++ b/src/Concerns/InteractsWithMouse.php
@@ -2,8 +2,11 @@
 
 namespace Laravel\Dusk\Concerns;
 
+use Facebook\WebDriver\Exception\ElementClickInterceptedException;
+use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\Interactions\WebDriverActions;
 use Facebook\WebDriver\WebDriverBy;
+use InvalidArgumentException;
 
 trait InteractsWithMouse
 {
@@ -48,11 +51,21 @@ trait InteractsWithMouse
     {
         if (is_null($selector)) {
             (new WebDriverActions($this->driver))->click()->perform();
-        } else {
-            $this->resolver->findOrFail($selector)->click();
+
+            return $this;
         }
 
-        return $this;
+        foreach ($this->resolver->all($selector) as $element) {
+            try {
+                $element->click();
+
+                return $this;
+            } catch (ElementClickInterceptedException $e) {
+                //
+            }
+        }
+
+        throw $e ?? new NoSuchElementException("Unable to locate element with selector $selector.");
     }
 
     /**


### PR DESCRIPTION
Currently, if you try to `click()` a selector that appears multiple times on the page, it will match the first one and click it. This causes trouble when working with nested modals.

For example, I have a base modal that has `dusk="close-modal"` on the close button. If I have nested modals, I can't reliably click that close button with `->click('@close-modal')`. Depending the order of the modals in the html, it will either work or throw the following exception:
> `ElementClickInterceptedException`: element is not clickable. Other element would receive the click

<img width="207" alt="image" src="https://user-images.githubusercontent.com/7202674/180758212-3e3399ee-cb9d-45bb-adf9-1afe37455d75.png">

This PR changes the `click()` method to try and click all matching elements before throwing the `ElementClickInterceptedException` exception. This change should be fully backwards compatible.
