### PR TITLE
feat: add alternative tag for element selection

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -410,7 +410,11 @@ class ElementResolver
         );
 
         if (Str::startsWith($selector, '@') && $selector === $originalSelector) {
-            $selector = '[dusk="'.explode('@', $selector)[1].'"]';
+            $elementPieces = explode('@', $selector);
+            $selector = $this->prefix . ' [dusk="'.$elementPieces[1].'"],';
+            $selector .= $this->prefix . ' [data-dusk="'.$elementPieces[1].'"]';
+
+            return trim($selector);
         }
 
         return trim($this->prefix.' '.$selector);

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -410,11 +410,12 @@ class ElementResolver
         );
 
         if (Str::startsWith($selector, '@') && $selector === $originalSelector) {
-            $elementPieces = explode('@', $selector);
-            $selector = $this->prefix . ' [dusk="'.$elementPieces[1].'"],';
-            $selector .= $this->prefix . ' [data-dusk="'.$elementPieces[1].'"]';
+            $segments = explode('@', $selector);
 
-            return trim($selector);
+            return trim(sprintf('%s,%s',
+                $this->prefix.' [dusk="'.$segments[1].'"]',
+                $this->prefix.' [data-dusk="'.$segments[1].'"]'
+            ));
         }
 
         return trim($this->prefix.' '.$selector);

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -94,7 +94,7 @@ class ComponentTest extends TestCase
         $component->selector = '@dusk-hook-root';
 
         $browser->within($component, function ($browser) {
-            $this->assertSame('body [dusk="dusk-hook-root"]', $browser->resolver->prefix);
+            $this->assertSame('body [dusk="dusk-hook-root"],body [data-dusk="dusk-hook-root"]', $browser->resolver->prefix);
         });
     }
 

--- a/tests/ElementResolverTest.php
+++ b/tests/ElementResolverTest.php
@@ -146,7 +146,7 @@ class ElementResolverTest extends TestCase
         $this->assertSame('prefix #first', $resolver->format('@modal'));
         $this->assertSame('prefix #second', $resolver->format('@modal-second'));
         $this->assertSame('prefix #first-third', $resolver->format('@modal-third'));
-        $this->assertSame('prefix [dusk="missing-element"]', $resolver->format('@missing-element'));
+        $this->assertSame('prefix [dusk="missing-element"],prefix [data-dusk="missing-element"]', $resolver->format('@missing-element'));
     }
 
     public function test_find_by_id_with_colon()

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -1134,7 +1134,7 @@ class MakesAssertionsTest extends TestCase
         $driver = m::mock(stdClass::class);
         $driver->shouldReceive('executeScript')
             ->with(
-                'var el = document.querySelector(\'body [dusk="vue-component"]\');'.
+                'var el = document.querySelector(\'body [dusk="vue-component"],body [data-dusk="vue-component"]\');'.
                 "if (typeof el.__vue__ !== 'undefined')".
                 '    return el.__vue__.name;'.
                 'try {'.


### PR DESCRIPTION
This adds the alternative `data-dusk="tag"` attribute. As described in: https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes: attributes that are not part of the spec should be prefixed with `data-`. 

Currently TSX does not allow any attributes that aren't defined in the spec, unless they have a data prefix. So without an alternative attribute to `dusk=`, TSX users won't be able to use Dusk as documented.