### PR TITLE
Fix favicon 404s triggered when using loginAs() or logout() methods

### DIFF
--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -33,7 +33,7 @@ class UserController
      *
      * @param  string  $userId
      * @param  string|null  $guard
-     * @return void
+     * @return \Illuminate\Http\Response
      */
     public function login($userId, $guard = null)
     {
@@ -54,7 +54,7 @@ class UserController
      * Log the user out of the application.
      *
      * @param  string|null  $guard
-     * @return void
+     * @return \Illuminate\Http\Response
      */
     public function logout($guard = null)
     {


### PR DESCRIPTION
Every Dusk test that uses `loginAs()` or `logout()` appears to record the following error in `tests/Browser/console`:

```
[
    {
        "level": "SEVERE",
        "message": "https:\/\/localhost\/favicon.ico - Failed to load resource: the server responded with a status of 404 ()",
        "source": "network",
        "timestamp": 1695715357814
    }
]
```

The referrer for the 404 is `https://localhost/_dusk/login/{id}`.

It happens because the controller than handles logging in and out returns void, which is presumably treated as an empty 200 response. This causes Chrome to make an additional request to `favicon.ico`. Instead these methods should return a 204 no content response, which informs Chrome it doesn't need to and stops these error logs.

This bug caused me a bit of confusion, as for a while I thought my app was missing a favicon somehow when it wasn't.