### PR TITLE
Allow `dusk` attribute selectors to be chained

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -410,7 +410,7 @@ class ElementResolver
         );
 
         if (Str::startsWith($selector, '@') && $selector === $originalSelector) {
-            $selector = '['.Dusk::$selectorHtmlAttribute.'="'.explode('@', $selector)[1].'"]';
+            $selector = preg_replace('/@(\S+)/', '['.Dusk::$selectorHtmlAttribute.'="$1"]', $selector);
         }
 
         return trim($this->prefix.' '.$selector);

--- a/tests/ElementResolverTest.php
+++ b/tests/ElementResolverTest.php
@@ -147,6 +147,7 @@ class ElementResolverTest extends TestCase
         $this->assertSame('prefix #second', $resolver->format('@modal-second'));
         $this->assertSame('prefix #first-third', $resolver->format('@modal-third'));
         $this->assertSame('prefix [dusk="missing-element"]', $resolver->format('@missing-element'));
+        $this->assertSame('prefix [dusk="missing-element"] > div', $resolver->format('@missing-element > div'));
     }
 
     public function test_find_by_id_with_colon()


### PR DESCRIPTION
I have come across a few situations when writing Dusk tests where I use the `dusk` attribute selector on a wrapper `div`, then want to select elements _within_ that `div`...

e.g.
```html
<div dusk="all-items">
    <div>Item 1</div>
    <div>Item 2</div>
    <div>Item 3</div>
    <div>Item 4</div>
</div>
````

And I was hoping I could do something like this...

```php
$items = $browser->elements('@all-items > div');

foreach($items as $item){
    // assert something
}
```

...but this doesn't work because the selector gets compiled to `[dusk="all-items > div"]`

This PR makes this selector get compiled to `[dusk="all-items"] > div`

### Bonus
Also allows multiple `dusk` attribute selectors to work as expected

This selector...
```
@item-list > div:nth-child(2) @submit-button
```

becomes...
```
[dusk="item-list"] > div:nth-child(2) [dusk="submit-button"]
```