### PR TITLE
Add `assertAttributeMissing()` method

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -767,6 +767,27 @@ JS;
     }
 
     /**
+     * Assert that the element matching the given selector is missing the provided attribute.
+     *
+     * @param  string  $selector
+     * @param  string  $attribute
+     * @return $this
+     */
+    public function assertAttributeMissing($selector, $attribute)
+    {
+        $fullSelector = $this->resolver->format($selector);
+
+        $actual = $this->resolver->findOrFail($selector)->getAttribute($attribute);
+
+        PHPUnit::assertNull(
+            $actual,
+            "Saw unexpected attribute [{$attribute}] within element [{$fullSelector}]."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the element matching the given selector contains the given value in the provided attribute.
      *
      * @param  string  $selector

--- a/tests/Unit/MakesAssertionsTest.php
+++ b/tests/Unit/MakesAssertionsTest.php
@@ -595,6 +595,35 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_attribute_missing()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element = m::mock(stdClass::class);
+        $element->shouldReceive('getAttribute')->with('bar')->andReturn(
+            null,
+            'joe',
+        );
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('Foo');
+        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertAttributeMissing('foo', 'bar');
+
+        try {
+            $browser->assertAttributeMissing('foo', 'bar');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Saw unexpected attribute [bar] within element [Foo].',
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_attribute_contains()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
It would be helpful to have an `assertAttributeMissing()` method for testing JS attribute toggling behaviour:

Currently you have to assert like this:

```
$this->assertNull($browser->element('div')->getAttribute('style'));
```

After this PR it's more succinct:

```
$this->assertAttributeMissing('div', 'style');
```