### PR TITLE
[8.x] Add `waitForTitle()`

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -132,7 +132,7 @@ trait WaitsForElements
     }
 
     /**
-     * Wait for the given title to become visible.
+     * Wait for the given title appears in the page's title bar.
      *
      * @param  string  $text
      * @param  int|null  $seconds

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -132,6 +132,24 @@ trait WaitsForElements
     }
 
     /**
+     * Wait for the given title to become visible.
+     *
+     * @param  string  $text
+     * @param  int|null  $seconds
+     * @return $this
+     *
+     * @throws \Facebook\WebDriver\Exception\TimeoutException
+     */
+    public function waitForTitle($text, $seconds = null)
+    {
+        $message = $this->formatTimeOutMessage('Waited %s seconds for title', $text);
+
+        return $this->waitUsing($seconds, 100, function () use ($text) {
+            return $this->assertTitle($text);
+        }, $message);
+    }
+
+    /**
      * Wait for the given link to become visible.
      *
      * @param  string  $link

--- a/tests/Unit/WaitsForElementsTest.php
+++ b/tests/Unit/WaitsForElementsTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Dusk\Tests\Unit;
 
 use Facebook\WebDriver\Exception\TimeOutException;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\RemoteWebElement;
 use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverWait;
@@ -511,5 +512,18 @@ JS;
         $browser = new Browser($driver, $resolver);
 
         $browser->waitForEvent('submit', 'form', 3);
+    }
+
+    public function test_can_wait_for_title()
+    {
+        $driver = m::mock(WebDriver::class);
+        $driver->shouldReceive('getTitle')->andReturn('Laravel');
+        $driver->shouldReceive('wait')->with(2, 100)->andReturnUsing(function ($seconds, $interval) use ($driver) {
+            return new WebDriverWait($driver, $seconds, $interval);
+        });
+
+        $browser = new Browser($driver);
+
+        $browser->waitForTitle('Laravel');
     }
 }

--- a/tests/Unit/WaitsForElementsTest.php
+++ b/tests/Unit/WaitsForElementsTest.php
@@ -3,7 +3,6 @@
 namespace Laravel\Dusk\Tests\Unit;
 
 use Facebook\WebDriver\Exception\TimeOutException;
-use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\RemoteWebElement;
 use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverWait;


### PR DESCRIPTION
The `waitForTitle` method may be used to wait until the given title is appears in the page's title bar.

https://github.com/laravel/docs/pull/9673