### PR TITLE
Update MakesAssertions.php

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -157,11 +157,12 @@ trait MakesAssertions
      * Assert that the given text is not present on the page.
      *
      * @param  string  $text
+     * @param  bool  $ignoreCase
      * @return $this
      */
-    public function assertDontSee($text)
+    public function assertDontSee($text, $ignoreCase = false)
     {
-        return $this->assertDontSeeIn('', $text);
+        return $this->assertDontSeeIn('', $text, $ignoreCase);
     }
 
     /**
@@ -191,16 +192,17 @@ trait MakesAssertions
      *
      * @param  string  $selector
      * @param  string  $text
+     * @param  bool  $ignoreCase
      * @return $this
      */
-    public function assertDontSeeIn($selector, $text)
+    public function assertDontSeeIn($selector, $text, $ignoreCase = false)
     {
         $fullSelector = $this->resolver->format($selector);
 
         $element = $this->resolver->findOrFail($selector);
 
         PHPUnit::assertFalse(
-            Str::contains($element->getText(), $text),
+            Str::contains($element->getText(), $text, $ignoreCase),
             "Saw unexpected text [{$text}] within element [{$fullSelector}]."
         );
 


### PR DESCRIPTION
Add optional parameter to MakesAssertions/assertDontSeeIn $ignoreCase

The `Ignorecase` attribute is handy with the `assertSee` method, and I think it will be helpful in `assertDontSee`, too.

Will not break since is an optional parameter with a default value.

Bests,
