### PR TITLE
[7.x] Use `--headless=new`

### DIFF
--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -34,7 +34,7 @@ abstract class DuskTestCase extends BaseTestCase
         ])->unless($this->hasHeadlessDisabled(), function (Collection $items) {
             return $items->merge([
                 '--disable-gpu',
-                '--headless',
+                '--headless=new',
             ]);
         })->all());
 


### PR DESCRIPTION
As of Chrome version 109, there is a new and improved headless mode that can be enabled with `--headless=new`. It is described in more detail in this [Selenium blog post](https://www.selenium.dev/blog/2023/headless-is-going-away/) and this [StackOverflow comment](https://stackoverflow.com/questions/45631715/downloading-with-chrome-headless-and-selenium/73840130#73840130).

The `--headless=new` flag also fixes a breaking change in Chromedriver where setting a custom download directory stopped working. I was using the code below to set a custom download directory:

```php
$options->setExperimentalOption('prefs', [
    'download.default_directory' => storage_path('app/dusk-downloads'),
]);
```

This stopped working recently and caused my tests to fail, but setting `--headless=new` fixed it.


