### PR TITLE
Add `pauseIf()` / `pauseUnless()`

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -652,6 +652,22 @@ class Browser
     }
 
     /**
+     * Pause for the given amount of milliseconds unless the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  int  $milliseconds
+     * @return $this
+     */
+    public function pauseUnless($boolean, $milliseconds)
+    {
+        if (! $boolean) {
+            return $this->pause($milliseconds);
+        }
+
+        return $this;
+    }
+
+    /**
      * Close the browser.
      *
      * @return void

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -636,6 +636,22 @@ class Browser
     }
 
     /**
+     * Pause for the given amount of milliseconds if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  int  $milliseconds
+     * @return $this
+     */
+    public function pauseIf($boolean, $milliseconds)
+    {
+        if ($boolean) {
+            return $this->pause($milliseconds);
+        }
+
+        return $this;
+    }
+
+    /**
      * Close the browser.
      *
      * @return void


### PR DESCRIPTION
Sometimes, in your test suite, it's helpful to conditionally pause without having to jump out of your method chain. For example, I needed `pauseIf(App::environment('testing'), 500)` so I could slow down our test suite when running remotely in GitHub Actions. However, I didn't need this when running our test suite locally on my machine. I added `pauseUnless()` for completeness.

There are no tests present for `pause()` so I haven't added any for `pauseIf()` / `pauseUnless()`.