### PR TITLE
Customizable Attribute Name for @selector Lookups

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -410,7 +410,7 @@ class ElementResolver
         );
 
         if (Str::startsWith($selector, '@') && $selector === $originalSelector) {
-            $selector = '[dusk="'.explode('@', $selector)[1].'"]';
+            $selector = '['.($_ENV['DUSK_HTML_ATTRIBUTE'] ?? 'dusk').'="'.explode('@', $selector)[1].'"]';
         }
 
         return trim($this->prefix.' '.$selector);


### PR DESCRIPTION
This adds support for an optional `DUSK_HTML_ATTRIBUTE` setting for attribute names besides "dusk" within HTML.

## Benefits

### W3C Compliancy

This will provide a way to achieve W3C compliancy as discussed [here](https://github.com/laravel/dusk/issues/666) and specified [here](https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes) with `data-` prefixes.

```
DUSK_HTML_ATTRIBUTE=data-dusk
```

### Transition Support

The attribute can be changed easily during transitory periods where there might be multiple testing engines acting against the same website.

### Reduced Exposure

This will allow a more generic attribute name to be chosen to prevent exposing the use of Dusk, Laravel, and PHP to the world. This can help reduce the attack surface for hackers.

## Backwards Compatibility

Because the absence of the `DUSK_HTML_ATTRIBUTE` results in the "dusk" default being used, default behavior should be completely unaffected.

## Note

This also achieves the goal sought in https://github.com/laravel/dusk/pull/1012 but achieves it through customization rather than by adding static support for `data-dusk` as a simultaneous attribute to `dusk`. As such it's a little less invasive while also offering greater flexibility.