### PR TITLE
Add withinComponent: using with method while keeping component scope

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -505,6 +505,25 @@ class Browser
 
         return $this;
     }
+    /**
+     * Execute a Closure with a scoped browser instance, keeping the component scope.
+     *
+     * @param  string|\Laravel\Dusk\Component  $selector
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function withinComponent($selector,$callback){
+        $parentBrowser=$this;
+        return $this->with($selector,function($browser) use ($parentBrowser,$callback){
+            $component=$parentBrowser->component;
+            $browser->component=$component;
+            $browser->resolver->pageElements(
+                $component->elements() + $parentBrowser->resolver->elements
+            );
+
+            return $callback($browser);
+        });
+    }
 
     /**
      * Execute a Closure with a scoped browser instance.


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Enabling with method while keeping the component scope. 

Imitates "Browser::with" method, while enabling methods and elements from the components to be used in the children elements. ("with" method creates a new browser instance, which inherits page scope but not component scope )

Example:

Suppose for security reasons, we have a screen keyboard for each input field. Keyboard layout changes by input type, but 
writing logic and closing keyboard by close button is the same ( so it is defined in the component)

```
<?php

namespace Tests\Browser\Components;

use Laravel\Dusk\Browser;
use Laravel\Dusk\Component as BaseComponent;

class FormWithScreenKeyboard extends BaseComponent
{

    /**
     * Get the element shortcuts for the component.
     *
     * @return array
     */
    public function elements()
    {
        return [
          '@close_button' => '.close',
          '@first_input'=>'#input1',
          '@second_input'=>'#input2',
          '@screen_keyboard'=>'.keyboard'
        ];
    }

    public function writeWithScreenKeyboard(Browser $browser,$value){        
               foreach (str_split((string)$value) as $letter) {
                     $browser->press($letter) 
              }
    }
}
```

This fails
```
$browser->within(new FormWithScreenKeyboard,function($component){
       $component->with("@second_input @screen_keyboard",function($keyboard){
           $keyboard->writeWithScreenKeyboard("hello world");  // fails with methodNotFound [ writeWithScreenKeyboard]  in Browser
           $keyboard->click("@close_button") // fails as it cannot finds [dusk=close_button] ( cannot find component element -> defaults to dusk selector )
    });
    
});

```

This succeeds
```

$browser->within(new FormWithScreenKeyboard,function($component){
       $component->withinComponent("@second_input @screen_keyboard",function($keyboard){
           $keyboard->writeWithScreenKeyboard("hello world");  // $keyboard can resolve FormWithScreenKeyboard component
           $keyboard->click("@close_button") // it can find @close_button as it is in $keyboard->resolver->element

    });
    
});

```


A counter argument would be "Why not define the screen keyboard as a component?". Yes, it is true that this problem can be avoided by making a "ScreenKeyboard" component and migrating writeWithScreenKeyboard and @close_button to the that class. Still, with increased number of sub-components (i.e. in above FormWithScreenKeyboard component has much more sub elements),  maintaining components would be cumbersome. On the other hand, encapsulating the logic in a few files would be hindered as one cannot use methods/elements on the scope of "with" method. 
