### PR TITLE
Show error if the test class name doesn't have the keyword Test appended.

### DIFF
--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -71,4 +71,15 @@ class MakeCommand extends GeneratorCommand
     {
         return 'Tests';
     }
+
+    public function handle()
+    {
+        $filename = $this->argument('name');
+
+        if(! Str::endsWith($filename, 'Test')) {
+            return $this->error("Please append your class name with the keyword 'Test'. For e.g LoginTest instead of just Login.");
+        }
+
+        parent::handle();
+    }
 }

--- a/src/Console/MakeCommand.php
+++ b/src/Console/MakeCommand.php
@@ -71,15 +71,13 @@ class MakeCommand extends GeneratorCommand
     {
         return 'Tests';
     }
-
+    
     public function handle()
     {
         $filename = $this->argument('name');
 
-        if(! Str::endsWith($filename, 'Test')) {
-            return $this->error("Please append your class name with the keyword 'Test'. For e.g LoginTest instead of just Login.");
-        }
-
-        parent::handle();
+        if(! Str::endsWith($filename, 'Test')) 
+            $this->error("Please append your class name with the keyword 'Test'. For e.g LoginTest instead of just Login.");
+        else parent::handle();
     }
 }


### PR DESCRIPTION
This is just a QOL improvement. I have found myself in situation when I use the dusk make command as following:

`php artisan dusk:make Dashboard`

In this case I want to make a Dashboard test but forgot to append the name with keyword "Test". As the dusk class name isn't DashboardTest, the tests just simply skipped silently. 

I wanted to make it this way where the command asks the input again but couldn't figure this out without overriding the `getNameInput()` method (and I feel that's overkill for this small improvement). 

Hence this PR just simply throws an error message if the "Test" keyword isn't appended. Let me know if it should be done differently. 