### PR TITLE
Fixes console logs trying to create file containing `DIRECTORY_SEPARATOR` value from data provider name.

### DIFF
--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -235,7 +235,7 @@ trait ProvidesBrowser
         $parts = array_filter([
             str_replace('\\', '_', get_class($this)),
             $name,
-            str_replace(['\\', ' '], ['', '_'], $this->dataName()),
+            str_replace(['\\', DIRECTORY_SEPARATOR, ' '], ['', '', '_'], $this->dataName()),
         ], fn ($part) => $part !== '');
 
         return substr(implode('_', $parts), -140);


### PR DESCRIPTION
![CleanShot 2024-02-15 at 13 00 16](https://github.com/laravel/dusk/assets/172966/d11282de-291c-4f6f-90d7-b9990d039020)
