### PR TITLE
[develop] Uses `Tests\CreatesApplication` only if exists

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -62,6 +62,20 @@ class InstallCommand extends Command
             }
         }
 
+        $baseTestCase = file_get_contents(base_path('tests/DuskTestCase.php'));
+
+        if (! trait_exists(\Tests\CreatesApplication::class)) {
+            file_put_contents(base_path('tests/DuskTestCase.php'), str_replace(<<<EOT
+                {
+                    use CreatesApplication;
+
+                EOT, <<<EOT
+                {
+                EOT,
+                $baseTestCase,
+            ));
+        }
+
         $this->info('Dusk scaffolding installed successfully.');
 
         $this->comment('Downloading ChromeDriver binaries...');

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -65,11 +65,11 @@ class InstallCommand extends Command
         $baseTestCase = file_get_contents(base_path('tests/DuskTestCase.php'));
 
         if (! trait_exists(\Tests\CreatesApplication::class)) {
-            file_put_contents(base_path('tests/DuskTestCase.php'), str_replace(<<<EOT
+            file_put_contents(base_path('tests/DuskTestCase.php'), str_replace(<<<'EOT'
                 {
                     use CreatesApplication;
 
-                EOT, <<<EOT
+                EOT, <<<'EOT'
                 {
                 EOT,
                 $baseTestCase,


### PR DESCRIPTION
This pull request updates `DuskTestCase.stub` to use the `Tests\CreatesApplication` trait only if it exists. This change follows the pull request found at: https://github.com/laravel/laravel/pull/6310.