### PR TITLE
Case insensitive assertions

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -145,7 +145,7 @@ trait MakesAssertions
      * Assert that the given text is present on the page.
      *
      * @param  string  $text
-     * @param  bool    $ignoreCase
+     * @param  bool  $ignoreCase
      * @return $this
      */
     public function assertSee($text, $ignoreCase = false)
@@ -169,7 +169,7 @@ trait MakesAssertions
      *
      * @param  string  $selector
      * @param  string  $text
-     * @param  bool    $ignoreCase
+     * @param  bool  $ignoreCase
      * @return $this
      */
     public function assertSeeIn($selector, $text, $ignoreCase = false)

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -145,11 +145,12 @@ trait MakesAssertions
      * Assert that the given text is present on the page.
      *
      * @param  string  $text
+     * @param  bool    $ignoreCase
      * @return $this
      */
-    public function assertSee($text)
+    public function assertSee($text, $ignoreCase = false)
     {
-        return $this->assertSeeIn('', $text);
+        return $this->assertSeeIn('', $text, $ignoreCase);
     }
 
     /**
@@ -168,16 +169,17 @@ trait MakesAssertions
      *
      * @param  string  $selector
      * @param  string  $text
+     * @param  bool    $ignoreCase
      * @return $this
      */
-    public function assertSeeIn($selector, $text)
+    public function assertSeeIn($selector, $text, $ignoreCase = false)
     {
         $fullSelector = $this->resolver->format($selector);
 
         $element = $this->resolver->findOrFail($selector);
 
         PHPUnit::assertTrue(
-            Str::contains($element->getText(), $text),
+            Str::contains($element->getText(), $text, $ignoreCase),
             "Did not see expected text [{$text}] within element [{$fullSelector}]."
         );
 

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -116,16 +116,17 @@ trait WaitsForElements
      * @param  string  $selector
      * @param  array|string  $text
      * @param  int|null  $seconds
+     * @param  bool  $ignoreCase
      * @return $this
      *
      * @throws \Facebook\WebDriver\Exception\TimeoutException
      */
-    public function waitForTextIn($selector, $text, $seconds = null)
+    public function waitForTextIn($selector, $text, $seconds = null, $ignoreCase = false)
     {
         $message = 'Waited %s seconds for text "'.$this->escapePercentCharacters($text).'" in selector '.$selector;
 
         return $this->waitUsing($seconds, 100, function () use ($selector, $text) {
-            return $this->assertSeeIn($selector, $text);
+            return $this->assertSeeIn($selector, $text, $ignoreCase);
         }, $message);
     }
 

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -106,7 +106,7 @@ trait WaitsForElements
 
         $message = $this->formatTimeOutMessage('Waited %s seconds for text', implode("', '", $text));
 
-        return $this->waitUsing($seconds, 100, function () use ($text) {
+        return $this->waitUsing($seconds, 100, function () use ($text, $ignoreCase) {
             return Str::contains($this->resolver->findOrFail('')->getText(), $text, $ignoreCase);
         }, $message);
     }
@@ -126,7 +126,7 @@ trait WaitsForElements
     {
         $message = 'Waited %s seconds for text "'.$this->escapePercentCharacters($text).'" in selector '.$selector;
 
-        return $this->waitUsing($seconds, 100, function () use ($selector, $text) {
+        return $this->waitUsing($seconds, 100, function () use ($selector, $text, $ignoreCase) {
             return $this->assertSeeIn($selector, $text, $ignoreCase);
         }, $message);
     }

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -95,18 +95,19 @@ trait WaitsForElements
      *
      * @param  array|string  $text
      * @param  int|null  $seconds
+     * @param  bool  $ignoreCase
      * @return $this
      *
      * @throws \Facebook\WebDriver\Exception\TimeoutException
      */
-    public function waitForText($text, $seconds = null)
+    public function waitForText($text, $seconds = null, $ignoreCase = false)
     {
         $text = Arr::wrap($text);
 
         $message = $this->formatTimeOutMessage('Waited %s seconds for text', implode("', '", $text));
 
         return $this->waitUsing($seconds, 100, function () use ($text) {
-            return Str::contains($this->resolver->findOrFail('')->getText(), $text);
+            return Str::contains($this->resolver->findOrFail('')->getText(), $text, $ignoreCase);
         }, $message);
     }
 


### PR DESCRIPTION
I'd like to add the ability for users to use the optional argument of `Str::contains()` through `->assertSeeIn()` and `->assertSee()` in order to make case-insensitive assertions.

## Why it matters
Currently, `->assertSeeIn()` only allows for case sensitive checks. Unfortunately this can cause a problem when comparing an element's innerText. On our site, we have this element:
```html
<span class="whitespace-nowrap uppercase" id="langHeader">en</span>
```

On Chrome, the innerText of this element is 'EN', but on Safari, it is 'en'. I'd like to only write one time here an assertion so that I can cover both cases instead of having conditional logic for the browser I'll be testing on:
```php
//Chrome, which passes
$browser->assertSeeIn('#langHeader', 'EN')

//Safari, which fails
$browser->assertSeeIn('#langHeader', 'EN')

//Proposed solution, passes on both
$browser->assertSeeIn('#langHeader', 'EN', true)
```

This won't break any current functionality since we can pass in a default argument which will keep the existing behavior as it is.
