### PR TITLE
Allow Dusk selectors anywhere in the selector string

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -409,7 +409,7 @@ class ElementResolver
             array_keys($sortedElements), array_values($sortedElements), $originalSelector = $selector
         );
 
-        if (Str::startsWith($selector, '@') && $selector === $originalSelector) {
+        if (Str::contains($selector, '@') && $selector === $originalSelector) {
             $selector = preg_replace('/@(\S+)/', '['.Dusk::$selectorHtmlAttribute.'="$1"]', $selector);
         }
 

--- a/tests/Unit/ElementResolverTest.php
+++ b/tests/Unit/ElementResolverTest.php
@@ -148,6 +148,7 @@ class ElementResolverTest extends TestCase
         $this->assertSame('prefix #first-third', $resolver->format('@modal-third'));
         $this->assertSame('prefix [dusk="missing-element"]', $resolver->format('@missing-element'));
         $this->assertSame('prefix [dusk="missing-element"] > div', $resolver->format('@missing-element > div'));
+        $this->assertSame('prefix div > [dusk="missing-element"]', $resolver->format('div > @missing-element'));
     }
 
     public function test_find_by_id_with_colon()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
The current implementation requires that the dusk selector is the first selector in a string of selectors, but will replace any number of dusk selectors with the appropriate data attribute syntax, regardless of where they occur in the selector string as long as the first is a dusk selector.

I can't see any reason that the string has to start with the `@` symbol from the dusk perspective, and whilst I can also appreciate that each dusk selector should perhaps be unique, I feel that there should be some form of duplication as if they are meant to be unique then why not use standard id attributes.

Therefore the change from `Str::startsWith()` to `Str::contains()` is generally more flexible, e.g., in cases where the dusk selectors are not unique on a page (for whatever reason) and you want to use css combinators to get the one you want without having to define the full css selector, which could be very brittle.

I know that `scoping` would provide a similar outcome, but I feel there would be scenarios where this might still be insufficient.

There's nothing in the documentation that states it has to be the first selector, which means it's a little confusing at first if you try and use a dusk selector as the 2nd or 3rd part of the full selector and the browser test fails because it's an invalid selector. 

From what I can tell, there shouldn't be any breaking changes associated with it:
- Anyone using unique dusk selectors is unlikely to have encountered this issue
- Anyone that may have attempted to use the dusk selector later in the selector string would probably have worked around it with scopes or replacing with the `[dusk="duskselector"]` manually.