### PR TITLE
Added .env file existence check

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -224,7 +224,8 @@ class DuskCommand extends Command
     protected function setupDuskEnvironment()
     {
         if (file_exists(base_path($this->duskFile()))) {
-            if (file_get_contents(base_path('.env')) !== file_get_contents(base_path($this->duskFile()))) {
+            if (file_exists(base_path('.env')) &&
+                file_get_contents(base_path('.env')) !== file_get_contents(base_path($this->duskFile()))) {
                 $this->backupEnvironment();
             }
 


### PR DESCRIPTION
An error occurs while running a command `php artisan dusk` while file .env.dusk exists, but .env does not:
```
In DuskCommand.php line 227:
file_get_contents(/code/.env): Failed to open stream: No such file or directory
```

In our case, this situation occurred while running tests in CI/CD, where .env is gitignored, but .env.dusk with default values exists.