### PR TITLE
Fixed timeout error message that contain percent characters when calling waitForTextIn

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -123,7 +123,7 @@ trait WaitsForElements
      */
     public function waitForTextIn($selector, $text, $seconds = null)
     {
-        $message = 'Waited %s seconds for text "'.$text.'" in selector '.$selector;
+        $message = 'Waited %s seconds for text "'.str_replace('%', '%%', $text).'" in selector '.$selector;
 
         return $this->waitUsing($seconds, 100, function () use ($selector, $text) {
             return $this->assertSeeIn($selector, $text);

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -123,7 +123,7 @@ trait WaitsForElements
      */
     public function waitForTextIn($selector, $text, $seconds = null)
     {
-        $message = 'Waited %s seconds for text "'.str_replace('%', '%%', $text).'" in selector '.$selector;
+        $message = 'Waited %s seconds for text "'.$this->escapePercentCharacters($text).'" in selector '.$selector;
 
         return $this->waitUsing($seconds, 100, function () use ($selector, $text) {
             return $this->assertSeeIn($selector, $text);
@@ -427,6 +427,17 @@ trait WaitsForElements
      */
     protected function formatTimeOutMessage($message, $expected)
     {
-        return $message.' ['.str_replace('%', '%%', $expected).'].';
+        return $message.' ['.$this->escapePercentCharacters($expected).'].';
+    }
+
+    /**
+     * Escape percent characters before feeding the message to sprintf().
+     *
+     * @param  string  $message
+     * @return string
+     */
+    protected function escapePercentCharacters($message)
+    {
+        return str_replace('%', '%%', $message);
     }
 }

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -431,7 +431,7 @@ trait WaitsForElements
     }
 
     /**
-     * Escape percent characters before feeding the message to sprintf().
+     * Escape percent characters in preparation for sending the given message to "sprintf".
      *
      * @param  string  $message
      * @return string

--- a/tests/WaitsForElementsTest.php
+++ b/tests/WaitsForElementsTest.php
@@ -213,6 +213,25 @@ class WaitsForElementsTest extends TestCase
         }
     }
 
+    public function test_wait_for_text_in_failure_message_containing_a_percent_character()
+    {
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getText')->andReturn('Discount: None');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
+        $browser = new Browser(new stdClass, $resolver);
+
+        try {
+            $browser->waitForTextIn('foo', 'Discount: 20%', 1);
+            $this->fail('waitForTextIn() did not timeout.');
+        } catch (TimeOutException $e) {
+            $this->assertSame('Waited 1 seconds for text "Discount: 20%" in selector foo', $e->getMessage());
+        }
+    }
+
     public function test_wait_for_an_element_to_be_enabled()
     {
         $element = m::mock(stdClass::class);

--- a/tests/WaitsForElementsTest.php
+++ b/tests/WaitsForElementsTest.php
@@ -195,6 +195,24 @@ class WaitsForElementsTest extends TestCase
         $browser->waitUntilMissing('foo');
     }
 
+    public function test_wait_until_missing_text_failure_message_containing_a_percent_character()
+    {
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getText')->andReturn('Discount: 20%');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('findOrFail')->with('')->andReturn($element);
+
+        $browser = new Browser(new stdClass, $resolver);
+
+        try {
+            $browser->waitUntilMissingText('Discount: 20%', 1);
+            $this->fail('waitUntilMissingText() did not timeout.');
+        } catch (TimeOutException $e) {
+            $this->assertSame('Waited 1 seconds for removal of text [Discount: 20%].', $e->getMessage());
+        }
+    }
+
     public function test_wait_for_text_failure_message_containing_a_percent_character()
     {
         $element = m::mock(stdClass::class);
@@ -229,6 +247,38 @@ class WaitsForElementsTest extends TestCase
             $this->fail('waitForTextIn() did not timeout.');
         } catch (TimeOutException $e) {
             $this->assertSame('Waited 1 seconds for text "Discount: 20%" in selector foo', $e->getMessage());
+        }
+    }
+
+    public function test_wait_for_link_failure_message_containing_a_percent_character()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('executeScript')
+            ->andReturnFalse();
+
+        $browser = new Browser($driver);
+
+        try {
+            $browser->waitForLink('https://laravel.com?q=foo%20bar', 1);
+            $this->fail('waitForLink() did not timeout.');
+        } catch (TimeOutException $e) {
+            $this->assertSame('Waited 1 seconds for link [https://laravel.com?q=foo%20bar].', $e->getMessage());
+        }
+    }
+
+    public function test_wait_for_location_failure_message_containing_a_percent_character()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('executeScript')
+            ->andReturnFalse();
+
+        $browser = new Browser($driver);
+
+        try {
+            $browser->waitForLocation('https://laravel.com?q=foo%20bar', 1);
+            $this->fail('waitForLocation() did not timeout.');
+        } catch (TimeOutException $e) {
+            $this->assertSame('Waited 1 seconds for location [https://laravel.com?q=foo%20bar].', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
Hello, I have found a bug with the timeout error message when calling `waitForTextIn` with text that contains a percent character.

For example: 

A failing call to `waitForTextIn('foo', 'Discount: 20%')` should display the following error message: 

```
Waited 1 seconds for text "Discount: 20%" in selector foo
```

But it actually shows 

```
ArgumentCountError: 3 arguments are required, 2 given
```

Which is caused by the `sprintf` call to format the error message getting confused by the extra % signs in the message.

I believe this has already been fixed for `waitForText`, as evidenced by the `test_wait_for_text_failure_message_containing_a_percent_character` test, but the bug remains for `waitForTextIn`.

I tried using the `formatTimeOutMessage` method which was used to fix this bug on `waitForText`, but it formats the error message differently and is not easily compatible with the error message format that's expected from the `waitForTextIn` method.

So my fix is simpler, and I've just added a `str_replace` call. It could be a good idea to refactor the `formatTimeOutMessage`, and make the error messages more uniform in the future, but that could be considered a breaking change I think, so I did not venture there.
