### PR TITLE
Add a see number of elements on page assertion helper

### DIFF
--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -884,6 +884,9 @@ class MakesAssertionsTest extends TestCase
      */
     public function test_assert_number_of_elements_dont_match($operator, $expected, $actual, $frequency)
     {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Expected element [body bar] {$frequency} {$expected} times.");
+
         $driver = m::mock(stdClass::class);
 
         $resolver = m::mock(stdClass::class);
@@ -892,14 +895,7 @@ class MakesAssertionsTest extends TestCase
 
         $browser = new Browser($driver, $resolver);
 
-        try {
-            $browser->assertNumberOfElements('bar', $operator, $expected);
-        } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString(
-                "Expected element [body bar] {$frequency} {$expected} times.",
-                $e->getMessage()
-            );
-        }
+        $browser->assertNumberOfElements('bar', $operator, $expected);
     }
 
     public static function assert_number_of_elements_dont_match_data_provider()

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -882,13 +882,13 @@ class MakesAssertionsTest extends TestCase
     /**
      * @dataProvider assert_number_of_elements_dont_match_data_provider
      */
-    public function test_assert_number_of_elements_dont_match($operator, $expected, $matches, $frequency)
+    public function test_assert_number_of_elements_dont_match($operator, $expected, $actual, $frequency)
     {
         $driver = m::mock(stdClass::class);
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('bar')->andReturn('body bar');
-        $resolver->shouldReceive('all')->with('bar')->andReturn(array_fill(0, $matches, m::mock(stdClass::class)));
+        $resolver->shouldReceive('all')->with('bar')->andReturn(array_fill(0, $actual, m::mock(stdClass::class)));
 
         $browser = new Browser($driver, $resolver);
 

--- a/tests/MakesAssertionsTest.php
+++ b/tests/MakesAssertionsTest.php
@@ -905,7 +905,7 @@ class MakesAssertionsTest extends TestCase
             'greater than operator'             => ['>', 2, 1, 'greater than'],
             'greater than or equal to operator' => ['>=', 2, 1, 'greater than or equal to'],
             'less than operator'                => ['<', 3, 4, 'less than'],
-            'less than or equal to operator'    => ['<=', 2, 3, 'less than or equal to'],
+            'less than or equal to operator'    => ['<=', 3, 4, 'less than or equal to'],
         ];
     }
 


### PR DESCRIPTION
This PR adds a new helper to assert the number of matching elements on the page:

```
$browser->assertNumberOfElements('foo', 1);
$browser->assertNumberOfElements('foo', '=', 1);
$browser->assertNumberOfElements('foo', '>', 1);
$browser->assertNumberOfElements('foo', '>=', 1);
$browser->assertNumberOfElements('foo', '<', 1);
$browser->assertNumberOfElements('foo', '<=', 1);
```

In my case I'm converting a Codeception testsuite over to Dusk, and was looking for an equivalent to its `seeNumberOfElements()` method so I can test an infinite scroll works. 

With this new method you'd be able to write a test like this:

```
$browser->loginAs(User::factory()->create())
    ->visitRoute('search')
    ->waitUntilEnabled('[type="submit"]')
    ->press('Search')
    ->assertNumberOfElements('table.results tbody tr', '=', 40)
    ->scrollIntoView('.results-bottom')
    ->pause(1000) // Wait for records to load...
    ->assertNumberOfElements('table.results tbody tr', '>' 40);
```