### PR TITLE
Support Dusk Selectors in `screenshotElement`

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -449,6 +449,30 @@ class Browser
     }
 
     /**
+     * Take a screenshot of a specific element and store it with the given name.
+     *
+     * @param  string  $selector
+     * @param  string  $name
+     * @return $this
+     */
+    public function elementScreenshot($selector, $name)
+    {
+        $filePath = sprintf('%s/%s.png', rtrim(static::$storeScreenshotsAt, '/'), $name);
+
+        $directoryPath = dirname($filePath);
+
+        if (! is_dir($directoryPath)) {
+            mkdir($directoryPath, 0777, true);
+        }
+
+        $this->scrollIntoView($selector)
+            ->driver->findElement(WebDriverBy::cssSelector($selector))
+            ->takeElementScreenshot($filePath);
+
+        return $this;
+    }
+
+    /**
      * Store the console output with the given name.
      *
      * @param  string  $name

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -455,7 +455,7 @@ class Browser
      * @param  string  $name
      * @return $this
      */
-    public function elementScreenshot($selector, $name)
+    public function screenshotElement($selector, $name)
     {
         $filePath = sprintf('%s/%s.png', rtrim(static::$storeScreenshotsAt, '/'), $name);
 

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -466,7 +466,7 @@ class Browser
         }
 
         $this->scrollIntoView($selector)
-            ->driver->findElement(WebDriverBy::cssSelector($selector))
+            ->driver->findElement(WebDriverBy::cssSelector($this->resolver->format($selector)))
             ->takeElementScreenshot($filePath);
 
         return $this;

--- a/tests/Unit/BrowserTest.php
+++ b/tests/Unit/BrowserTest.php
@@ -244,7 +244,7 @@ class BrowserTest extends TestCase
         $this->assertFileExists(Browser::$storeScreenshotsAt.'/'.$name.'.png');
     }
 
-    public function test_element_screenshot()
+    public function test_screenshot_element()
     {
         $elementMock = $this->createMock(RemoteWebElement::class);
         $elementMock->expects($this->once())
@@ -256,7 +256,7 @@ class BrowserTest extends TestCase
         $driverMock = $this->createMock(RemoteWebDriver::class);
         $driverMock->expects($this->once())
             ->method('findElement')
-            ->with(WebDriverBy::cssSelector('#selector'))
+            ->with(WebDriverBy::cssSelector('body #selector'))
             ->willReturn($elementMock);
 
         $browser = new Browser($driverMock);
@@ -271,7 +271,7 @@ class BrowserTest extends TestCase
         $this->assertFileExists(Browser::$storeScreenshotsAt.'/'.$name.'.png');
     }
 
-    public function test_element_screenshot_in_subdirectory()
+    public function test_screenshot_element_in_subdirectory()
     {
         $elementMock = $this->createMock(RemoteWebElement::class);
         $elementMock->expects($this->once())
@@ -283,7 +283,7 @@ class BrowserTest extends TestCase
         $driverMock = $this->createMock(RemoteWebDriver::class);
         $driverMock->expects($this->once())
             ->method('findElement')
-            ->with(WebDriverBy::cssSelector('#selector'))
+            ->with(WebDriverBy::cssSelector('body #selector'))
             ->willReturn($elementMock);
 
         $browser = new Browser($driverMock);

--- a/tests/Unit/BrowserTest.php
+++ b/tests/Unit/BrowserTest.php
@@ -263,7 +263,7 @@ class BrowserTest extends TestCase
 
         $browser::$storeScreenshotsAt = sys_get_temp_dir();
 
-        $browser->elementScreenshot(
+        $browser->screenshotElement(
             '#selector',
             $name = 'screenshot-01',
         );
@@ -290,7 +290,7 @@ class BrowserTest extends TestCase
 
         $browser::$storeScreenshotsAt = sys_get_temp_dir();
 
-        $browser->elementScreenshot(
+        $browser->screenshotElement(
             '#selector',
             $name = uniqid('random').'/sub/dir/screenshot-01',
         );

--- a/tests/Unit/BrowserTest.php
+++ b/tests/Unit/BrowserTest.php
@@ -3,7 +3,10 @@
 namespace Laravel\Dusk\Tests\Unit;
 
 use Facebook\WebDriver\Remote\RemoteKeyboard;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Facebook\WebDriver\Remote\RemoteWebElement;
 use Facebook\WebDriver\Remote\WebDriverBrowserType;
+use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverKeys;
 use Laravel\Dusk\Browser;
 use Laravel\Dusk\Keyboard;
@@ -236,6 +239,60 @@ class BrowserTest extends TestCase
 
         $this->browser->screenshot(
             $name = uniqid('random').'/sub/dir/screenshot-01'
+        );
+
+        $this->assertFileExists(Browser::$storeScreenshotsAt.'/'.$name.'.png');
+    }
+
+    public function test_element_screenshot()
+    {
+        $elementMock = $this->createMock(RemoteWebElement::class);
+        $elementMock->expects($this->once())
+            ->method('takeElementScreenshot')
+            ->willReturnCallback(function ($filePath) {
+                return touch($filePath);
+            });
+
+        $driverMock = $this->createMock(RemoteWebDriver::class);
+        $driverMock->expects($this->once())
+            ->method('findElement')
+            ->with(WebDriverBy::cssSelector('#selector'))
+            ->willReturn($elementMock);
+
+        $browser = new Browser($driverMock);
+
+        $browser::$storeScreenshotsAt = sys_get_temp_dir();
+
+        $browser->elementScreenshot(
+            '#selector',
+            $name = 'screenshot-01',
+        );
+
+        $this->assertFileExists(Browser::$storeScreenshotsAt.'/'.$name.'.png');
+    }
+
+    public function test_element_screenshot_in_subdirectory()
+    {
+        $elementMock = $this->createMock(RemoteWebElement::class);
+        $elementMock->expects($this->once())
+            ->method('takeElementScreenshot')
+            ->willReturnCallback(function ($filePath) {
+                return touch($filePath);
+            });
+
+        $driverMock = $this->createMock(RemoteWebDriver::class);
+        $driverMock->expects($this->once())
+            ->method('findElement')
+            ->with(WebDriverBy::cssSelector('#selector'))
+            ->willReturn($elementMock);
+
+        $browser = new Browser($driverMock);
+
+        $browser::$storeScreenshotsAt = sys_get_temp_dir();
+
+        $browser->elementScreenshot(
+            '#selector',
+            $name = uniqid('random').'/sub/dir/screenshot-01',
         );
 
         $this->assertFileExists(Browser::$storeScreenshotsAt.'/'.$name.'.png');


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
in the previous PR #1093 the use of Dusk selectors were not supported. This formats the selector as per other methods thereby supporting the use of Dusk selectors.