### PR TITLE
[7.x] Keyboard Support Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
 composer.lock
 /phpunit.xml
+.phpunit.cache/*
 .phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release Notes
 
-## [Unreleased](https://github.com/laravel/dusk/compare/v7.9.2...7.x)
+## [Unreleased](https://github.com/laravel/dusk/compare/v7.9.3...7.x)
+
+## [v7.9.3](https://github.com/laravel/dusk/compare/v7.9.2...v7.9.3) - 2023-08-03
+
+- [7.x] Prevent interaction with `Http::preventStrayRequests` by [@joshbonnick](https://github.com/joshbonnick) in https://github.com/laravel/dusk/pull/1052
 
 ## [v7.9.2](https://github.com/laravel/dusk/compare/v7.9.1...v7.9.2) - 2023-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,8 @@
 
 ## [v7.9.2](https://github.com/laravel/dusk/compare/v7.9.1...v7.9.2) - 2023-07-30
 
-### What's Changed
-
 - [7.x] Export ignore `testbench.yaml` file by [@crynobone](https://github.com/crynobone) in https://github.com/laravel/dusk/pull/1048
 - [7.x] Fixes using `ChromeDriverCommand` with Telescope by [@crynobone](https://github.com/crynobone) in https://github.com/laravel/dusk/pull/1050
-
-**Full Changelog**: https://github.com/laravel/dusk/compare/v7.9.1...v7.9.2
 
 ## [v7.9.1](https://github.com/laravel/dusk/compare/v7.9.0...v7.9.1) - 2023-07-27
 

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -5,10 +5,8 @@ namespace Laravel\Dusk\Concerns;
 use Facebook\WebDriver\Interactions\WebDriverActions;
 use Facebook\WebDriver\Remote\LocalFileDetector;
 use Facebook\WebDriver\WebDriverBy;
-use Facebook\WebDriver\WebDriverKeys;
 use Facebook\WebDriver\WebDriverSelect;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 
 trait InteractsWithElements
 {

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Str;
 
 trait InteractsWithElements
 {
+    use InteractsWithKeyboard;
+
     /**
      * Get all of the elements matching the given selector.
      *
@@ -111,27 +113,6 @@ trait InteractsWithElements
         $this->resolver->findOrFail($selector)->sendKeys($this->parseKeys($keys));
 
         return $this;
-    }
-
-    /**
-     * Parse the keys before sending to the keyboard.
-     *
-     * @param  array  $keys
-     * @return array
-     */
-    protected function parseKeys($keys)
-    {
-        return collect($keys)->map(function ($key) {
-            if (is_string($key) && Str::startsWith($key, '{') && Str::endsWith($key, '}')) {
-                $key = constant(WebDriverKeys::class.'::'.strtoupper(trim($key, '{}')));
-            }
-
-            if (is_array($key) && Str::startsWith($key[0], '{')) {
-                $key[0] = constant(WebDriverKeys::class.'::'.strtoupper(trim($key[0], '{}')));
-            }
-
-            return $key;
-        })->all();
     }
 
     /**

--- a/src/Concerns/InteractsWithKeyboard.php
+++ b/src/Concerns/InteractsWithKeyboard.php
@@ -3,6 +3,7 @@
 namespace Laravel\Dusk\Concerns;
 
 use Facebook\WebDriver\WebDriverKeys;
+use Illuminate\Support\Str;
 use Laravel\Dusk\Keyboard;
 
 trait InteractsWithKeyboard

--- a/src/Concerns/InteractsWithKeyboard.php
+++ b/src/Concerns/InteractsWithKeyboard.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Laravel\Dusk\Concerns;
+
+use Facebook\WebDriver\WebDriverKeys;
+use Laravel\Dusk\Keyboard;
+
+trait InteractsWithKeyboard
+{
+    /**
+     * Uses browser's keyboard.
+     *
+     * @param  callable(\Laravel\Dusk\Keyboard):void  $callback
+     * @return $this
+     */
+    protected function usesKeyboard(callable $callback)
+    {
+        if (is_callable($callback)) {
+            call_user_func($callback, new Keyboard($this));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Parse the keys before sending to the keyboard.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    protected function parseKeys($keys)
+    {
+        return collect($keys)->map(function ($key) {
+            if (is_string($key) && Str::startsWith($key, '{') && Str::endsWith($key, '}')) {
+                $key = constant(WebDriverKeys::class.'::'.strtoupper(trim($key, '{}')));
+            }
+
+            if (is_array($key) && Str::startsWith($key[0], '{')) {
+                $key[0] = constant(WebDriverKeys::class.'::'.strtoupper(trim($key[0], '{}')));
+            }
+
+            return $key;
+        })->all();
+    }
+}

--- a/src/Concerns/InteractsWithKeyboard.php
+++ b/src/Concerns/InteractsWithKeyboard.php
@@ -9,16 +9,14 @@ use Laravel\Dusk\Keyboard;
 trait InteractsWithKeyboard
 {
     /**
-     * Uses browser's keyboard.
+     * Execute the given callback while interacting with the keyboard.
      *
      * @param  callable(\Laravel\Dusk\Keyboard):void  $callback
      * @return $this
      */
-    public function usesKeyboard(callable $callback)
+    public function withKeyboard(callable $callback)
     {
-        call_user_func($callback, new Keyboard($this));
-
-        return $this;
+        return tap($this, fn () => $callback(new Keyboard($this)));
     }
 
     /**

--- a/src/Concerns/InteractsWithKeyboard.php
+++ b/src/Concerns/InteractsWithKeyboard.php
@@ -14,7 +14,7 @@ trait InteractsWithKeyboard
      * @param  callable(\Laravel\Dusk\Keyboard):void  $callback
      * @return $this
      */
-    protected function usesKeyboard(callable $callback)
+    public function usesKeyboard(callable $callback)
     {
         call_user_func($callback, new Keyboard($this));
 

--- a/src/Concerns/InteractsWithKeyboard.php
+++ b/src/Concerns/InteractsWithKeyboard.php
@@ -15,9 +15,7 @@ trait InteractsWithKeyboard
      */
     protected function usesKeyboard(callable $callback)
     {
-        if (is_callable($callback)) {
-            call_user_func($callback, new Keyboard($this));
-        }
+        call_user_func($callback, new Keyboard($this));
 
         return $this;
     }

--- a/src/Concerns/InteractsWithMouse.php
+++ b/src/Concerns/InteractsWithMouse.php
@@ -5,9 +5,9 @@ namespace Laravel\Dusk\Concerns;
 use Facebook\WebDriver\Exception\ElementClickInterceptedException;
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\Interactions\WebDriverActions;
-use Facebook\WebDriver\Remote\RemoteKeyboard;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverKeys;
+use Laravel\Dusk\Keyboard;
 use Laravel\Dusk\OperatingSystem;
 
 trait InteractsWithMouse
@@ -164,15 +164,13 @@ trait InteractsWithMouse
      */
     public function controlClick($selector = null)
     {
-        $ctrlKey = OperatingSystem::onMac() ? WebDriverKeys::META : WebDriverKeys::CONTROL;
+        return $this->usesKeyboard(function (Keyboard $keyboard) use ($selector) {
+            $key = OperatingSystem::onMac() ? WebDriverKeys::META : WebDriverKeys::CONTROL;
 
-        tap($this->driver->getKeyboard(), function (RemoteKeyboard $keyboard) use ($selector, $ctrlKey) {
-            $keyboard->pressKey($ctrlKey);
+            $keyboard->press($key);
             $this->click($selector);
-            $keyboard->releaseKey($ctrlKey);
+            $keyboard->release($key);
         });
-
-        return $this;
     }
 
     /**

--- a/src/Concerns/InteractsWithMouse.php
+++ b/src/Concerns/InteractsWithMouse.php
@@ -164,7 +164,7 @@ trait InteractsWithMouse
      */
     public function controlClick($selector = null)
     {
-        return $this->usesKeyboard(function (Keyboard $keyboard) use ($selector) {
+        return $this->withKeyboard(function (Keyboard $keyboard) use ($selector) {
             $key = OperatingSystem::onMac() ? WebDriverKeys::META : WebDriverKeys::CONTROL;
 
             $keyboard->press($key);

--- a/src/Keyboard.php
+++ b/src/Keyboard.php
@@ -76,23 +76,6 @@ class Keyboard
      */
     public function __call($method, $parameters)
     {
-        $mouseInteractions = [
-            'mouseover',
-            'click',
-            'clickAtPoint',
-            'clickAtXPath',
-            'clickAndHold',
-            'doubleClick',
-            'rightClick',
-            'releaseMouse',
-        ];
-
-        if (in_array($method, $mouseInteractions)) {
-            $this->browser->{$method}(...$parameters);
-
-            return $this;
-        }
-
         if (static::hasMacro($method)) {
             return $this->macroCall($method, $parameters);
         }

--- a/src/Keyboard.php
+++ b/src/Keyboard.php
@@ -9,7 +9,7 @@ class Keyboard
 {
     use Macroable {
         __call as macroCall;
-    };
+    }
 
     /**
      * The browser instance.

--- a/src/Keyboard.php
+++ b/src/Keyboard.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Laravel\Dusk;
+
+use BadMethodCallException;
+use Illuminate\Support\Traits\Macroable;
+
+class Keyboard
+{
+    use Macroable {
+        __call as macroCall;
+    };
+
+    /**
+     * The browser instance.
+     *
+     * @var \Laravel\Dusk\Browser
+     */
+    public $browser;
+
+    /**
+     * Create a keyboard instance.
+     *
+     * @param  \Laravel\Dusk\Browser  $browser
+     * @return void
+     */
+    public function __construct(Browser $browser)
+    {
+        $this->browser = $browser;
+    }
+
+    /**
+     * Dynamically call a method on the keyboard.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
+        $keyboard = $browser->driver->getKeyboard();
+
+        if (method_exists($keyboard, $method)) {
+            $keyboard->{$method}(...$parameters);
+        }
+
+        throw new BadMethodCallException("Call to undefined method [{$method}].");
+    }
+}

--- a/src/Keyboard.php
+++ b/src/Keyboard.php
@@ -34,6 +34,8 @@ class Keyboard
 
     /**
      * Press the key using keyboard.
+     *
+     * @return $this
      */
     public function press($key)
     {
@@ -43,7 +45,9 @@ class Keyboard
     }
 
     /**
-     * Release the key using keyboard.
+     * Release the given pressed key.
+     *
+     * @return $this
      */
     public function release($key)
     {
@@ -53,7 +57,7 @@ class Keyboard
     }
 
     /**
-     * Type the keys using keyboard.
+     * Type the given keys using keyboard.
      *
      * @param  string|array<int, string>  $keys
      * @return $this
@@ -92,6 +96,6 @@ class Keyboard
             }
         }
 
-        throw new BadMethodCallException("Call to undefined method [{$method}].");
+        throw new BadMethodCallException("Call to undefined keyboard method [{$method}].");
     }
 }

--- a/src/Keyboard.php
+++ b/src/Keyboard.php
@@ -78,6 +78,23 @@ class Keyboard
      */
     public function __call($method, $parameters)
     {
+        $mouseInteractions = [
+            'mouseover',
+            'click',
+            'clickAtPoint',
+            'clickAtXPath',
+            'clickAndHold',
+            'doubleClick',
+            'rightClick',
+            'releaseMouse',
+        ];
+
+        if (in_array($method, $mouseInteractions)) {
+            $this->browser->{$method}(...$parameters);
+
+            return $this;
+        }
+
         if (static::hasMacro($method)) {
             return $this->macroCall($method, $parameters);
         }

--- a/src/Keyboard.php
+++ b/src/Keyboard.php
@@ -5,6 +5,9 @@ namespace Laravel\Dusk;
 use BadMethodCallException;
 use Illuminate\Support\Traits\Macroable;
 
+/**
+ * @mixin \Facebook\WebDriver\Remote\RemoteKeyboard
+ */
 class Keyboard
 {
     use Macroable {
@@ -30,6 +33,41 @@ class Keyboard
     }
 
     /**
+     * Press the key using keyboard.
+     *
+     */
+    public function press($key)
+    {
+        $this->pressKey($key);
+
+        return $this;
+    }
+
+    /**
+     * Release the key using keyboard.
+     *
+     */
+    public function release($key)
+    {
+        $this->releaseKey($key);
+
+        return $this;
+    }
+
+    /**
+     * Type the keys using keyboard.
+     *
+     * @param  string|array<int, string>  $keys
+     * @return $this
+     */
+    public function type($keys)
+    {
+        $this->sendKeys($keys);
+
+        return $this;
+    }
+
+    /**
      * Dynamically call a method on the keyboard.
      *
      * @param  string  $method
@@ -44,10 +82,16 @@ class Keyboard
             return $this->macroCall($method, $parameters);
         }
 
-        $keyboard = $browser->driver->getKeyboard();
+        $keyboard = $this->browser->driver->getKeyboard();
 
         if (method_exists($keyboard, $method)) {
-            $keyboard->{$method}(...$parameters);
+            $response = $keyboard->{$method}(...$parameters);
+
+            if ($response === $keyboard) {
+                return $this;
+            } else {
+                return $response;
+            }
         }
 
         throw new BadMethodCallException("Call to undefined method [{$method}].");

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -2,8 +2,11 @@
 
 namespace Laravel\Dusk\Tests;
 
+use Facebook\WebDriver\Remote\RemoteKeyboard;
 use Facebook\WebDriver\Remote\WebDriverBrowserType;
+use Facebook\WebDriver\WebDriverKeys;
 use Laravel\Dusk\Browser;
+use Laravel\Dusk\Keyboard;
 use Laravel\Dusk\Page;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -190,6 +193,22 @@ class BrowserTest extends TestCase
         $browser = new Browser($driver);
 
         $browser->storeConsoleLog('file');
+    }
+
+    public function test_uses_keyboard()
+    {
+        $driver = m::mock(stdClass::class);
+        $remoteKeyboard = m::mock(RemoteKeyboard::class);
+        $driver->shouldReceive('getKeyboard')->once()->andReturn($remoteKeyboard);
+        $remoteKeyboard->shouldReceive('pressKey')->once()->with(WebDriverKeys::CONTROL)->andReturnNull();
+        $browser = new Browser($driver);
+
+        $browser->usesKeyboard(function ($keyboard) use ($browser) {
+            $this->assertInstanceof(Keyboard::class, $keyboard);
+            $this->assertSame($browser, $keyboard->browser);
+
+            $keyboard->press(WebDriverKeys::CONTROL);
+        });
     }
 
     public function test_screenshot()

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -203,7 +203,7 @@ class BrowserTest extends TestCase
         $remoteKeyboard->shouldReceive('pressKey')->once()->with(WebDriverKeys::CONTROL)->andReturnNull();
         $browser = new Browser($driver);
 
-        $browser->usesKeyboard(function ($keyboard) use ($browser) {
+        $browser->withKeyboard(function ($keyboard) use ($browser) {
             $this->assertInstanceof(Keyboard::class, $keyboard);
             $this->assertSame($browser, $keyboard->browser);
 


### PR DESCRIPTION
### Before

```php
$key = PHP_OS_FAMILY === 'Darwin' ? \Facebook\WebDriver\WebDriverKeys::COMMAND : \Facebook\WebDriver\WebDriverKeys::CONTROL;

$this->browse(function (Browser $browser) use ($key) {
    $browser
        ->visit('/first')
        // ...
        ->tap(function (Browser $browser) use ($key) {
            $browser->driver->getKeyboard()->pressKey($key);
        })
        ->click('@link.to.second')
        ->tap(function (Browser $browser) use ($key) {
            $browser->driver->getKeyboard()->releaseKey($key);
        })
        // ...
    ;
});
```

### After

```php
$key = PHP_OS_FAMILY === 'Darwin' ? \Facebook\WebDriver\WebDriverKeys::COMMAND : \Facebook\WebDriver\WebDriverKeys::CONTROL;

$this->browse(function (Browser $browser) use ($key) {
    $browser
        ->visit('/first')
        // ...
        ->usesKeyboard(function (Keyboard $keyboard) use ($key) {
            $keyboard->press($key);
            $keyboard->browser->click('@link.to.second');
            $keyboard->release($key);
        }) 
        // or alternatively
        ->controlClick('@link.to.second')
        // ...
    ;
});
```