### PR TITLE
Add support for native scroll into view options

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -386,10 +386,10 @@ class Browser
     {
         $selector = addslashes($this->resolver->format($selector));
 
-        $options = match($options) {
+        $options = match ($options) {
             null => '',
-            true => json_encode([ 'block' => 'start', 'inline' => 'nearest' ]),
-            false => json_encode([ 'block' => 'end', 'inline' => 'nearest' ]),
+            true => json_encode(['block' => 'start', 'inline' => 'nearest']),
+            false => json_encode(['block' => 'end', 'inline' => 'nearest']),
             default => json_encode($options, JSON_THROW_ON_ERROR)
         };
 
@@ -746,7 +746,7 @@ class Browser
      */
     public function stop()
     {
-        exit();
+        exit;
     }
 
     /**

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -399,6 +399,20 @@ class Browser
     }
 
     /**
+     * Scroll element instantly into view at the given selector.
+     *
+     * @param  string  $selector
+     * @param  bool|array|null  $options
+     * @return $this
+     */
+    public function scrollInstantlyIntoView($selector, $options = null)
+    {
+        return $this->scrollIntoView($selector, array_merge([
+            'behavior' => 'instant',
+        ], $options ?? []));
+    }
+
+    /**
      * Scroll screen to element at the given selector.
      *
      * @param  string  $selector

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -379,13 +379,21 @@ class Browser
      * Scroll element into view at the given selector.
      *
      * @param  string  $selector
+     * @param  bool|array|null  $options
      * @return $this
      */
-    public function scrollIntoView($selector)
+    public function scrollIntoView($selector, $options = null)
     {
         $selector = addslashes($this->resolver->format($selector));
 
-        $this->driver->executeScript("document.querySelector(\"$selector\").scrollIntoView();");
+        $options = match($options) {
+            null => '',
+            true => json_encode([ 'block' => 'start', 'inline' => 'nearest' ]),
+            false => json_encode([ 'block' => 'end', 'inline' => 'nearest' ]),
+            default => json_encode($options, JSON_THROW_ON_ERROR)
+        };
+
+        $this->driver->executeScript("document.querySelector(\"$selector\").scrollIntoView($options);");
 
         return $this;
     }


### PR DESCRIPTION
This expands the work from @u01jmg3 (#765), by adding support for the native "scrollIntoViewOptions", as described by [Mozilla's documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView).
Furthermore, PR also adds a shortcut method for scrolling an element "instantly" into view.
