### PR TITLE
[8.x] Extract chromedriver regardless of position in archive

### DIFF
--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -94,6 +94,7 @@ class ChromeDriverCommand extends Command
         foreach (OperatingSystem::all() as $os) {
             if ($all || ($os === $currentOS)) {
                 $archive = $this->download($version, $os);
+
                 $binary = $this->extract($archive);
 
                 $this->rename($binary, $os);

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -212,7 +212,6 @@ class ChromeDriverCommand extends Command
     /**
      * Extract the ChromeDriver binary from the archive and delete the archive.
      *
-     * @param  string  $version
      * @param  string  $archive
      * @return string
      */

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -224,7 +224,7 @@ class ChromeDriverCommand extends Command
 
         $binary = null;
 
-        for($fileIndex = 0; $fileIndex < $zip->numFiles; $fileIndex++) {
+        for ($fileIndex = 0; $fileIndex < $zip->numFiles; $fileIndex++) {
             $filename = $zip->getNameIndex($fileIndex);
 
             if (Str::startsWith(basename($filename), 'chromedriver')) {

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -94,8 +94,7 @@ class ChromeDriverCommand extends Command
         foreach (OperatingSystem::all() as $os) {
             if ($all || ($os === $currentOS)) {
                 $archive = $this->download($version, $os);
-
-                $binary = $this->extract($version, $archive);
+                $binary = $this->extract($archive);
 
                 $this->rename($binary, $os);
             }
@@ -217,25 +216,33 @@ class ChromeDriverCommand extends Command
      * @param  string  $archive
      * @return string
      */
-    protected function extract($version, $archive)
+    protected function extract($archive)
     {
         $zip = new ZipArchive;
 
         $zip->open($archive);
 
-        $zip->extractTo($this->directory);
+        $binary = null;
 
-        $index = match (true) {
-            version_compare($version, '115.0', '<') => 0,
-            version_compare($version, '127.0', '<') => 1,
-            default => 2,
-        };
+        for($fileIndex = 0; $fileIndex < $zip->numFiles; $fileIndex++) {
+            $filename = $zip->getNameIndex($fileIndex);
 
-        $binary = $zip->getNameIndex($index);
+            if (Str::startsWith(basename($filename), 'chromedriver')) {
+                $binary = $filename;
+
+                $zip->extractTo($this->directory, $binary);
+
+                break;
+            }
+        }
 
         $zip->close();
 
         unlink($archive);
+
+        if (! $binary) {
+            throw new Exception('Could not extract the ChromeDriver binary.');
+        }
 
         return $binary;
     }


### PR DESCRIPTION
The aim of this PR is to do a small refactor to prevent dusk breaking if Chrome annoyingly change the order of, or add files in their driver zip archive.

It looks through the archive and only extracts files beginning with `chromedriver`. This should handle all windows, linux and mac chromedriver files.

