### PR TITLE
Add `waitUntilPresent()`

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -47,6 +47,30 @@ trait WaitsForElements
     }
 
     /**
+     * Wait for the given selector to be present.
+     *
+     * @param  string  $selector
+     * @param  int|null  $seconds
+     * @return $this
+     *
+     * @throws \Facebook\WebDriver\Exception\TimeoutException
+     */
+    public function waitUntilPresent($selector, $seconds = null)
+    {
+        $message = $this->formatTimeOutMessage('Waited %s seconds for selector to be present', $selector);
+
+        return $this->waitUsing($seconds, 100, function () use ($selector) {
+            try {
+                $present = $this->resolver->findOrFail($selector)->isDisplayed();
+            } catch (NoSuchElementException $e) {
+                $present = false;
+            }
+
+            return $present;
+        }, $message);
+    }
+
+    /**
      * Wait for the given selector to be removed.
      *
      * @param  string  $selector

--- a/tests/Unit/WaitsForElementsTest.php
+++ b/tests/Unit/WaitsForElementsTest.php
@@ -229,6 +229,26 @@ class WaitsForElementsTest extends TestCase
         $browser->waitUntilMissingText('Discount: 20%');
     }
 
+    public function test_wait_until_present()
+    {
+        $element = m::mock(RemoteWebElement::class);
+        $element->shouldReceive('isDisplayed')
+            ->times(2)
+            ->andReturn(false, true);
+
+        $driver = m::mock(WebDriver::class);
+        $driver->shouldReceive('wait')->with(2, 100)->andReturnUsing(function ($seconds, $interval) use ($driver) {
+            return new WebDriverWait($driver, $seconds, $interval);
+        });
+
+        $resolver = m::mock(ElementResolver::class);
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->waitUntilPresent('foo');
+    }
+
     public function test_wait_until_missing()
     {
         $element = m::mock(RemoteWebElement::class);


### PR DESCRIPTION
The new `waitUntilPresent()` compliments the existing [`waitUntilMissing()`](https://laravel.com/docs/10.x/dusk#waiting-for-selectors).

(Test included ✅)