### PR TITLE
Limiting length of getCallerName return value to avoid issue when storing logs and screenshots

### DIFF
--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -232,7 +232,7 @@ trait ProvidesBrowser
             ? $this->name()
             : $this->getName(false); // @phpstan-ignore-line
 
-        return str_replace('\\', '_', get_class($this)).'_'.$name;
+        return str_replace('\\', '_', substr(get_class($this), 0, 70)).'_'.substr($name, 0, 70);
     }
 
     /**

--- a/tests/Unit/ProvidesBrowserTest.php
+++ b/tests/Unit/ProvidesBrowserTest.php
@@ -44,6 +44,17 @@ class ProvidesBrowserTest extends TestCase
         $this->storeConsoleLogsFor($browsers);
     }
 
+    public function test_truncate_test_name_where_that_name_is_too_long_and_might_cause_issues()
+    {
+        $browser = m::mock(stdClass::class);
+        $browser->shouldReceive('storeConsoleLog')->with(
+            'Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_truncate_test_name_where_that_name_is_too_long_and_might_cause_is-0'
+        );
+        $browsers = collect([$browser]);
+
+        $this->storeConsoleLogsFor($browsers);
+    }
+
     public static function testData()
     {
         return [


### PR DESCRIPTION
Hello,

I have some dusk tests that fails when there is console logs, because the filename is too long

```
ErrorException : file_put_contents(/var/www/html/tests/Browser/console/Tests_Browser_Pages_SomeFolder_MoreFolders_MyFolder_MyTestClass_testFunction-0.log): Failed to open stream: File name too long
```

it happens when the test class is in a deep subfolder, in my case i have 5 folders, and also the name of the test itself is pretty long, 

i propose to limit the number of characters of the return value of the ProvidesBrowser::getCallerName function

```php
/**
 * Get the browser caller name.
 *
 * @return string
 */
protected function getCallerName()
{
    $name = version_compare(Version::id(), '10', '>=')
        ? $this->name()
        : $this->getName(false); // @phpstan-ignore-line

    return str_replace('\\', '_', substr(get_class($this), 0, 70)).'_'.substr($name, 0, 70);
}
```
both the class name and the test name will be limited to 70 characters

i added a test, to verify that the test name is correctly truncated,

to test that the class name is correctly truncated would require the creation of another test class with a very long name, 

i don't know if it's something you want to do.




