### PR TITLE
fix: removed Laravel\Dusk\Page import from dusk:page stub

### DIFF
--- a/src/Console/stubs/page.stub
+++ b/src/Console/stubs/page.stub
@@ -3,7 +3,6 @@
 namespace DummyNamespace;
 
 use Laravel\Dusk\Browser;
-use Laravel\Dusk\Page;
 
 class DummyClass extends Page
 {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Changes

- Fixes the generated pages using `php artisan dusk:page PageName` to not use `Laravel\Dusk\Page`.
Because with the install command `php artisan dusk:install` a abstract class `Page`was created in `Tests\Browser\Pages` and should be used instead.


## Reason
- Without modification (the proposed changes) to the created page the [global shorthand selectors](https://laravel.com/docs/11.x/dusk#global-shorthand-selectors) do not work.