### PR TITLE
[8.x] Separate `dump()` and `dd()` usage for consistency

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -742,7 +742,7 @@ class Browser
      */
     public function dump()
     {
-        dd($this->driver->getPageSource());
+        dump($this->driver->getPageSource());
     }
 
     /**

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -758,7 +758,7 @@ class Browser
 
         $this->quit();
 
-        die();
+        exit;
     }
 
     /**

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -743,6 +743,22 @@ class Browser
     public function dump()
     {
         dump($this->driver->getPageSource());
+
+        return $this;
+    }
+
+    /**
+     * Dump and die the content from the last response.
+     *
+     * @return void
+     */
+    public function dd()
+    {
+        dump($this->driver->getPageSource());
+
+        $this->quit();
+
+        die();
     }
 
     /**


### PR DESCRIPTION
This should avoid issue mentioned in #1095 
