### PR TITLE
Add assertCount() method

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -250,6 +250,26 @@ trait MakesAssertions
     }
 
     /**
+     * Assert that a given element is present a given amount of times.
+     *
+     * @param string $selector
+     * @param int $expected
+     * @return $this
+     */
+    public function assertCount($selector, $expected)
+    {
+        $fullSelector = $this->resolver->format($selector);
+
+        PHPUnit::assertCount(
+            $expected,
+            $this->resolver->all($selector),
+            "Expected element [{$fullSelector}] exactly {$expected} times."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the given JavaScript expression evaluates to the given value.
      *
      * @param  string  $expression

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -252,8 +252,8 @@ trait MakesAssertions
     /**
      * Assert that a given element is present a given amount of times.
      *
-     * @param string $selector
-     * @param int $expected
+     * @param  string  $selector
+     * @param  int  $expected
      * @return $this
      */
     public function assertCount($selector, $expected)

--- a/tests/Unit/MakesAssertionsTest.php
+++ b/tests/Unit/MakesAssertionsTest.php
@@ -1257,6 +1257,32 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_count()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element1 = m::mock(RemoteWebElement::class);
+        $element2 = m::mock(RemoteWebElement::class);
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
+        $resolver->shouldReceive('all')->with('foo')->andReturn([$element1, $element2]);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertCount('foo', 2);
+
+        try {
+            $browser->assertCount('foo', 3);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Expected element [body foo] exactly 3 times.',
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_script()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
This PR adds a new helper to assert the number of matching elements on the page.

It's useful when assertions are performed on DOM elements that are tied to factories:

```
Books::factory()
    ->times(3)
    ->sequence(['stock' => true], ['stock' => true], ['stock' => false])
    ->create();

$browser->assertCount('input[name="books_in_stock"]:checked', 2);
```