### PR TITLE
[8.x] Behaviour change on assertAttributeDoesntContain

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -800,7 +800,7 @@ JS;
     public function assertAttributeContains($selector, $attribute, $value)
     {
         $fullSelector = $this->resolver->format($selector);
-        
+
         $actual = $this->resolver->findOrFail($selector)->getAttribute($attribute);
 
         PHPUnit::assertNotNull(

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -799,14 +799,11 @@ JS;
      */
     public function assertAttributeContains($selector, $attribute, $value)
     {
-        $fullSelector = $this->resolver->format($selector);
-
         $actual = $this->resolver->findOrFail($selector)->getAttribute($attribute);
 
-        PHPUnit::assertNotNull(
-            $actual,
-            "Did not see expected attribute [{$attribute}] within element [{$fullSelector}]."
-        );
+        if (is_null($actual)) {
+            return $this;
+        }
 
         PHPUnit::assertStringContainsString(
             $value,
@@ -830,11 +827,6 @@ JS;
         $fullSelector = $this->resolver->format($selector);
 
         $actual = $this->resolver->findOrFail($selector)->getAttribute($attribute);
-
-        PHPUnit::assertNotNull(
-            $actual,
-            "Did not see expected attribute [{$attribute}] within element [{$fullSelector}]."
-        );
 
         PHPUnit::assertStringNotContainsString(
             $value,

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -832,7 +832,7 @@ JS;
         if (is_null($actual)) {
             return $this;
         }
-        
+
         PHPUnit::assertStringNotContainsString(
             $value,
             $actual,

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -799,11 +799,14 @@ JS;
      */
     public function assertAttributeContains($selector, $attribute, $value)
     {
+        $fullSelector = $this->resolver->format($selector);
+        
         $actual = $this->resolver->findOrFail($selector)->getAttribute($attribute);
 
-        if (is_null($actual)) {
-            return $this;
-        }
+        PHPUnit::assertNotNull(
+            $actual,
+            "Did not see expected attribute [{$attribute}] within element [{$fullSelector}]."
+        );
 
         PHPUnit::assertStringContainsString(
             $value,
@@ -824,10 +827,12 @@ JS;
      */
     public function assertAttributeDoesntContain($selector, $attribute, $value)
     {
-        $fullSelector = $this->resolver->format($selector);
-
         $actual = $this->resolver->findOrFail($selector)->getAttribute($attribute);
 
+        if (is_null($actual)) {
+            return $this;
+        }
+        
         PHPUnit::assertStringNotContainsString(
             $value,
             $actual,

--- a/tests/Unit/MakesAssertionsTest.php
+++ b/tests/Unit/MakesAssertionsTest.php
@@ -683,15 +683,7 @@ class MakesAssertionsTest extends TestCase
 
         $browser->assertAttributeDoesntContain('foo', 'bar', 'class-c');
 
-        try {
-            $browser->assertAttributeDoesntContain('foo', 'bar', 'class-c');
-            $this->fail();
-        } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString(
-                'Did not see expected attribute [bar] within element [Foo].',
-                $e->getMessage()
-            );
-        }
+        $browser->assertAttributeDoesntContain('foo', 'bar', 'class-c');
 
         try {
             $browser->assertAttributeDoesntContain('foo', 'bar', 'class-1');


### PR DESCRIPTION
See issue #1153 for more info.

Removed notNull assertion in MakeAssertions/assertAttributeDoesntContain and added an early return if the attribute is null.

Updated test in tests/Unit/MakeAssertionsTest.php to reflect new behaviour in unit test.

