### PR TITLE
Fixes `waitForTextIn()` broken in v7.11.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.4.2",
-        "orchestra/testbench": "^7.0|^8.0",
+        "orchestra/testbench": "^7.33|^8.13",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^9.5.10|^10.0.1",
         "psy/psysh": "^0.11.12"

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -6,3 +6,6 @@ migrations:
 
 workbench:
   start: '/'
+  welcome: false
+  discovers:
+    web: true

--- a/tests/Browser/BrowserTest.php
+++ b/tests/Browser/BrowserTest.php
@@ -13,4 +13,15 @@ class BrowserTest extends DuskTestCase
                 ->assertSee('Documentation');
         });
     }
+
+    public function test_it_handle_wait_for_text_in()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/tests/wait-for-text-in')
+                ->assertSeeIn('@copy-button', 'Copy')
+                ->press('@copy-button')
+                ->assertSeeIn('@copy-button', 'Copied!')
+                ->waitForTextIn('@copy-button', 'Copy', 3);
+        });
+    }
 }

--- a/workbench/resources/views/wait-for-text-in.blade.php
+++ b/workbench/resources/views/wait-for-text-in.blade.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <script type="text/javascript">
+            function copy(e) {
+                e.innerHTML = 'Copied!'
+
+                setTimeout(() => {
+                    e.innerHTML = 'Copy'
+                }, 3000);
+            }
+        </script>
+    </head>
+    <body>
+        <button dusk="copy-button" onclick="copy(this)">Copy</button>
+    </body>
+</html>

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Web Routes
+|--------------------------------------------------------------------------
+|
+| Here is where you can register web routes for your application. These
+| routes are loaded by the RouteServiceProvider and all of them will
+| be assigned to the "web" middleware group. Make something great!
+|
+*/
+
+Route::view('/', 'welcome');
+Route::view('tests/wait-for-text-in', 'workbench::wait-for-text-in');


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
