### PR TITLE
check for directory existence when storing console log or storing source, if it does not exist create it

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -484,8 +484,16 @@ class Browser
             $console = $this->driver->manage()->getLog('browser');
 
             if (! empty($console)) {
+                $filePath = sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name);
+
+                $directoryPath = dirname($filePath);
+
+                if (! is_dir($directoryPath)) {
+                    mkdir($directoryPath, 0777, true);
+                }
+
                 file_put_contents(
-                    sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name), json_encode($console, JSON_PRETTY_PRINT)
+                    $filePath, json_encode($console, JSON_PRETTY_PRINT)
                 );
             }
         }
@@ -504,9 +512,15 @@ class Browser
         $source = $this->driver->getPageSource();
 
         if (! empty($source)) {
-            file_put_contents(
-                sprintf('%s/%s.txt', rtrim(static::$storeSourceAt, '/'), $name), $source
-            );
+            $filePath = sprintf('%s/%s.txt', rtrim(static::$storeSourceAt, '/'), $name);
+
+            $directoryPath = dirname($filePath);
+
+            if (! is_dir($directoryPath)) {
+                mkdir($directoryPath, 0777, true);
+            }
+
+            file_put_contents($filePath, $source);
         }
 
         return $this;


### PR DESCRIPTION
This PR fixes missing destination directory for storing console log or source code.

Currently when saving console log or source code to the path defined in `\Laravel\Dusk\Browser::$storeConsoleLogAt` or `\Laravel\Dusk\Browser::$storeSourceAt`, the code does not check for the existence of the directory.

Because of missing check for destination directory existence, current code throws `ErrorException` when trying to save console log or source code:
```
file_put_contents(/Sites/laravel-dusk/storage/app/customPath/pageSources/source.txt): Failed to open stream: No such file or directory
```

This PR adds code to check for the exitence of the destination directory and if it does not exist, then tries to create it.