### PR TITLE
Add `component()` method to get scoped Browser instance

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -586,6 +586,12 @@ class Browser
         });
     }
 
+    /**
+     * Return a browser scoped to the given component.
+     *
+     * @param  \Laravel\Dusk\Component  $component
+     * @return \Illuminate\Support\HigherOrderTapProxy
+     */
     public function component(Component $component): HigherOrderTapProxy
     {
         $browser = new static($this->driver, $this->resolver);

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -594,6 +594,11 @@ class Browser
     public function component(Component $component)
     {
         $browser = new static($this->driver, $this->resolver);
+
+        if ($this->page) {
+            $browser->onWithoutAssert($this->page);
+        }
+
         $browser->onComponent($component, $this->resolver);
 
         return $browser;

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -593,7 +593,9 @@ class Browser
      */
     public function component(Component $component)
     {
-        $browser = new static($this->driver, $this->resolver);
+        $browser = new static(
+            $this->driver, new ElementResolver($this->driver, $this->resolver->format($component))
+        );
 
         if ($this->page) {
             $browser->onWithoutAssert($this->page);

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -8,6 +8,7 @@ use Facebook\WebDriver\Remote\WebDriverBrowserType;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverDimension;
 use Facebook\WebDriver\WebDriverPoint;
+use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 
@@ -583,6 +584,14 @@ class Browser
         return $this->elsewhere('', function ($browser) use ($selector, $callback, $seconds) {
             $browser->whenAvailable($selector, $callback, $seconds);
         });
+    }
+
+    public function component(Component $component): HigherOrderTapProxy
+    {
+        $browser = new static($this->driver, $this->resolver);
+        $browser->onComponent($component, $this->resolver);
+
+        return new HigherOrderTapProxy($component);
     }
 
     /**

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -8,7 +8,6 @@ use Facebook\WebDriver\Remote\WebDriverBrowserType;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverDimension;
 use Facebook\WebDriver\WebDriverPoint;
-use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 
@@ -590,14 +589,14 @@ class Browser
      * Return a browser scoped to the given component.
      *
      * @param  \Laravel\Dusk\Component  $component
-     * @return \Illuminate\Support\HigherOrderTapProxy
+     * @return \Laravel\Dusk\Browser
      */
-    public function component(Component $component): HigherOrderTapProxy
+    public function component(Component $component)
     {
         $browser = new static($this->driver, $this->resolver);
         $browser->onComponent($component, $this->resolver);
 
-        return new HigherOrderTapProxy($browser);
+        return $browser;
     }
 
     /**

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -591,7 +591,7 @@ class Browser
         $browser = new static($this->driver, $this->resolver);
         $browser->onComponent($component, $this->resolver);
 
-        return new HigherOrderTapProxy($component);
+        return new HigherOrderTapProxy($browser);
     }
 
     /**

--- a/tests/Unit/ComponentTest.php
+++ b/tests/Unit/ComponentTest.php
@@ -30,7 +30,7 @@ class ComponentTest extends TestCase
         });
     }
 
-    public function test_resolver_prefix()
+    public function test_within_method_resolver_prefix()
     {
         $driver = m::mock(stdClass::class);
         $browser = new Browser($driver);
@@ -48,7 +48,7 @@ class ComponentTest extends TestCase
         });
     }
 
-    public function test_component_macros()
+    public function test_within_method_component_macros()
     {
         $driver = m::mock(stdClass::class);
         $browser = new Browser($driver);
@@ -64,7 +64,7 @@ class ComponentTest extends TestCase
         });
     }
 
-    public function test_component_elements()
+    public function test_within_method_component_elements()
     {
         $driver = m::mock(stdClass::class);
         $browser = new Browser($driver);
@@ -85,7 +85,7 @@ class ComponentTest extends TestCase
         });
     }
 
-    public function test_root_selector_can_be_dusk_hook()
+    public function test_within_method_root_selector_can_be_dusk_hook()
     {
         $driver = m::mock(stdClass::class);
         $browser = new Browser($driver);
@@ -98,7 +98,7 @@ class ComponentTest extends TestCase
         });
     }
 
-    public function test_root_selector_can_be_element_alias()
+    public function test_within_method_root_selector_can_be_element_alias()
     {
         $driver = m::mock(stdClass::class);
         $browser = new Browser($driver);
@@ -111,7 +111,7 @@ class ComponentTest extends TestCase
         });
     }
 
-    public function test_component_overrides_page_macros()
+    public function test_within_method_component_overrides_page_macros()
     {
         $driver = m::mock(stdClass::class);
         $browser = new Browser($driver);
@@ -128,6 +128,107 @@ class ComponentTest extends TestCase
 
             $this->assertTrue($browser->page->macroed);
         });
+    }
+
+    public function test_component_method_triggers_assertion()
+    {
+        $driver  = m::mock(stdClass::class);
+        $browser = new Browser($driver);
+
+        $scoped = $browser->component(new TestComponent);
+        $this->assertTrue($scoped->component->asserted);
+
+        $nested = $scoped->component(new TestNestedComponent);
+        $this->assertTrue($nested->component->asserted);
+    }
+
+    public function test_component_method_resolver_prefix()
+    {
+        $driver  = m::mock(stdClass::class);
+        $browser = new Browser($driver);
+
+        $scoped = $browser->component(new TestComponent);
+        $this->assertSame('body #component-root', $scoped->resolver->prefix);
+
+        $nested = $scoped->component(new TestNestedComponent);
+        $this->assertSame('body #component-root #nested-root', $nested->resolver->prefix);
+
+        $nested->with('prefix', function (Browser $browser) {
+            $this->assertSame('body #component-root #nested-root prefix', $browser->resolver->prefix);
+        });
+    }
+
+    public function test_component_method_component_macros()
+    {
+        $driver  = m::mock(stdClass::class);
+        $browser = new Browser($driver);
+
+        $scoped = $browser->component(new TestComponent);
+        $scoped->doSomething();
+        $this->assertTrue($scoped->component->macroed);
+
+        $nested = $scoped->component(new TestNestedComponent);
+        $nested->doSomething();
+        $this->assertTrue($nested->component->macroed);
+    }
+
+    public function test_component_method_component_elements()
+    {
+        $driver = m::mock(stdClass::class);
+        $browser = new Browser($driver);
+
+        $scoped = $browser->component(new TestComponent);
+        $this->assertEquals([
+            '@component-alias' => '#component-alias',
+            '@overridden-alias' => '#not-overridden',
+        ], $scoped->resolver->elements);
+
+        $nested = $scoped->component(new TestNestedComponent);
+        $this->assertEquals([
+            '@nested-alias' => '#nested-alias',
+            '@overridden-alias' => '#overridden',
+            '@component-alias' => '#component-alias',
+        ], $nested->resolver->elements);
+    }
+
+    public function test_component_method_root_selector_can_be_dusk_hook()
+    {
+        $driver = m::mock(stdClass::class);
+        $browser = new Browser($driver);
+
+        $component = new TestComponent;
+        $component->selector = '@dusk-hook-root';
+
+        $scoped = $browser->component($component);
+        $this->assertSame('body [dusk="dusk-hook-root"]', $scoped->resolver->prefix);
+    }
+
+    public function test_component_method_root_selector_can_be_element_alias()
+    {
+        $driver = m::mock(stdClass::class);
+        $browser = new Browser($driver);
+
+        $component = new TestComponent;
+        $component->selector = '@component-alias';
+
+        $scoped = $browser->component($component);
+        $this->assertSame('body #component-alias', $scoped->resolver->prefix);
+    }
+
+    public function test_component_method_overrides_page_macros()
+    {
+        $driver = m::mock(stdClass::class);
+        $browser = new Browser($driver);
+
+        $browser->on($page = new TestPage);
+
+        $scoped = $browser->component(new TestComponent);
+        $scoped->doSomething();
+        $this->assertFalse($scoped->page->macroed);
+        $this->assertTrue($scoped->component->macroed);
+
+        $scoped->doPageSpecificThing();
+        $this->assertTrue($scoped->page->macroed);
     }
 }
 


### PR DESCRIPTION
This PR adds a new `component()` method that returns a browser instance scoped to a component. It works identically to `with()`, only it doesn't require a closure, which can be more convenient:

```
// Before
$browser->with(new DatePickerComponent, function ($browser) {
    $browser->typeDate('2021-02-03 04:05:06');
});

$browser->with(new PrimaryCategoryPickerComponent, function ($browser) {
    $browser->typeReference('FOO-123');
    $browser->assertPickersSelected('FOO-123');
});

$browser->with(new SecondaryCategoryPickerComponent, function ($browser) {
    $browser->typeReference('FOO-456');
    $browser->assertPickersSelected('FOO-456');
});

// After
$datePicker = $browser->component(new DatePickerComponent);
$datePicker->typeDate('2021-02-03 04:05:06');

$primaryPicker = $browser->component(new PrimaryCategoryPickerComponent);
$primaryPicker->typeReference('FOO-123');
$primaryPicker->assertPickersSelected('FOO-123');

$secondaryPicker = $browser->component(new SecondaryCategoryPickerComponent);
$secondaryPicker->typeReference('FOO-456');
$secondaryPicker->assertPickersSelected('FOO-456');
```