### PR TITLE
[8.x] Explicitly set `chromedriver` port.

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -51,7 +51,7 @@ jobs:
         run: php vendor/bin/testbench dusk:chrome-driver --detect
 
       - name: Start Chrome Driver
-        run: ./bin/chromedriver-linux &
+        run: ./bin/chromedriver-linux --port=9515 &
 
       - name: Run Laravel Server
         run: php vendor/bin/testbench serve --no-reload &

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -43,7 +43,8 @@ abstract class TestCase extends FoundationTestCase
     protected function driver()
     {
         return RemoteWebDriver::create(
-            'http://localhost:9515', DesiredCapabilities::chrome()
+            $_ENV['DUSK_DRIVER_URL'] ?? env('DUSK_DRIVER_URL') ?? 'http://localhost:9515',
+            DesiredCapabilities::chrome()
         );
     }
 

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -20,7 +20,7 @@ abstract class DuskTestCase extends BaseTestCase
     public static function prepare(): void
     {
         if (! static::runningInSail()) {
-            static::startChromeDriver();
+            static::startChromeDriver(['--port=9515']);
         }
     }
 


### PR DESCRIPTION
fixes #1123
fixes #1122

Before 128, ChromeDriver will use the default 9515 port, however this is no longer the case and would cause chromedriver to run on port 0. https://issues.chromium.org/issues/361370192

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
