### PR TITLE
Include verification of the value (Fixed Brackets)

### DIFF
--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -52,7 +52,7 @@ abstract class DuskTestCase extends BaseTestCase
     protected function hasHeadlessDisabled(): bool
     {
         return (isset($_SERVER['DUSK_HEADLESS_DISABLED']) && $_SERVER['DUSK_HEADLESS_DISABLED']) ||
-               (isset($_ENV['DUSK_HEADLESS_DISABLED']) && $_ENV['DUSK_HEADLESS_DISABLED'];
+               (isset($_ENV['DUSK_HEADLESS_DISABLED']) && $_ENV['DUSK_HEADLESS_DISABLED']);
     }
 
     /**

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -51,8 +51,8 @@ abstract class DuskTestCase extends BaseTestCase
      */
     protected function hasHeadlessDisabled(): bool
     {
-        return isset($_SERVER['DUSK_HEADLESS_DISABLED']) ||
-               isset($_ENV['DUSK_HEADLESS_DISABLED']);
+        return (isset($_SERVER['DUSK_HEADLESS_DISABLED']) && $_SERVER['DUSK_HEADLESS_DISABLED']) ||
+               (isset($_ENV['DUSK_HEADLESS_DISABLED']) && $_ENV['DUSK_HEADLESS_DISABLED'];
     }
 
     /**
@@ -60,7 +60,7 @@ abstract class DuskTestCase extends BaseTestCase
      */
     protected function shouldStartMaximized(): bool
     {
-        return isset($_SERVER['DUSK_START_MAXIMIZED']) ||
-               isset($_ENV['DUSK_START_MAXIMIZED']);
+        return (isset($_SERVER['DUSK_START_MAXIMIZED']) && $_SERVER['DUSK_START_MAXIMIZED']) ||
+               (isset($_ENV['DUSK_START_MAXIMIZED']) && $_ENV['DUSK_START_MAXIMIZED']);
     }
 }


### PR DESCRIPTION
**Using `isset` is not a flexible/good enough check to consider the state of the options.**  

With the currently implemented solution, even if `DUSK_HEADLESS_DISABLED=false`, the function returns truthy because the value "is set".

My proposed solution also checks the value.

Example showing that the current implementation is returning truthy.
```php
/*
 * Currently implemented code.
 * Outputs 'TRUE || 1' 
 * Despite being explicitly set to FALSE, it would return true.
 */
$DUSK_HEADLESS_DISABLED = false;
echo isset($DUSK_HEADLESS_DISABLED) ? 'true' : 'false';

/*
 * Suggested change
 * Outputs 'FALSE || 0' 
 * Being explicitly set to FALSE, it returns false.
 */
$DUSK_HEADLESS_DISABLED = false;
echo (isset($DUSK_HEADLESS_DISABLED) && $DUSK_HEADLESS_DISABLED) ? 'true' : 'false';
```

> The code was tested on a local install of Laravel using Dusk. 
> Change suggestion made using Github's interface to make my contribution back to Dusk easier.

_Please suggest feedback before closing if you disagree with the solution proposed._