### PR TITLE
[TASK] Only allow routes for tests

### DIFF
--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -14,7 +14,7 @@ class DuskServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (! $this->app->environment('production')) {
+        if ($this->app->runningUnitTests()) {
             Route::group(array_filter([
                 'prefix' => config('dusk.path', '_dusk'),
                 'domain' => config('dusk.domain', null),


### PR DESCRIPTION
On test environments this feature can be abused and therefor can be a liability. This looks for the env == testing to only allow it to be accessable during tests.

If needed, the `$this->app->isLocal()` can be added to allow local abusing.