### PR TITLE
Include verification of the value

### DIFF
--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -51,8 +51,8 @@ abstract class DuskTestCase extends BaseTestCase
      */
     protected function hasHeadlessDisabled(): bool
     {
-        return isset($_SERVER['DUSK_HEADLESS_DISABLED']) ||
-               isset($_ENV['DUSK_HEADLESS_DISABLED']);
+        return (isset($_SERVER['DUSK_HEADLESS_DISABLED']) && $_SERVER['DUSK_HEADLESS_DISABLED']) ||
+               (isset($_ENV['DUSK_HEADLESS_DISABLED']) && $_ENV['DUSK_HEADLESS_DISABLED'];
     }
 
     /**
@@ -60,7 +60,7 @@ abstract class DuskTestCase extends BaseTestCase
      */
     protected function shouldStartMaximized(): bool
     {
-        return isset($_SERVER['DUSK_START_MAXIMIZED']) ||
-               isset($_ENV['DUSK_START_MAXIMIZED']);
+        return (isset($_SERVER['DUSK_START_MAXIMIZED']) && $_SERVER['DUSK_START_MAXIMIZED']) ||
+               (isset($_ENV['DUSK_START_MAXIMIZED']) && $_ENV['DUSK_START_MAXIMIZED']);
     }
 }


### PR DESCRIPTION
isset is not enough to consider the state of the options.  

With the previous solution, even if DUSK_HEADLESS_DISABLED=false, the result was truthy because the value was set.

The proposed solution also checks the value.

```
<?php

// Outputs  'FALSE || 0'
echo isset($DUSK_HEADLESS_DISABLED) ? '_SET' : '_UNSET';
	
// Outputs  'TRUE || 0'
$DUSK_HEADLESS_DISABLED = true;
echo isset($DUSK_HEADLESS_DISABLED) ? '_SET' : '_UNSET';

// Outputs 'TRUE || 1'
$DUSK_HEADLESS_DISABLED = false;
echo isset($DUSK_HEADLESS_DISABLED) ? '_SET' : '_UNSET';
```

Notice that last example, although the value is false, it would be considered truth with the existing implementation.