### PR TITLE
feat: wait for query string

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -180,6 +180,22 @@ trait WaitsForElements
     }
 
     /**
+     * Wait for the given query string to be present in the URL.
+     * 
+     * @param  string  $query
+     * @param  int|null  $seconds
+     * @return $this
+     * 
+     * @throws \Facebook\WebDriver\Exception\TimeoutException
+     */
+    public function waitForQueryString($query, $seconds = null)
+    {
+        $message = $this->formatTimeOutMessage('Waited %s seconds for query string', $query);
+
+        return $this->waitUntil("window.location.search.includes('{$query}')", $seconds, $message);
+    }
+
+    /**
      * Wait for the given location using a named route.
      *
      * @param  string  $route

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -124,7 +124,7 @@ trait WaitsForElements
      */
     public function waitForTextIn($selector, $text, $seconds = null, $ignoreCase = false)
     {
-        $message = 'Waited %s seconds for text "'.$this->escapePercentCharacters($text).'" in selector '.$selector;
+        $message = 'Waited %s seconds for text "' . $this->escapePercentCharacters($text) . '" in selector ' . $selector;
 
         return $this->waitUsing($seconds, 100, function () use ($selector, $text, $ignoreCase) {
             return $this->assertSeeIn($selector, $text, $ignoreCase);
@@ -175,17 +175,17 @@ trait WaitsForElements
         $message = $this->formatTimeOutMessage('Waited %s seconds for location', $path);
 
         return Str::startsWith($path, ['http://', 'https://'])
-            ? $this->waitUntil('`${location.protocol}//${location.host}${location.pathname}` == \''.$path.'\'', $seconds, $message)
+            ? $this->waitUntil('`${location.protocol}//${location.host}${location.pathname}` == \'' . $path . '\'', $seconds, $message)
             : $this->waitUntil("window.location.pathname == '{$path}'", $seconds, $message);
     }
 
     /**
      * Wait for the given query string to be present in the URL.
-     * 
+     *
      * @param  string  $query
      * @param  int|null  $seconds
      * @return $this
-     * 
+     *
      * @throws \Facebook\WebDriver\Exception\TimeoutException
      */
     public function waitForQueryString($query, $seconds = null)
@@ -259,11 +259,11 @@ trait WaitsForElements
     public function waitUntil($script, $seconds = null, $message = null)
     {
         if (! Str::startsWith($script, 'return ')) {
-            $script = 'return '.$script;
+            $script = 'return ' . $script;
         }
 
         if (! Str::endsWith($script, ';')) {
-            $script = $script.';';
+            $script = $script . ';';
         }
 
         return $this->waitUsing($seconds, 100, function () use ($script) {
@@ -318,7 +318,8 @@ trait WaitsForElements
         $seconds = is_null($seconds) ? static::$waitSeconds : $seconds;
 
         $this->driver->wait($seconds, 100)->until(
-            WebDriverExpectedCondition::alertIsPresent(), "Waited {$seconds} seconds for dialog."
+            WebDriverExpectedCondition::alertIsPresent(),
+            "Waited {$seconds} seconds for dialog."
         );
 
         return $this;
@@ -434,7 +435,7 @@ trait WaitsForElements
      */
     protected function formatTimeOutMessage($message, $expected)
     {
-        return $message.' ['.$this->escapePercentCharacters($expected).'].';
+        return $message . ' [' . $this->escapePercentCharacters($expected) . '].';
     }
 
     /**

--- a/tests/Unit/WaitsForElementsTest.php
+++ b/tests/Unit/WaitsForElementsTest.php
@@ -178,7 +178,7 @@ class WaitsForElementsTest extends TestCase
     {
         $driver = m::mock(WebDriver::class);
         $driver->shouldReceive('executeScript')
-            ->with('return location.search.contains(\'foo=bar\');')
+            ->with('return window.location.search.includes(\'foo=bar\');')
             ->andReturnTrue();
         $driver->shouldReceive('wait')->with(2, 100)->andReturnUsing(function ($seconds, $interval) use ($driver) {
             return new WebDriverWait($driver, $seconds, $interval);

--- a/tests/Unit/WaitsForElementsTest.php
+++ b/tests/Unit/WaitsForElementsTest.php
@@ -174,6 +174,21 @@ class WaitsForElementsTest extends TestCase
         $browser->waitForLocation('https://example.com/home');
     }
 
+    public function test_can_wait_for_a_query_string_location()
+    {
+        $driver = m::mock(WebDriver::class);
+        $driver->shouldReceive('executeScript')
+            ->with('return location.search.contains(\'foo=bar\');')
+            ->andReturnTrue();
+        $driver->shouldReceive('wait')->with(2, 100)->andReturnUsing(function ($seconds, $interval) use ($driver) {
+            return new WebDriverWait($driver, $seconds, $interval);
+        });
+
+        $browser = new Browser($driver);
+
+        $browser->waitForQueryString('foo=bar');
+    }
+
     public function test_can_wait_for_route()
     {
         $this->swapUrlGenerator();


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello 👋,

There is an assert called `assertQueryStringHas` but nothing to wait for a specific query string.

Actually, I have an input that will change the URL query string before showing the new data and having a way to wait for a change in the query string could be very useful.
