### PR TITLE
Added `--disable-search-engine-choice-screen` argument

### DIFF
--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -31,6 +31,7 @@ abstract class DuskTestCase extends BaseTestCase
     {
         $options = (new ChromeOptions)->addArguments(collect([
             $this->shouldStartMaximized() ? '--start-maximized' : '--window-size=1920,1080',
+            '--disable-search-engine-choice-screen',
         ])->unless($this->hasHeadlessDisabled(), function (Collection $items) {
             return $items->merge([
                 '--disable-gpu',

--- a/tests/Browser/DuskTestCase.php
+++ b/tests/Browser/DuskTestCase.php
@@ -57,6 +57,7 @@ class DuskTestCase extends TestCase
     {
         $options = (new ChromeOptions)->addArguments(collect([
             $this->shouldStartMaximized() ? '--start-maximized' : '--window-size=1920,1080',
+            '--disable-search-engine-choice-screen',
         ])->unless($this->hasHeadlessDisabled(), function (Collection $items) {
             return $items->merge([
                 '--disable-gpu',


### PR DESCRIPTION
As of Chrome v127, there is a "Choose your search engine" modal, which is quite annoying when taking screenshots or debugging a Dusk test. This PR adds the `--disable-search-engine-choice-screen` flag to get rid of it.

<img width="2032" alt="Screenshot 2024-07-30 at 10 34 23" src="https://github.com/user-attachments/assets/15f1bcf7-e45e-4390-9e1e-1052b846d12f">