### PR TITLE
[8.x] Fixes installing ChromeDriver 127 and above

### DIFF
--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -225,7 +225,13 @@ class ChromeDriverCommand extends Command
 
         $zip->extractTo($this->directory);
 
-        $binary = $zip->getNameIndex(version_compare($version, '115.0', '<') ? 0 : 1);
+        $index = match (true) {
+            version_compare($version, '115.0', '<') => 0,
+            version_compare($version, '127.0', '<') => 1,
+            default => 2,
+        };
+
+        $binary = $zip->getNameIndex($index);
 
         $zip->close();
 


### PR DESCRIPTION
fixes #1109

The zip file now contains 3 files instead of 2 in previous releases causing this issue.
