### PR TITLE
[8.x] New Chromedriver downloads

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,8 +11,6 @@
          stopOnError="false"
          stopOnFailure="false"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
-         cacheDirectory=".phpunit.cache"
-         backupStaticProperties="false"
 >
     <testsuites>
         <testsuite name="Laravel Dusk Test Suite">

--- a/src/Chrome/ChromeProcess.php
+++ b/src/Chrome/ChromeProcess.php
@@ -41,10 +41,10 @@ class ChromeProcess
         } else {
             $filenames = [
                 'linux' => 'chromedriver-linux',
-                'mac' => 'chromedriver-mac',
                 'mac-intel' => 'chromedriver-mac-intel',
                 'mac-arm' => 'chromedriver-mac-arm',
-                'win' => 'chromedriver-win.exe',
+                'win32' => 'chromedriver-win32.exe',
+                'win64' => 'chromedriver-win64.exe',
             ];
 
             $driver = __DIR__.'/../../bin'.DIRECTORY_SEPARATOR.$filenames[$this->operatingSystemId()];

--- a/src/OperatingSystem.php
+++ b/src/OperatingSystem.php
@@ -14,7 +14,7 @@ class OperatingSystem
     public static function id()
     {
         if (static::onWindows()) {
-            return 'win';
+            return static::windowsArchitectureId();
         } elseif (static::onMac()) {
             return static::macArchitectureId();
         }
@@ -30,6 +30,21 @@ class OperatingSystem
     public static function onWindows()
     {
         return PHP_OS === 'WINNT' || Str::contains(php_uname(), 'Microsoft');
+    }
+
+    /**
+     * Windows platform architecture.
+     *
+     * @return string
+     */
+    public static function windowsArchitectureId()
+    {
+        switch (PHP_INT_SIZE) {
+            case 8:
+                return 'win64';
+            default:
+                return 'win32';
+        }
     }
 
     /**

--- a/tests/ChromeProcessTest.php
+++ b/tests/ChromeProcessTest.php
@@ -24,7 +24,7 @@ class ChromeProcessTest extends TestCase
         try {
             (new ChromeProcessWindows)->toProcess();
         } catch (RuntimeException $exception) {
-            $this->assertStringContainsString('chromedriver-win.exe', $exception->getMessage());
+            $this->assertStringContainsString('chromedriver-win32.exe', $exception->getMessage());
         }
     }
 
@@ -78,7 +78,7 @@ class ChromeProcessWindows extends ChromeProcess
 
     protected function operatingSystemId()
     {
-        return 'win';
+        return 'win32';
     }
 }
 


### PR DESCRIPTION
This updates Dusk to the new urls from Google for getting the latest version of the chromedrivers as well as their download links for each OS. Chrome changed this to a JSON payload instead: https://chromedriver.chromium.org/home

> Starting with M115 the latest Chrome + ChromeDriver releases per release channel (Stable, Beta, Dev, Canary) are available at[ the Chrome for Testing availability dashboard](https://googlechromelabs.github.io/chrome-for-testing/). For automated version downloading one can use the convenient [JSON endpoints](https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json).

Here's a list of all endpoints: https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints

I'm using the `last-known-good-versions-with-downloads.json` one to grab the latest stable version one and the `latest-versions-per-milestone-with-downloads.json` to easily match a requested milestone (e.g. 115) with their download url.

I've also changed the slug and OS matching to the new naming conventions. And also added support for Windows 64 bit chromedrivers (I can take out that part if you want).

To upgrade, people will need to install at least Chrome 115 and re-run `php artisan dusk:chrome-driver`.

I have not yet tested this out on a Laravel app.