### PR TITLE
Disable smooth scrolling in TestCase

### DIFF
--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -32,6 +32,7 @@ abstract class DuskTestCase extends BaseTestCase
         $options = (new ChromeOptions)->addArguments(collect([
             $this->shouldStartMaximized() ? '--start-maximized' : '--window-size=1920,1080',
             '--disable-search-engine-choice-screen',
+            '--disable-smooth-scrolling',
         ])->unless($this->hasHeadlessDisabled(), function (Collection $items) {
             return $items->merge([
                 '--disable-gpu',

--- a/tests/Browser/DuskTestCase.php
+++ b/tests/Browser/DuskTestCase.php
@@ -58,6 +58,7 @@ class DuskTestCase extends TestCase
         $options = (new ChromeOptions)->addArguments(collect([
             $this->shouldStartMaximized() ? '--start-maximized' : '--window-size=1920,1080',
             '--disable-search-engine-choice-screen',
+            '--disable-smooth-scrolling',
         ])->unless($this->hasHeadlessDisabled(), function (Collection $items) {
             return $items->merge([
                 '--disable-gpu',


### PR DESCRIPTION
My colleague @MizouZie tracked down that this behaviour can be the source of flaky test failures, particularly in CI. We turned this flag on a few months ago, and it's reduced our intermittent CI test failures significantly.

The flag is documented here: https://peter.sh/experiments/chromium-command-line-switches/#disable-smooth-scrolling

The type of failures we've found it helps with are ones like this, when locating the element involves scrolling:

```
NoSuchElementException: no such element: Unable to locate element: {"method":"css selector","selector":"body #foo-bar"}
```