### PR TITLE
Allow to click and wait [N] seconds for reload

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -335,13 +335,14 @@ trait WaitsForElements
      * Click an element and wait for the page to reload.
      *
      * @param  string|null  $selector
+     * @param  int|null  $seconds
      * @return $this
      */
-    public function clickAndWaitForReload($selector = null)
+    public function clickAndWaitForReload($selector = null, $seconds = null)
     {
         return $this->waitForReload(function ($browser) use ($selector) {
             $browser->click($selector);
-        });
+        }, $seconds);
     }
 
     /**


### PR DESCRIPTION
Just a tiny PR to add missing `$seconds` parameter to `->clickAndWaitForReload` in order to set the wait timeout

the parameter is directly passed to the subsequent `->waitForReload()` call