### PR TITLE
[7.x] Uses Collision's printer if possible

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -156,7 +156,7 @@ class DuskCommand extends Command
     }
 
     /**
-     * If the Collision's printer should be used.
+     * Determine if Collision's printer should be used.
      *
      * @return bool
      */

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -5,6 +5,7 @@ namespace Laravel\Dusk\Console;
 use Dotenv\Dotenv;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
+use NunoMaduro\Collision\Adapters\Phpunit\Subscribers\EnsurePrinterIsRegisteredSubscriber;
 use PHPUnit\Runner\Version;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
@@ -119,6 +120,10 @@ class DuskCommand extends Command
      */
     protected function phpunitArguments($options)
     {
+        if ($this->shouldUseCollisionPrinter()) {
+            $options[] = '--no-output';
+        }
+
         $options = array_values(array_filter($options, function ($option) {
             return ! Str::startsWith($option, ['--env=', '--pest']);
         }));
@@ -137,9 +142,29 @@ class DuskCommand extends Command
      */
     protected function env()
     {
+       $variables = [];
+
         if ($this->option('browse') && ! isset($_ENV['CI']) && ! isset($_SERVER['CI'])) {
-            return ['DUSK_HEADLESS_DISABLED' => true];
+            $variables['DUSK_HEADLESS_DISABLED'] = true;
         }
+
+        if ($this->shouldUseCollisionPrinter()) {
+            $variables['COLLISION_PRINTER'] = 'DefaultPrinter';
+        }
+
+        return $variables;
+    }
+
+    /**
+     * If the Collision's printer should be used.
+     *
+     * @return bool
+     */
+    protected function shouldUseCollisionPrinter()
+    {
+        return ! $this->option('pest')
+            && class_exists(EnsurePrinterIsRegisteredSubscriber::class)
+            && version_compare(Version::id(), '10.0', '>=');
     }
 
     /**

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -142,7 +142,7 @@ class DuskCommand extends Command
      */
     protected function env()
     {
-       $variables = [];
+        $variables = [];
 
         if ($this->option('browse') && ! isset($_ENV['CI']) && ! isset($_SERVER['CI'])) {
             $variables['DUSK_HEADLESS_DISABLED'] = true;


### PR DESCRIPTION
This pull request makes Dusk use the Collision printer if possible. The idea originally came from https://github.com/laravel/dusk/pull/1036, and this pull request made some tweaks to it.

Before:
<img width="839" alt="before" src="https://github.com/laravel/dusk/assets/5457236/fdfcd8a8-5d8d-4a6c-9dc9-940fd8f81347">

After:
<img width="798" alt="after" src="https://github.com/laravel/dusk/assets/5457236/9f295f7e-5271-44a7-8c9c-663d7dbabfc7">
