### PR TITLE
Ignore Symfony console default options

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -72,7 +72,6 @@ class DuskCommand extends Command
                 '--browse', '--without-tty',
                 '--quiet', '-q',
                 '--verbose', '-v', '-vv', '-vvv',
-                '--version', '-V',
                 '--no-interaction', '-n',
             ])
             ->values()

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -68,7 +68,13 @@ class DuskCommand extends Command
 
         $options = collect($_SERVER['argv'])
             ->slice(2)
-            ->diff(['--browse', '--without-tty', ...$this->getDefaultOptions()])
+            ->diff([
+                '--browse', '--without-tty',
+                '--quiet', '-q',
+                '--verbose', '-v', '-vv', '-vvv',
+                '--version', '-V',
+                '--no-interaction', '-n',
+            ])
             ->values()
             ->all();
 
@@ -381,27 +387,5 @@ class DuskCommand extends Command
         }
 
         return '.env.dusk';
-    }
-
-    /**
-     * Get the Symfony Console application's default options.
-     *
-     * @return array
-     */
-    protected function getDefaultOptions(): array
-    {
-        return collect($this->getApplication()->getDefinition()->getOptions())
-            ->filter(fn ($option) => ! in_array($option->getName(), ['env', 'ansi', 'no-ansi']))
-            ->map(function ($option) {
-                return [
-                    '--'.$option->getName(),
-                    ...collect(explode('|', $option->getShortcut()))
-                        ->filter()
-                        ->map(fn ($shortcut) => '-'.$shortcut)
-                        ->toArray(),
-                ];
-            })
-            ->flatten()
-            ->toArray();
     }
 }

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -394,10 +394,10 @@ class DuskCommand extends Command
             ->filter(fn ($option) => ! in_array($option->getName(), ['env', 'ansi', 'no-ansi']))
             ->map(function ($option) {
                 return [
-                    '--' . $option->getName(),
+                    '--'.$option->getName(),
                     ...collect(explode('|', $option->getShortcut()))
                         ->filter()
-                        ->map(fn ($shortcut) => '-' . $shortcut)
+                        ->map(fn ($shortcut) => '-'.$shortcut)
                         ->toArray(),
                 ];
             })

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -68,7 +68,7 @@ class DuskCommand extends Command
 
         $options = collect($_SERVER['argv'])
             ->slice(2)
-            ->diff(['--browse', '--without-tty'])
+            ->diff(['--browse', '--without-tty', ...$this->getDefaultOptions()])
             ->values()
             ->all();
 
@@ -381,5 +381,27 @@ class DuskCommand extends Command
         }
 
         return '.env.dusk';
+    }
+
+    /**
+     * Get the Symfony Console application's default options.
+     *
+     * @return array
+     */
+    protected function getDefaultOptions(): array
+    {
+        return collect($this->getApplication()->getDefinition()->getOptions())
+            ->filter(fn ($option) => ! in_array($option->getName(), ['env', 'ansi', 'no-ansi']))
+            ->map(function ($option) {
+                return [
+                    '--' . $option->getName(),
+                    ...collect(explode('|', $option->getShortcut()))
+                        ->filter()
+                        ->map(fn ($shortcut) => '-' . $shortcut)
+                        ->toArray(),
+                ];
+            })
+            ->flatten()
+            ->toArray();
     }
 }


### PR DESCRIPTION
When default Symfony options get passed to the Dusk command, PHPUnit doesn't run:

```
❯ php artisan dusk --quiet
PHPUnit 11.3.6 by Sebastian Bergmann and contributors.

Unknown option "--quiet"
```

I did originally commit a version that looped through Symfony's options programmatically, however I worry what would happen if any new defaults got added in the future, so I just hardcoded the offending options here.