### PR TITLE
Allow `dusk` selectors to contain spaces

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -410,7 +410,13 @@ class ElementResolver
         );
 
         if (Str::startsWith($selector, '@') && $selector === $originalSelector) {
-            $selector = preg_replace('/@(\S+)/', '['.Dusk::$selectorHtmlAttribute.'="$1"]', $selector);
+            $selector = $selector.' ';
+            $selector = trim(
+                preg_replace(
+                    '/@([a-zA-Z0-9\:\_\-\ ]+)(?=\s)/',
+                    '['.Dusk::$selectorHtmlAttribute.'="$1"]', $selector
+                )
+            );
         }
 
         return trim($this->prefix.' '.$selector);

--- a/tests/ElementResolverTest.php
+++ b/tests/ElementResolverTest.php
@@ -147,7 +147,12 @@ class ElementResolverTest extends TestCase
         $this->assertSame('prefix #second', $resolver->format('@modal-second'));
         $this->assertSame('prefix #first-third', $resolver->format('@modal-third'));
         $this->assertSame('prefix [dusk="missing-element"]', $resolver->format('@missing-element'));
+        $this->assertSame('prefix [dusk="missing:element"]', $resolver->format('@missing:element'));
         $this->assertSame('prefix [dusk="missing-element"] > div', $resolver->format('@missing-element > div'));
+        $this->assertSame('prefix [dusk="missing element"] > div', $resolver->format('@missing element > div'));
+        $this->assertSame('prefix [dusk="missing element"] .class', $resolver->format('@missing element .class'));
+        $this->assertSame('prefix [dusk="missing element"] > div:nth-child(2) [dusk="item-1"]', $resolver->format('@missing element > div:nth-child(2) @item-1'));
+        $this->assertSame('prefix [dusk="missing element"] > div:nth-child(2) [dusk="item 1"]', $resolver->format('@missing element > div:nth-child(2) @item 1'));
     }
 
     public function test_find_by_id_with_colon()


### PR DESCRIPTION
As reported by @patrickomeara, PR #1034 broke tests for anyone using `dusk` selectors that contained a space character.

This PR fixes that.

**NOTE**
I have limited the characters that can be matched in a `dusk` selector to alphanumeric chars plus `:`, `_`, `-`, `[:space:]` because we can't allow chars like `>` or `.` because that would then start matching chained selectors like...

```
@dusk selector .class
@dusk selector > div
```

The biggest issue with this fix though is you will not be able to do a selector like this...

```
@dusk selector div
```

...as the regex doesn't know which space to stop matching on. This will compile to...

```
dusk=["dusk selector div"]
```

rather than the desired
```
dusk=["dusk selector"] div
```


So, I see 3 options here...

1. Revert #1034
2. Keep as-is and note in the docs that `dusk` selectors cannot contain spaces
3. Merge this PR which adds complexity and fixes the space issue, but doesn't allow all types of CSS selector chaining

My preference would be option 2, but then I would say that as it suits my requirements, but I was a little perplexed when I couldn't chain selectors, seemed like an obvious thing to allow.

Options 3 (this PR) worries me as it feels like we may end up chasing our tails.

Thanks