### PR TITLE
Drop PHPUnit 9 and limits Laravel supported versions to 10 and 11

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -6,6 +6,7 @@ on:
       - master
       - develop
       - '*.x'
+      - 'feat/*'
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -17,24 +17,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.0', 8.1, 8.2, 8.3]
-        laravel: [9, 10, 11]
-        phpunit: [9, 10]
+        php: [8.1, 8.2, 8.3]
+        laravel: [10, 11]
+        phpunit: [10.5, '11.0']
         exclude:
-          - php: '8.0'
-            laravel: 11
           - php: 8.1
             laravel: 11
-          - php: '8.0'
-            laravel: 10
-          - php: '8.0'
-            phpunit: 10
-          - php: 8.3
-            laravel: 9
-          - laravel: 11
-            phpunit: 9
-          - laravel: 9
-            phpunit: 10
+          - laravel: 10
+            phpunit: '11.0'
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - PHPUnit ${{ matrix.phpunit }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
       - master
       - develop
       - '*.x'
+      - 'feat/*'
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,24 +17,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.0', 8.1, 8.2, 8.3]
-        laravel: [9, 10, 11]
-        phpunit: [9, 10]
+        php: [8.1, 8.2, 8.3]
+        laravel: [10, 11]
+        phpunit: [10.5, '11.0']
         exclude:
-          - php: '8.0'
-            laravel: 11
           - php: 8.1
             laravel: 11
-          - php: '8.0'
-            laravel: 10
-          - php: '8.0'
-            phpunit: 10
-          - php: 8.3
-            laravel: 9
-          - laravel: 11
-            phpunit: 9
-          - laravel: 9
-            phpunit: 10
+          - laravel: 10
+            phpunit: '11.0'
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - PHPUnit ${{ matrix.phpunit }}
 
@@ -71,7 +61,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2]
-        laravel: [9, 10]
+        laravel: [10]
 
     name: Test Stubs PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -14,24 +14,24 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "ext-zip": "*",
-        "guzzlehttp/guzzle": "^7.2",
-        "illuminate/console": "^9.0|^10.0|^11.0",
-        "illuminate/support": "^9.0|^10.0|^11.0",
-        "nesbot/carbon": "^2.0",
+        "guzzlehttp/guzzle": "^7.5",
+        "illuminate/console": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0",
+        "nesbot/carbon": "^2.67",
         "php-webdriver/webdriver": "^1.9.0",
-        "symfony/console": "^6.0|^7.0",
-        "symfony/finder": "^6.0|^7.0",
-        "symfony/process": "^6.0|^7.0",
+        "symfony/console": "^6.2|^7.0",
+        "symfony/finder": "^6.2|^7.0",
+        "symfony/process": "^6.2|^7.0",
         "vlucas/phpdotenv": "^5.2"
     },
     "require-dev": {
-        "mockery/mockery": "^1.4.2",
-        "orchestra/testbench": "^7.33|^8.13|^9.0",
+        "mockery/mockery": "^1.5.1",
+        "orchestra/testbench": "^8.19|^9.0",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.5.10|^10.4.0",
+        "phpunit/phpunit": "^10.1|^11.0",
         "psy/psysh": "^0.11.12|^0.12"
     },
     "suggest": {

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Illuminate\Support\Collection;
 use Laravel\Dusk\Browser;
+use PHPUnit\Framework\Attributes\AfterClass;
 use PHPUnit\Runner\Version;
 use ReflectionFunction;
 use Throwable;
@@ -29,10 +30,9 @@ trait ProvidesBrowser
     /**
      * Tear down the Dusk test case class.
      *
-     * @afterClass
-     *
      * @return void
      */
+    #[AfterClass]
     public static function tearDownDuskClass()
     {
         static::closeAll();

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -2,11 +2,12 @@
 
 namespace Tests;
 
-use Illuminate\Support\Collection;
 use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Illuminate\Support\Collection;
 use Laravel\Dusk\TestCase as BaseTestCase;
+use PHPUnit\Framework\Attributes\BeforeClass;
 
 abstract class DuskTestCase extends BaseTestCase
 {
@@ -14,9 +15,8 @@ abstract class DuskTestCase extends BaseTestCase
 
     /**
      * Prepare for Dusk test execution.
-     *
-     * @beforeClass
      */
+    #[BeforeClass]
     public static function prepare(): void
     {
         if (! static::runningInSail()) {

--- a/tests/Browser/DuskTestCase.php
+++ b/tests/Browser/DuskTestCase.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Laravel\Dusk\Browser;
 use Laravel\Dusk\TestCase;
 use Orchestra\Testbench\Concerns\CreatesApplication;
+use PHPUnit\Framework\Attributes\BeforeClass;
 
 class DuskTestCase extends TestCase
 {
@@ -40,9 +41,8 @@ class DuskTestCase extends TestCase
 
     /**
      * Prepare for Dusk test execution.
-     *
-     * @beforeClass
      */
+    #[BeforeClass]
     public static function prepare(): void
     {
         if (! static::runningInSail()) {

--- a/tests/Unit/OperatingSystemTest.php
+++ b/tests/Unit/OperatingSystemTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Dusk\Tests\Unit;
 
 use Laravel\Dusk\OperatingSystem;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class OperatingSystemTest extends TestCase
@@ -41,9 +42,7 @@ class OperatingSystemTest extends TestCase
         OperatingSystem::chromeVersionCommands('window_os');
     }
 
-    /**
-     * @dataProvider resolveChromeDriverSlugDataProvider
-     */
+    #[DataProvider('resolveChromeDriverSlugDataProvider')]
     public function test_it_can_resolve_chromedriver_slug($version, $os, $expected)
     {
         $this->assertSame($expected, OperatingSystem::chromeDriverSlug($os, $version));

--- a/tests/Unit/ProvidesBrowserTest.php
+++ b/tests/Unit/ProvidesBrowserTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Dusk\Tests\Unit;
 
 use Laravel\Dusk\Concerns\ProvidesBrowser;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -16,9 +17,7 @@ class ProvidesBrowserTest extends TestCase
         m::close();
     }
 
-    /**
-     * @dataProvider testData
-     */
+    #[DataProvider('testData')]
     public function test_capture_failures_for()
     {
         $browser = m::mock(stdClass::class);
@@ -30,9 +29,7 @@ class ProvidesBrowserTest extends TestCase
         $this->captureFailuresFor($browsers);
     }
 
-    /**
-     * @dataProvider testData
-     */
+    #[DataProvider('testData')]
     public function test_store_console_logs_for()
     {
         $browser = m::mock(stdClass::class);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
