### PR TITLE
Use the default printer from Collision

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-zip": "*",
         "php-webdriver/webdriver": "^1.9.0",
         "nesbot/carbon": "^2.0",
-        "nunomaduro/collision": "^7.7",
+        "nunomaduro/collision": "^6.0|^7.0",
         "illuminate/console": "^9.0|^10.0",
         "illuminate/support": "^9.0|^10.0",
         "symfony/console": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "ext-zip": "*",
         "php-webdriver/webdriver": "^1.9.0",
         "nesbot/carbon": "^2.0",
+        "nunomaduro/collision": "^7.7",
         "illuminate/console": "^9.0|^10.0",
         "illuminate/support": "^9.0|^10.0",
         "symfony/console": "^6.0",


### PR DESCRIPTION
I would like some feedback on some speed bumps I have hit.

My main objective is getting a nicer console output from the dusk command and keep some consistency with `php artisan test`. The additional benefit is getting quicker feedback from CI environments that print line by line.

PHPUnit 10 dropped support for printers and instead introduced subscribers. @nunomaduro's `EnsurePrinterIsRegisteredSubscriber` class is a subscriber. However this class is marked as `@internal` so I'm unsure if we should use it in Dusk or follow best practices and break it out into it's own package that both Collision and Dusk, and others can use. Any feedback would be appreciated.

I can confirm that this is working in collision 7/phpunit 10.

<img width="890" alt="image" src="https://github.com/laravel/dusk/assets/571773/bdf1f031-56c6-445e-acdf-8187179c0fc6">

I've added the collision constraint as `^6.0|^7.0` for backwards compatibility. Although, the printer won't work in PHPUnit 9.

<img width="810" alt="image" src="https://github.com/laravel/dusk/assets/571773/bcc91b85-ed72-46ac-9f4f-4cf130e8c904">

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
