### PR TITLE
Require Dusk selectors to adhere to CSS naming rules

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -409,8 +409,8 @@ class ElementResolver
             array_keys($sortedElements), array_values($sortedElements), $originalSelector = $selector
         );
 
-        if (Str::startsWith($selector, '@') && $selector === $originalSelector) {
-            $selector = preg_replace('/@(\S+)/', '['.Dusk::$selectorHtmlAttribute.'="$1"]', $selector);
+        if (Str::contains($selector, '@') && $selector === $originalSelector) {
+            $selector = preg_replace('/@(-?[_a-zA-Z]+[_a-zA-Z0-9-]*)/', '['.Dusk::$selectorHtmlAttribute.'="$1"]', $selector);
         }
 
         return trim($this->prefix.' '.$selector);

--- a/tests/Unit/ElementResolverTest.php
+++ b/tests/Unit/ElementResolverTest.php
@@ -148,6 +148,8 @@ class ElementResolverTest extends TestCase
         $this->assertSame('prefix #first-third', $resolver->format('@modal-third'));
         $this->assertSame('prefix [dusk="missing-element"]', $resolver->format('@missing-element'));
         $this->assertSame('prefix [dusk="missing-element"] > div', $resolver->format('@missing-element > div'));
+        $this->assertSame('prefix [dusk="foo"].bar', $resolver->format('@foo.bar'));
+        $this->assertSame('prefix .foo[dusk="bar"]', $resolver->format('.foo@bar'));
     }
 
     public function test_find_by_id_with_colon()


### PR DESCRIPTION
# Description

This PR fixes issue #1113 by refining the Dusk selector parsing to ensure compatibility with valid CSS class names. Currently, the documentation, PHPDoc, and unit tests do not clearly define which characters are valid for Dusk selectors, leading to potential conflicts when Dusk selectors are combined with other CSS selectors on the same element.

# Motivation
The existing documentation and unit tests only uses dashes in Dusk selectors. However, Dusk selectors cannot be used alongside other CSS selectors if they target the same element, which requires them not to be separated by a space. By aligning the Dusk selector parsing with the standards for valid CSS names (as outlined in [this Stack Overflow answer](https://stackoverflow.com/questions/448981/which-characters-are-valid-in-css-class-names-selectors#449000)), we add support for Dusk selectors to target the same element as other CSS selectors.

# Changes

* Updated the Dusk selector parsing regex to only allow valid CSS names.
* Modified the existing condition to use Str::contains instead of Str::startsWith to support Dusk selectors to exist after another CSS selector not separated by a space.
* Added unit tests to ensure the new regex handles combined selectors correctly.