### PR TITLE
feat: wait for query string

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -180,6 +180,22 @@ trait WaitsForElements
     }
 
     /**
+     * Wait for the given query string to be present in the URL.
+     *
+     * @param  string  $query
+     * @param  int|null  $seconds
+     * @return $this
+     *
+     * @throws \Facebook\WebDriver\Exception\TimeoutException
+     */
+    public function waitForQueryString($query, $seconds = null)
+    {
+        $message = $this->formatTimeOutMessage('Waited %s seconds for query string', $query);
+
+        return $this->waitUntil("window.location.search.includes('{$query}')", $seconds, $message);
+    }
+
+    /**
      * Wait for the given location using a named route.
      *
      * @param  string  $route

--- a/tests/Unit/WaitsForElementsTest.php
+++ b/tests/Unit/WaitsForElementsTest.php
@@ -174,6 +174,21 @@ class WaitsForElementsTest extends TestCase
         $browser->waitForLocation('https://example.com/home');
     }
 
+    public function test_can_wait_for_a_query_string_location()
+    {
+        $driver = m::mock(WebDriver::class);
+        $driver->shouldReceive('executeScript')
+            ->with('return window.location.search.includes(\'foo=bar\');')
+            ->andReturnTrue();
+        $driver->shouldReceive('wait')->with(2, 100)->andReturnUsing(function ($seconds, $interval) use ($driver) {
+            return new WebDriverWait($driver, $seconds, $interval);
+        });
+
+        $browser = new Browser($driver);
+
+        $browser->waitForQueryString('foo=bar');
+    }
+
     public function test_can_wait_for_route()
     {
         $this->swapUrlGenerator();


### PR DESCRIPTION
Hello 👋,

There is an assert called assertQueryStringHas but nothing to wait for a specific query string.

Actually, I have an input that will change the URL query string before showing the new data and having a way to wait for a change in the query string could be very useful.