### PR TITLE
New Helper `elementScreenshot`

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -449,6 +449,30 @@ class Browser
     }
 
     /**
+     * Take a screenshot of a specific element and store it with the given name.
+     *
+     * @param  string  $selector
+     * @param  string  $name
+     * @return $this
+     */
+    public function elementScreenshot($selector, $name)
+    {
+        $filePath = sprintf('%s/%s.png', rtrim(static::$storeScreenshotsAt, '/'), $name);
+
+        $directoryPath = dirname($filePath);
+
+        if (! is_dir($directoryPath)) {
+            mkdir($directoryPath, 0777, true);
+        }
+
+        $this->scrollIntoView($selector)
+            ->driver->findElement(WebDriverBy::cssSelector($selector))
+            ->takeElementScreenshot($filePath);
+
+        return $this;
+    }
+
+    /**
      * Store the console output with the given name.
      *
      * @param  string  $name

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -455,7 +455,7 @@ class Browser
      * @param  string  $name
      * @return $this
      */
-    public function elementScreenshot($selector, $name)
+    public function screenshotElement($selector, $name)
     {
         $filePath = sprintf('%s/%s.png', rtrim(static::$storeScreenshotsAt, '/'), $name);
 

--- a/tests/Unit/BrowserTest.php
+++ b/tests/Unit/BrowserTest.php
@@ -263,7 +263,7 @@ class BrowserTest extends TestCase
 
         $browser::$storeScreenshotsAt = sys_get_temp_dir();
 
-        $browser->elementScreenshot(
+        $browser->screenshotElement(
             '#selector',
             $name = 'screenshot-01',
         );
@@ -290,7 +290,7 @@ class BrowserTest extends TestCase
 
         $browser::$storeScreenshotsAt = sys_get_temp_dir();
 
-        $browser->elementScreenshot(
+        $browser->screenshotElement(
             '#selector',
             $name = uniqid('random').'/sub/dir/screenshot-01',
         );

--- a/tests/Unit/BrowserTest.php
+++ b/tests/Unit/BrowserTest.php
@@ -3,7 +3,10 @@
 namespace Laravel\Dusk\Tests\Unit;
 
 use Facebook\WebDriver\Remote\RemoteKeyboard;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Facebook\WebDriver\Remote\RemoteWebElement;
 use Facebook\WebDriver\Remote\WebDriverBrowserType;
+use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverKeys;
 use Laravel\Dusk\Browser;
 use Laravel\Dusk\Keyboard;
@@ -236,6 +239,60 @@ class BrowserTest extends TestCase
 
         $this->browser->screenshot(
             $name = uniqid('random').'/sub/dir/screenshot-01'
+        );
+
+        $this->assertFileExists(Browser::$storeScreenshotsAt.'/'.$name.'.png');
+    }
+
+    public function test_element_screenshot()
+    {
+        $elementMock = $this->createMock(RemoteWebElement::class);
+        $elementMock->expects($this->once())
+            ->method('takeElementScreenshot')
+            ->willReturnCallback(function ($filePath) {
+                return touch($filePath);
+            });
+
+        $driverMock = $this->createMock(RemoteWebDriver::class);
+        $driverMock->expects($this->once())
+            ->method('findElement')
+            ->with(WebDriverBy::cssSelector('#selector'))
+            ->willReturn($elementMock);
+
+        $browser = new Browser($driverMock);
+
+        $browser::$storeScreenshotsAt = sys_get_temp_dir();
+
+        $browser->elementScreenshot(
+            '#selector',
+            $name = 'screenshot-01',
+        );
+
+        $this->assertFileExists(Browser::$storeScreenshotsAt.'/'.$name.'.png');
+    }
+
+    public function test_element_screenshot_in_subdirectory()
+    {
+        $elementMock = $this->createMock(RemoteWebElement::class);
+        $elementMock->expects($this->once())
+            ->method('takeElementScreenshot')
+            ->willReturnCallback(function ($filePath) {
+                return touch($filePath);
+            });
+
+        $driverMock = $this->createMock(RemoteWebDriver::class);
+        $driverMock->expects($this->once())
+            ->method('findElement')
+            ->with(WebDriverBy::cssSelector('#selector'))
+            ->willReturn($elementMock);
+
+        $browser = new Browser($driverMock);
+
+        $browser::$storeScreenshotsAt = sys_get_temp_dir();
+
+        $browser->elementScreenshot(
+            '#selector',
+            $name = uniqid('random').'/sub/dir/screenshot-01',
         );
 
         $this->assertFileExists(Browser::$storeScreenshotsAt.'/'.$name.'.png');


### PR DESCRIPTION
Expanding on the existing helpers for `screenshot` and `responsiveScreenshots` this new helper is for taking a screenshot of a specific element, by passing in the `$selector` for the element and then using the `takeElementScreenshot()` method of the `RemoteWebElement::class`.

As the element needs to be 'in view' before the screenshot can be taken, the helper first calls `scrollIntoView` before taking the screenshot.

Of course, the same could be achieved by adding a `Browser::macro` in the service provider, but this pull request would put it alongside the existing methods and include in the package.

Tests have been included that follow a similar pattern as those for the `screenshot` method.