### PR TITLE
[7.x] Prevent interaction with `Http::preventStrayRequests`

### DIFF
--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -6,7 +6,6 @@ use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Utils;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Laravel\Dusk\OperatingSystem;
 use Symfony\Component\Process\Process;

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -307,6 +307,7 @@ class ChromeDriverCommand extends Command
      * Get the contents of a URL using the 'proxy' and 'ssl-no-verify' command options.
      *
      * @return string
+     *
      * @throws Exception
      */
     protected function getUrl(string $url)

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -311,10 +311,10 @@ class ChromeDriverCommand extends Command
      */
     protected function getUrl(string $url)
     {
-        return Http::withOptions(array_merge([
+        return (new Client())->get($url, array_merge([
             'verify' => $this->option('ssl-no-verify') === false,
         ], array_filter([
             'proxy' => $this->option('proxy'),
-        ])))->get($url)->body();
+        ])))->getBody();
     }
 }

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -307,13 +307,22 @@ class ChromeDriverCommand extends Command
      * Get the contents of a URL using the 'proxy' and 'ssl-no-verify' command options.
      *
      * @return string
+     * @throws Exception
      */
     protected function getUrl(string $url)
     {
-        return (new Client())->get($url, array_merge([
+        $client = new Client();
+
+        $response = $client->get($url, array_merge([
             'verify' => $this->option('ssl-no-verify') === false,
         ], array_filter([
             'proxy' => $this->option('proxy'),
-        ])))->getBody();
+        ])));
+
+        if ($response->getStatusCode() < 200 || $response->getStatusCode() > 299) {
+            throw new Exception("Unable to fetch contents from [{$url}]");
+        }
+
+        return (string) $response->getBody();
     }
 }

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -321,7 +321,7 @@ class ChromeDriverCommand extends Command
         ])));
 
         if ($response->getStatusCode() < 200 || $response->getStatusCode() > 299) {
-            throw new Exception("Unable to fetch contents from [{$url}]");
+            throw new Exception("Unable to fetch contents from [{$url}].");
         }
 
         return (string) $response->getBody();


### PR DESCRIPTION
This PR replaces the use of the `Http` facade with direct use of the Guzzle client allowing the request to be made regardless of stray requests being prevented.

Since #1043 the `getUrl` method for the `dusk:chrome-driver` command has used the `Http` facade to get the URL for the latest download URL. This has the unintended consequence of throwing an exception if stray requests are being prevented. Previously the URL was obtained using `file_get_contents` so it would still allow the command to successfully execute when requests are being prevented.

The Guzzle client is also directly used in the `download` method already.

