### PR TITLE
Add attribute does not contain assertion

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -793,6 +793,34 @@ JS;
     }
 
     /**
+     * Assert that the element matching the given selector does not contain the given value in the provided attribute.
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertAttributeDoesNotContain($selector, $attribute, $value)
+    {
+        $fullSelector = $this->resolver->format($selector);
+
+        $actual = $this->resolver->findOrFail($selector)->getAttribute($attribute);
+
+        PHPUnit::assertNotNull(
+            $actual,
+            "Did not see expected attribute [{$attribute}] within element [{$fullSelector}]."
+        );
+
+        PHPUnit::assertStringNotContainsString(
+            $value,
+            $actual,
+            "Attribute '$attribute' contains [{$value}]. Full attribute value was [$actual]."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the element matching the given selector has the given value in the provided aria attribute.
      *
      * @param  string  $selector

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -800,7 +800,7 @@ JS;
      * @param  string  $value
      * @return $this
      */
-    public function assertAttributeDoesNotContain($selector, $attribute, $value)
+    public function assertAttributeDoesntContain($selector, $attribute, $value)
     {
         $fullSelector = $this->resolver->format($selector);
 
@@ -1113,6 +1113,19 @@ JS;
         PHPUnit::assertContains($value, $attribute);
 
         return $this;
+    }
+
+    /**
+     * Assert that a given Vue component data property is an array and does not contain the given value.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @param  string|null  $componentSelector
+     * @return $this
+     */
+    public function assertVueDoesntContain($key, $value, $componentSelector = null)
+    {
+        return $this->assertVueDoesNotContain($key, $value, $componentSelector);
     }
 
     /**

--- a/tests/Unit/MakesAssertionsTest.php
+++ b/tests/Unit/MakesAssertionsTest.php
@@ -652,10 +652,10 @@ class MakesAssertionsTest extends TestCase
 
         $browser = new Browser($driver, $resolver);
 
-        $browser->assertAttributeDoesNotContain('foo', 'bar', 'class-c');
+        $browser->assertAttributeDoesntContain('foo', 'bar', 'class-c');
 
         try {
-            $browser->assertAttributeDoesNotContain('foo', 'bar', 'class-c');
+            $browser->assertAttributeDoesntContain('foo', 'bar', 'class-c');
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString(
@@ -665,7 +665,7 @@ class MakesAssertionsTest extends TestCase
         }
 
         try {
-            $browser->assertAttributeDoesNotContain('foo', 'bar', 'class-1');
+            $browser->assertAttributeDoesntContain('foo', 'bar', 'class-1');
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString(

--- a/tests/Unit/MakesAssertionsTest.php
+++ b/tests/Unit/MakesAssertionsTest.php
@@ -635,6 +635,46 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_attribute_does_not_contain()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getAttribute')->with('bar')->andReturn(
+            'class-a class-b',
+            null,
+            'class-1 class-2'
+        );
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('Foo');
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertAttributeDoesNotContain('foo', 'bar', 'class-c');
+
+        try {
+            $browser->assertAttributeDoesNotContain('foo', 'bar', 'class-c');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Did not see expected attribute [bar] within element [Foo].',
+                $e->getMessage()
+            );
+        }
+
+        try {
+            $browser->assertAttributeDoesNotContain('foo', 'bar', 'class-1');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                "Attribute 'bar' contains [class-1]. Full attribute value was [class-1 class-2].",
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_data_attribute()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
I've found I sometimes need the opposite of `assertAttributeContains()` in tests.

For example, I've often got elements where Bootstrap classes are being toggled in JS:

```
<ul class="list-inline">
    <li class="list-inline-item main d-none">Foo</li>
    <li class="list-inline-item sub">Bar</li>
</ul>
```

Currently I have to assert all the classes on the second `<li>`, even though I'm only interested in `d-none`:

```
$browser->assertAttributeContains('li:nth-child(1)', 'class', 'd-none');
$browser->assertAttribute('li:nth-child(2)', 'class', 'list-inline-item sub');
```

After this PR its clearer what's being tested:
```
$browser->assertAttributeContains('li:nth-child(1)', 'class', 'd-none');
$browser->assertAttributeDoesNotContain('li:nth-child(2)', 'class', 'd-none');
```