### PR TITLE
Add PHPUnit data provider set name to output filenames

### DIFF
--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -5,7 +5,6 @@ namespace Laravel\Dusk\Concerns;
 use Closure;
 use Exception;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use PHPUnit\Runner\Version;
 use ReflectionFunction;
@@ -236,7 +235,7 @@ trait ProvidesBrowser
         $parts = array_filter([
             str_replace('\\', '_', get_class($this)),
             $name,
-            Str::snake($this->dataName()),
+            str_replace(['\\', ' '], ['', '_'], $this->dataName()),
         ], fn ($part) => $part !== '');
 
         return substr(implode('_', $parts), -140);

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -233,12 +233,12 @@ trait ProvidesBrowser
             : $this->getName(false); // @phpstan-ignore-line
 
         $parts = array_filter([
-            str_replace('\\', '_', substr(get_class($this), 0, 70)),
-            substr($name, 0, 70),
-            substr($this->dataName(), 0, 70),
+            str_replace('\\', '_', get_class($this)),
+            $name,
+            Str::snake($this->dataName()),
         ], fn ($part) => $part !== '');
 
-        return implode('_', $parts);
+        return substr(implode('_', $parts), -140);
     }
 
     /**

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -228,11 +228,21 @@ trait ProvidesBrowser
      */
     protected function getCallerName()
     {
-        $name = version_compare(Version::id(), '10', '>=')
-            ? $this->name()
-            : $this->getName(false); // @phpstan-ignore-line
+        if (version_compare(Version::id(), '10', '>=')) {
+            $name = $this->name();
+            $data = $this->dataName();
+        } else {
+            $name = $this->getName(false); // @phpstan-ignore-line
+            $data = $this->getDataSetAsString(false); // @phpstan-ignore-line
+        }
 
-        return str_replace('\\', '_', substr(get_class($this), 0, 70)).'_'.substr($name, 0, 70);
+        $parts = array_filter([
+            str_replace('\\', '_', substr(get_class($this), 0, 70)),
+            substr($name, 0, 70),
+            substr($data, 0, 70),
+        ], fn ($part) => $part !== '');
+
+        return implode('_', $parts);
     }
 
     /**

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -5,6 +5,7 @@ namespace Laravel\Dusk\Concerns;
 use Closure;
 use Exception;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use PHPUnit\Runner\Version;
 use ReflectionFunction;

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -228,18 +228,14 @@ trait ProvidesBrowser
      */
     protected function getCallerName()
     {
-        if (version_compare(Version::id(), '10', '>=')) {
-            $name = $this->name();
-            $data = $this->dataName();
-        } else {
-            $name = $this->getName(false); // @phpstan-ignore-line
-            $data = $this->getDataSetAsString(false); // @phpstan-ignore-line
-        }
+        $name = version_compare(Version::id(), '10', '>=')
+            ? $this->name()
+            : $this->getName(false); // @phpstan-ignore-line
 
         $parts = array_filter([
             str_replace('\\', '_', substr(get_class($this), 0, 70)),
             substr($name, 0, 70),
-            substr($data, 0, 70),
+            substr($this->dataName(), 0, 70),
         ], fn ($part) => $part !== '');
 
         return implode('_', $parts);

--- a/tests/Unit/ProvidesBrowserTest.php
+++ b/tests/Unit/ProvidesBrowserTest.php
@@ -23,7 +23,7 @@ class ProvidesBrowserTest extends TestCase
     {
         $browser = m::mock(stdClass::class);
         $browser->shouldReceive('screenshot')->with(
-            'failure-Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_capture_failures_for-0'
+            'failure-Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_capture_failures_for_foo-0'
         );
         $browsers = collect([$browser]);
 
@@ -37,7 +37,7 @@ class ProvidesBrowserTest extends TestCase
     {
         $browser = m::mock(stdClass::class);
         $browser->shouldReceive('storeConsoleLog')->with(
-            'Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_store_console_logs_for-0'
+            'Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_store_console_logs_for_foo-0'
         );
         $browsers = collect([$browser]);
 
@@ -58,7 +58,7 @@ class ProvidesBrowserTest extends TestCase
     public static function testData()
     {
         return [
-            ['foo'],
+            'foo' => ['foo'],
         ];
     }
 

--- a/tests/Unit/ProvidesBrowserTest.php
+++ b/tests/Unit/ProvidesBrowserTest.php
@@ -28,7 +28,7 @@ class ProvidesBrowserTest extends TestCase
     }
 
     /**
-     * @dataProvider testData
+     * @dataProvider data
      */
     public function test_capture_failures_for_data()
     {
@@ -42,7 +42,7 @@ class ProvidesBrowserTest extends TestCase
     }
 
     /**
-     * @dataProvider testData
+     * @dataProvider data
      */
     public function test_store_console_logs_for_data()
     {
@@ -56,7 +56,7 @@ class ProvidesBrowserTest extends TestCase
     }
 
     /**
-     * @dataProvider testData
+     * @dataProvider data
      */
     public function test_truncate_test_name_where_that_name_is_really_really_really_too_long_and_might_cause_issues_data()
     {
@@ -69,7 +69,7 @@ class ProvidesBrowserTest extends TestCase
         $this->storeConsoleLogsFor($browsers);
     }
 
-    public static function testData()
+    public static function data()
     {
         return [
             'foo' => ['foo'],

--- a/tests/Unit/ProvidesBrowserTest.php
+++ b/tests/Unit/ProvidesBrowserTest.php
@@ -16,14 +16,11 @@ class ProvidesBrowserTest extends TestCase
         m::close();
     }
 
-    /**
-     * @dataProvider testData
-     */
     public function test_capture_failures_for()
     {
         $browser = m::mock(stdClass::class);
         $browser->shouldReceive('screenshot')->with(
-            'failure-Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_capture_failures_for_foo_data-0'
+            'failure-Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_capture_failures_for-0'
         );
         $browsers = collect([$browser]);
 
@@ -33,11 +30,25 @@ class ProvidesBrowserTest extends TestCase
     /**
      * @dataProvider testData
      */
-    public function test_store_console_logs_for()
+    public function test_capture_failures_for_data()
+    {
+        $browser = m::mock(stdClass::class);
+        $browser->shouldReceive('screenshot')->with(
+            'failure-Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_capture_failures_for_data_foo-0'
+        );
+        $browsers = collect([$browser]);
+
+        $this->captureFailuresFor($browsers);
+    }
+
+    /**
+     * @dataProvider testData
+     */
+    public function test_store_console_logs_for_data()
     {
         $browser = m::mock(stdClass::class);
         $browser->shouldReceive('storeConsoleLog')->with(
-            'Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_store_console_logs_for_foo_data-0'
+            'Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_store_console_logs_for_data_foo-0'
         );
         $browsers = collect([$browser]);
 
@@ -47,11 +58,11 @@ class ProvidesBrowserTest extends TestCase
     /**
      * @dataProvider testData
      */
-    public function test_truncate_test_name_where_that_name_is_really_really_really_too_long_and_might_cause_issues()
+    public function test_truncate_test_name_where_that_name_is_really_really_really_too_long_and_might_cause_issues_data()
     {
         $browser = m::mock(stdClass::class);
         $browser->shouldReceive('storeConsoleLog')->with(
-            'Dusk_Tests_Unit_ProvidesBrowserTest_test_truncate_test_name_where_that_name_is_really_really_really_too_long_and_might_cause_issues_foo_data-0'
+            'Dusk_Tests_Unit_ProvidesBrowserTest_test_truncate_test_name_where_that_name_is_really_really_really_too_long_and_might_cause_issues_data_foo-0'
         );
         $browsers = collect([$browser]);
 
@@ -61,7 +72,7 @@ class ProvidesBrowserTest extends TestCase
     public static function testData()
     {
         return [
-            'foo data' => ['foo'],
+            'foo' => ['foo'],
         ];
     }
 

--- a/tests/Unit/ProvidesBrowserTest.php
+++ b/tests/Unit/ProvidesBrowserTest.php
@@ -23,7 +23,7 @@ class ProvidesBrowserTest extends TestCase
     {
         $browser = m::mock(stdClass::class);
         $browser->shouldReceive('screenshot')->with(
-            'failure-Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_capture_failures_for_foo-0'
+            'failure-Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_capture_failures_for_foo_data-0'
         );
         $browsers = collect([$browser]);
 
@@ -37,18 +37,21 @@ class ProvidesBrowserTest extends TestCase
     {
         $browser = m::mock(stdClass::class);
         $browser->shouldReceive('storeConsoleLog')->with(
-            'Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_store_console_logs_for_foo-0'
+            'Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_store_console_logs_for_foo_data-0'
         );
         $browsers = collect([$browser]);
 
         $this->storeConsoleLogsFor($browsers);
     }
 
-    public function test_truncate_test_name_where_that_name_is_too_long_and_might_cause_issues()
+    /**
+     * @dataProvider testData
+     */
+    public function test_truncate_test_name_where_that_name_is_really_really_really_too_long_and_might_cause_issues()
     {
         $browser = m::mock(stdClass::class);
         $browser->shouldReceive('storeConsoleLog')->with(
-            'Laravel_Dusk_Tests_Unit_ProvidesBrowserTest_test_truncate_test_name_where_that_name_is_too_long_and_might_cause_is-0'
+            'Dusk_Tests_Unit_ProvidesBrowserTest_test_truncate_test_name_where_that_name_is_really_really_really_too_long_and_might_cause_issues_foo_data-0'
         );
         $browsers = collect([$browser]);
 
@@ -58,7 +61,7 @@ class ProvidesBrowserTest extends TestCase
     public static function testData()
     {
         return [
-            'foo' => ['foo'],
+            'foo data' => ['foo'],
         ];
     }
 


### PR DESCRIPTION
If there's a failure in a Dusk test case that uses PHPUnit data providers, then only a screenshot of the last data set that failed will be available in the `screenshots` directory. This is because without the data set in the filename, each new screenshot overwrites the previous one.

This PR adds the data set, where applicable, to the filenames of screenshots and console output:

With no data provider:
```
failure-Tests_Browser_FooTest_test_without_data-0.png
```

With unnamed data set (`0`, `1`): 
```
failure-Tests_Browser_FooTest_test_with_data_0-0.png
failure-Tests_Browser_FooTest_test_with_data_1-0.png
```

With named data set (`foo`, `bar`):
```
failure-Tests_Browser_FooTest_test_with_named_data_foo-0.png
failure-Tests_Browser_FooTest_test_with_named_data_bar-0.png
```

I've retained the existing [140 character filename limit](https://github.com/laravel/dusk/pull/1070) by trimming it off the left hand side of the filename, so namespaces are truncated.