### PR TITLE
[9.x] Handle requests in test (rather than separate server process)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,17 @@
         "php": "^8.1",
         "ext-json": "*",
         "ext-zip": "*",
+        "ext-sockets": "*",
         "guzzlehttp/guzzle": "^7.5",
         "illuminate/console": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0",
         "php-webdriver/webdriver": "^1.15.2",
+        "react/event-loop": "^1.5",
+        "react/http": "^1.10",
         "symfony/console": "^6.2|^7.0",
         "symfony/finder": "^6.2|^7.0",
         "symfony/process": "^6.2|^7.0",
+        "symfony/psr-http-message-bridge": "^7.1",
         "vlucas/phpdotenv": "^5.2"
     },
     "require-dev": {

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Laravel\Dusk\Http\ProxyServer;
 use Laravel\Dusk\Http\UrlGenerator;
+use React\EventLoop\Loop;
 
 class Browser
 {
@@ -680,7 +681,16 @@ class Browser
      */
     public function pause($milliseconds)
     {
-        usleep($milliseconds * 1000);
+        $sleeping = true;
+
+        Loop::addTimer($milliseconds / 1000, function () use (&$sleeping) {
+            $sleeping = false;
+            Loop::stop();
+        });
+
+        while ($sleeping) {
+            Loop::run();
+        }
 
         return $this;
     }

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -11,6 +11,7 @@ use Facebook\WebDriver\WebDriverPoint;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Laravel\Dusk\Http\ProxyServer;
+use Laravel\Dusk\Http\UrlGenerator;
 
 class Browser
 {
@@ -183,8 +184,8 @@ class Browser
             $url = static::$baseUrl.'/'.ltrim($url, '/');
         }
 
-        // Force our proxy server — this needs to be improved
-        $url = str_replace(rtrim(static::$baseUrl, '/'), app(ProxyServer::class)->url(), $url);
+        // Pass the request through our proxy
+        $url = app(UrlGenerator::class)->proxy($url);
 
         $this->driver->navigate()->to($url);
 

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -10,6 +10,7 @@ use Facebook\WebDriver\WebDriverDimension;
 use Facebook\WebDriver\WebDriverPoint;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Laravel\Dusk\Http\ProxyServer;
 
 class Browser
 {
@@ -181,6 +182,9 @@ class Browser
         if (! Str::startsWith($url, ['http://', 'https://'])) {
             $url = static::$baseUrl.'/'.ltrim($url, '/');
         }
+
+        // Force our proxy server — this needs to be improved
+        $url = str_replace(rtrim(static::$baseUrl, '/'), app(ProxyServer::class)->url(), $url);
 
         $this->driver->navigate()->to($url);
 

--- a/src/Concerns/ProvidesProxyServer.php
+++ b/src/Concerns/ProvidesProxyServer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Dusk\Concerns;
+
+use Illuminate\Routing\UrlGenerator;
+use Laravel\Dusk\Http\ProxyServer;
+use PHPUnit\Framework\Attributes\Before;
+
+trait ProvidesProxyServer
+{
+    #[Before]
+    public function setUpProvidesProxyServer(): void
+    {
+        $this->afterApplicationCreated(function () {
+            $proxy = $this->app->make(ProxyServer::class)->listen();
+            $this->app->make(UrlGenerator::class)->forceRootUrl($proxy->url());
+        });
+
+        $this->beforeApplicationDestroyed(function () {
+            $this->app->make(ProxyServer::class)->flush();
+            $this->app->make(UrlGenerator::class)->forceRootUrl(null);
+        });
+    }
+}

--- a/src/Concerns/ProvidesProxyServer.php
+++ b/src/Concerns/ProvidesProxyServer.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Dusk\Concerns;
 
-use Illuminate\Routing\UrlGenerator;
+use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
+use Illuminate\Routing\UrlGenerator as BaseUrlGenerator;
 use Laravel\Dusk\Http\ProxyServer;
+use Laravel\Dusk\Http\UrlGenerator;
 use PHPUnit\Framework\Attributes\Before;
 
 trait ProvidesProxyServer
@@ -12,13 +14,14 @@ trait ProvidesProxyServer
     public function setUpProvidesProxyServer(): void
     {
         $this->afterApplicationCreated(function () {
-            $proxy = $this->app->make(ProxyServer::class)->listen();
-            $this->app->make(UrlGenerator::class)->forceRootUrl($proxy->url());
+            $this->app->make(ProxyServer::class)->listen();
+            $this->app->instance('url', $this->app->make(UrlGenerator::class));
+            $this->app->instance(UrlGeneratorContract::class, $this->app->make(UrlGenerator::class));
+            $this->app->instance(BaseUrlGenerator::class, $this->app->make(UrlGenerator::class));
         });
 
         $this->beforeApplicationDestroyed(function () {
             $this->app->make(ProxyServer::class)->flush();
-            $this->app->make(UrlGenerator::class)->forceRootUrl(null);
         });
     }
 }

--- a/src/Driver/AsyncCommandExecutor.php
+++ b/src/Driver/AsyncCommandExecutor.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Laravel\Dusk\Driver;
+
+use Facebook\WebDriver\Exception\Internal\LogicException;
+use Facebook\WebDriver\Exception\WebDriverException;
+use Facebook\WebDriver\Remote\HttpCommandExecutor;
+use Facebook\WebDriver\Remote\WebDriverCommand;
+use Facebook\WebDriver\Remote\WebDriverResponse;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use JsonException;
+use Psr\Http\Message\ResponseInterface;
+use React\EventLoop\Loop;
+use React\Http\Browser as ReactHttpClient;
+use React\Promise\PromiseInterface;
+
+class AsyncCommandExecutor extends HttpCommandExecutor
+{
+    /**
+     * Execute a web driver command asynchronously.
+     *
+     * @param  WebDriverCommand  $command
+     * @return WebDriverResponse
+     */
+    public function execute(WebDriverCommand $command): WebDriverResponse
+    {
+        $client = new ReactHttpClient();
+
+        [$url, $method, $headers, $payload] = $this->extractRequestDataFromCommand($command);
+
+        return $this->sendRequestAndWaitForResponse(match ($method) {
+            'GET' => $client->get($url, $headers),
+            'POST' => $client->post($url, $headers, $this->encodePayload($payload)),
+            'DELETE' => $client->delete($url, $headers),
+        });
+    }
+
+    /**
+     * Run event loop until request is fulfilled.
+     *
+     * @param  PromiseInterface  $request
+     * @return WebDriverResponse
+     *
+     * @throws JsonException
+     * @throws WebDriverException
+     */
+    protected function sendRequestAndWaitForResponse(PromiseInterface $request): WebDriverResponse
+    {
+        $resolved = null;
+
+        $request->then(function ($response) use (&$resolved) {
+            Loop::get()->futureTick(fn() => Loop::stop());
+            $resolved = $response;
+        });
+
+        while ($resolved === null) {
+            Loop::run();
+        }
+
+        return $this->mapAsyncResponseToWebDriverResponse($resolved);
+    }
+
+    /**
+     * Parse HTTP response and map to web driver response.
+     *
+     * @param  ResponseInterface  $response
+     * @return WebDriverResponse
+     *
+     * @throws JsonException
+     * @throws WebDriverException
+     */
+    protected function mapAsyncResponseToWebDriverResponse(ResponseInterface $response): WebDriverResponse
+    {
+        $value = null;
+        $message = null;
+        $sessionId = null;
+        $status = 0;
+
+        $results = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        if (is_array($results)) {
+            $value = Arr::get($results, 'value');
+            $message = Arr::get($results, 'message');
+            $status = Arr::get($results, 'status', 0);
+
+            if (is_array($value) && array_key_exists('sessionId', $value)) {
+                $sessionId = $value['sessionId'];
+            } elseif (array_key_exists('sessionId', $results)) {
+                $sessionId = $results['sessionId'];
+            }
+        }
+
+        if (is_array($value) && isset($value['error'])) {
+            WebDriverException::throwException($value['error'], $message, $results);
+        }
+
+        if ($status !== 0) {
+            WebDriverException::throwException($status, $message, $results);
+        }
+
+        return (new WebDriverResponse($sessionId))->setStatus($status)->setValue($value);
+    }
+
+    /**
+     * Ensure that payload is always a JSON object.
+     *
+     * @param  Collection  $payload
+     * @return string
+     */
+    protected function encodePayload(Collection $payload): string
+    {
+        // POST body must be valid JSON object, even if empty: https://www.w3.org/TR/webdriver/#processing-model
+        if ($payload->isEmpty()) {
+            return '{}';
+        }
+
+        return $payload->toJson();
+    }
+
+    /**
+     * Extract data necessary to make HTTP request for web driver command.
+     *
+     * @param  WebDriverCommand  $command
+     * @return array{0: string, 1: string, 2: array, 3: Collection}
+     *
+     * @throws LogicException
+     */
+    protected function extractRequestDataFromCommand(WebDriverCommand $command): array
+    {
+        ['url' => $path, 'method' => $method] = $this->getCommandHttpOptions($command);
+
+        // Keys that are prefixed with ":" are URL parameters. All others are JSON payload data.
+        [$parameters, $payload] = collect($command->getParameters() ?? [])
+            ->put(':sessionId', (string) $command->getSessionID())
+            ->partition(fn($value, $key) => str_starts_with($key, ':'));
+
+        if ($payload->isNotEmpty() && $method !== 'POST') {
+            throw LogicException::forInvalidHttpMethod($path, $method, $payload->all());
+        }
+
+        $url = $this->url.$this->applyParametersToPath($parameters, $path);
+        $method = strtoupper($method);
+        $headers = $this->defaultHeaders($method);
+
+        return [$url, $method, $headers, $payload];
+    }
+
+    /**
+     * Replace prefixed placeholders with request parameters.
+     *
+     * @param  Collection  $parameters
+     * @param  string  $path
+     * @return string
+     */
+    protected function applyParametersToPath(Collection $parameters, string $path): string
+    {
+        return str_replace($parameters->keys()->all(), $parameters->values()->all(), $path);
+    }
+
+    /**
+     * Get the default HTTP headers for a given request method.
+     *
+     * @param  string  $method
+     * @return array
+     */
+    protected function defaultHeaders(string $method): array
+    {
+        $headers = collect(static::DEFAULT_HTTP_HEADERS)->mapWithKeys(function ($header) {
+            [$key, $value] = explode(':', $header, 2);
+            return [$key => $value];
+        });
+
+        if (in_array($method, ['POST', 'PUT'], true)) {
+            $headers->put('Expect', '');
+        }
+
+        return $headers->all();
+    }
+}

--- a/src/Driver/AsyncWebDriver.php
+++ b/src/Driver/AsyncWebDriver.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Laravel\Dusk\Driver;
+
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Facebook\WebDriver\Remote\HttpCommandExecutor;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Facebook\WebDriver\WebDriverCapabilities;
+
+class AsyncWebDriver extends RemoteWebDriver
+{
+    /**
+     * Create a new asynchronous web driver instance.
+     *
+     * @param  string  $selenium_server_url
+     * @param  DesiredCapabilities|array|null  $desired_capabilities
+     * @param  int|null  $connection_timeout_in_ms
+     * @param  int|null  $request_timeout_in_ms
+     * @param  string|null  $http_proxy
+     * @param  int|null  $http_proxy_port
+     * @param  DesiredCapabilities|null  $required_capabilities
+     * @return AsyncWebDriver
+     */
+    public static function create(
+        $selenium_server_url = 'http://localhost:4444/wd/hub',
+        $desired_capabilities = null,
+        $connection_timeout_in_ms = null,
+        $request_timeout_in_ms = null,
+        $http_proxy = null,
+        $http_proxy_port = null,
+        DesiredCapabilities $required_capabilities = null,
+    ): AsyncWebDriver {
+        $factory = new AsyncWebDriverFactory(
+            $selenium_server_url, $desired_capabilities, $connection_timeout_in_ms,
+            $request_timeout_in_ms, $http_proxy, $http_proxy_port, $required_capabilities,
+        );
+
+        return $factory();
+    }
+
+    /**
+     * Public constructor to allow for instantiation via factory.
+     *
+     * @param  AsyncCommandExecutor  $commandExecutor
+     * @param  string  $sessionId
+     * @param  WebDriverCapabilities  $capabilities
+     * @param  bool  $isW3cCompliant
+     */
+    public function __construct(
+        AsyncCommandExecutor $commandExecutor,
+        string $sessionId,
+        WebDriverCapabilities $capabilities,
+        bool $isW3cCompliant = false,
+    ) {
+        parent::__construct($commandExecutor, $sessionId, $capabilities, $isW3cCompliant);
+    }
+}

--- a/src/Driver/AsyncWebDriverFactory.php
+++ b/src/Driver/AsyncWebDriverFactory.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Laravel\Dusk\Driver;
+
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Facebook\WebDriver\Remote\HttpCommandExecutor;
+use Facebook\WebDriver\Remote\WebDriverCommand;
+
+class AsyncWebDriverFactory
+{
+    protected DesiredCapabilities $desiredCapabilities;
+
+    protected DesiredCapabilities $sessionCapabilities;
+
+    protected bool $isW3cCompliant;
+
+    protected string $sessionId;
+
+    /**
+     * Construct a new factory instance.
+     */
+    public function __construct(
+        protected string $seleniumServerUrl = 'http://localhost:9515',
+        DesiredCapabilities|array|null $desiredCapabilities = null,
+        protected ?int $connectionTimeoutMs = null,
+        protected ?int $requestTimeoutMs = null,
+        protected ?string $httpProxy = null,
+        protected ?int $httpProxyPort = null,
+        protected ?DesiredCapabilities $requiredCapabilities = null,
+    ) {
+        $this->seleniumServerUrl = rtrim($this->seleniumServerUrl, '/');
+
+        $this->desiredCapabilities = match (true) {
+            $desiredCapabilities instanceof DesiredCapabilities => $desiredCapabilities,
+            is_array($desiredCapabilities) => new DesiredCapabilities($desiredCapabilities),
+            default => new DesiredCapabilities(),
+        };
+    }
+
+    /**
+     * Create and initialize new AsyncWebDriver.
+     *
+     * @return AsyncWebDriver
+     */
+    public function __invoke(): AsyncWebDriver
+    {
+        $this->initializeSession();
+
+        $executor = new AsyncCommandExecutor($this->seleniumServerUrl, $this->httpProxy, $this->httpProxyPort);
+
+        $this->configureExecutor($executor);
+
+        return new AsyncWebDriver($executor, $this->sessionId, $this->sessionCapabilities, $this->isW3cCompliant);
+    }
+
+    /**
+     * Initialize the web driver session synchronously.
+     *
+     * @return void
+     */
+    protected function initializeSession(): void
+    {
+        $executor = $this->configureExecutor(
+            new HttpCommandExecutor($this->seleniumServerUrl, $this->httpProxy, $this->httpProxyPort),
+        );
+
+        $response = $executor->execute(WebDriverCommand::newSession($this->parameters()));
+        $value = $response->getValue();
+
+        $this->isW3cCompliant = isset($value['capabilities']);
+
+        $this->sessionCapabilities = $this->isW3cCompliant
+            ? DesiredCapabilities::createFromW3cCapabilities($value['capabilities'])
+            : new DesiredCapabilities($value['capabilities']);
+
+        $this->sessionId = $response->getSessionID();
+    }
+
+    /**
+     * Apply timeouts/configuration to the command executor.
+     *
+     * @param  HttpCommandExecutor  $executor
+     * @return HttpCommandExecutor
+     */
+    protected function configureExecutor(HttpCommandExecutor $executor): HttpCommandExecutor
+    {
+        if (!is_null($this->connectionTimeoutMs)) {
+            $executor->setConnectionTimeout($this->connectionTimeoutMs);
+        }
+
+        if (!is_null($this->requestTimeoutMs)) {
+            $executor->setRequestTimeout($this->requestTimeoutMs);
+        }
+
+        return $executor;
+    }
+
+    /**
+     * Convert desired/required capabilities into session parameters.
+     *
+     * @return array
+     */
+    protected function parameters(): array
+    {
+        // Set W3C parameters first
+        $parameters = [
+            'capabilities' => [
+                'firstMatch' => [
+                    (object) $this->desiredCapabilities->toW3cCompatibleArray(),
+                ],
+            ],
+        ];
+
+        // Handle *required* params
+        if ($this->requiredCapabilities && count($this->requiredCapabilities->toArray())) {
+            $parameters['capabilities']['alwaysMatch'] = (object) $this->requiredCapabilities->toW3cCompatibleArray();
+            $this->desiredCapabilities->setCapability('requiredCapabilities',
+                (object) $this->requiredCapabilities->toArray());
+        }
+
+        $parameters['desiredCapabilities'] = (object) $this->desiredCapabilities->toArray();
+
+        return $parameters;
+    }
+}

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -28,8 +28,11 @@ class DuskServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton(UrlGenerator::class, function (Application $app) {
+            $proxy = $app->make(ProxyServer::class);
+
             return new UrlGenerator(
-                endpoint: $app->make(ProxyServer::class)->url(),
+                proxyHostname: $proxy->host,
+                proxyPort: $proxy->port,
                 appHost: parse_url(config('app.url'), PHP_URL_HOST),
                 url: $app->make(UrlGeneratorContract::class),
             );

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -3,9 +3,13 @@
 namespace Laravel\Dusk;
 
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
+use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
+use Illuminate\Foundation\Application;
+use Illuminate\Routing\RouteCollectionInterface;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Dusk\Http\ProxyServer;
+use Laravel\Dusk\Http\UrlGenerator;
 use React\EventLoop\Loop;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 
@@ -20,6 +24,14 @@ class DuskServiceProvider extends ServiceProvider
                 factory: $app->make(HttpFoundationFactory::class),
                 host: config('dusk.proxy.host', '127.0.0.1'),
                 port: config('dusk.proxy.port', $this->findOpenPort(...)),
+            );
+        });
+
+        $this->app->singleton(UrlGenerator::class, function (Application $app) {
+            return new UrlGenerator(
+                endpoint: $app->make(ProxyServer::class)->url(),
+                appHost: parse_url(config('app.url'), PHP_URL_HOST),
+                url: $app->make(UrlGeneratorContract::class),
             );
         });
     }

--- a/src/Http/ProxyServer.php
+++ b/src/Http/ProxyServer.php
@@ -10,6 +10,7 @@ use React\EventLoop\LoopInterface;
 use React\EventLoop\TimerInterface;
 use React\Http\HttpServer as ReactHttpServer;
 use React\Http\Message\Response;
+use React\Http\Message\Uri;
 use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
 use React\Http\Middleware\RequestBodyBufferMiddleware;
 use React\Http\Middleware\RequestBodyParserMiddleware;
@@ -119,6 +120,8 @@ class ProxyServer
      */
     protected function handleRequest(ServerRequestInterface $psr_request): Promise|Response
     {
+        $psr_request = $psr_request->withUri(new Uri($psr_request->getQueryParams()['url']));
+
         // If this is just a request for a static asset, just stream that content back
         if ($static_response = $this->staticResponse($psr_request)) {
             return $static_response;

--- a/src/Http/ProxyServer.php
+++ b/src/Http/ProxyServer.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace Laravel\Dusk\Http;
+
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
+use React\Http\HttpServer as ReactHttpServer;
+use React\Http\Message\Response;
+use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
+use React\Http\Middleware\RequestBodyBufferMiddleware;
+use React\Http\Middleware\RequestBodyParserMiddleware;
+use React\Http\Middleware\StreamingRequestMiddleware;
+use React\Promise\Promise;
+use React\Socket\ConnectionInterface;
+use React\Socket\SocketServer;
+use React\Stream\ReadableResourceStream;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\Mime\MimeTypes;
+use Throwable;
+
+class ProxyServer
+{
+    /**
+     * The ReactPHP socket server instance.
+     *
+     * @var SocketServer
+     */
+    protected SocketServer $socket;
+
+    /**
+     * A count of active requests pending a response.
+     *
+     * @var int
+     */
+    protected int $requestsInFlight = 0;
+
+    /**
+     * All open TCP connections.
+     *
+     * @var ConnectionInterface[]
+     */
+    protected array $connections = [];
+
+    /**
+     * Whether the server is flushing active connections.
+     *
+     * @var bool
+     */
+    protected bool $flushing = false;
+
+    /**
+     * Proxy server constructor.
+     *
+     * @param  HttpKernel  $kernel
+     * @param  LoopInterface  $loop
+     * @param  HttpFoundationFactory  $factory
+     * @param  string  $host
+     * @param  int  $port
+     */
+    public function __construct(
+        protected HttpKernel $kernel,
+        protected LoopInterface $loop,
+        protected HttpFoundationFactory $factory,
+        protected string $host = '127.0.0.1',
+        protected int $port = 8099,
+    ) {
+    }
+
+    /**
+     * Start listening for incoming HTTP connections, and pass them thru the Kernel.
+     *
+     * @return $this
+     */
+    public function listen(): static
+    {
+        if (!isset($this->socket)) {
+            $this->socket = new SocketServer("{$this->host}:{$this->port}", [], $this->loop);
+
+            $this->socket->on('connection', function (ConnectionInterface $connection) {
+                $this->connections[] = $connection;
+            });
+
+            $server = new ReactHttpServer(
+                $this->loop,
+                new StreamingRequestMiddleware(),
+                new LimitConcurrentRequestsMiddleware(100),
+                new RequestBodyBufferMiddleware(32 * 1024 * 1024), // 32 MB
+                new RequestBodyParserMiddleware(32 * 1024 * 1024, 100), // 32 MB
+                $this->handleRequest(...),
+            );
+
+            $server->listen($this->socket);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the proxy server base URL.
+     *
+     * @return string
+     */
+    public function url(): string
+    {
+        return "http://{$this->host}:{$this->port}";
+    }
+
+    /**
+     * Handle the request.
+     *
+     * @param  ServerRequestInterface  $psr_request
+     * @return Promise|Response
+     */
+    protected function handleRequest(ServerRequestInterface $psr_request): Promise|Response
+    {
+        // If this is just a request for a static asset, just stream that content back
+        if ($static_response = $this->staticResponse($psr_request)) {
+            return $static_response;
+        }
+
+        $promise = $this->runRequestThroughKernel(
+            Request::createFromBase($this->factory->createRequest($psr_request)),
+        );
+
+        // Handle exception
+        $promise->catch(function (Throwable $exception) {
+            return Response::plaintext($exception->getMessage()."\n".$exception->getTraceAsString())
+                ->withStatus(Response::STATUS_INTERNAL_SERVER_ERROR);
+        });
+
+        return $promise;
+    }
+
+    /**
+     * Pass a dynamic request to the Kernel.
+     *
+     * @param  Request  $request
+     * @return Promise
+     */
+    protected function runRequestThroughKernel(Request $request): Promise
+    {
+        $this->requestsInFlight++;
+
+        return new Promise(function (callable $resolve) use ($request) {
+            $this->loop->futureTick(fn() => $this->loop->stop());
+
+            $response = $this->kernel->handle($request);
+
+            $resolve(new Response(
+                status: $response->getStatusCode(),
+                headers: $this->normalizeResponseHeaders($response->headers),
+                body: $this->getResponseContent($response),
+                version: $response->getProtocolVersion(),
+            ));
+
+            $this->kernel->terminate($request, $response);
+
+            $this->requestsInFlight--;
+        });
+    }
+
+    /**
+     * Extract the content from a Symfony response for async use.
+     *
+     * @param  SymfonyResponse  $response
+     * @return string
+     */
+    protected function getResponseContent(SymfonyResponse $response): string
+    {
+        ob_start();
+
+        $response->sendContent();
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Normalize Symfony headers for async use.
+     *
+     * @param  ResponseHeaderBag  $bag
+     * @return array
+     */
+    protected function normalizeResponseHeaders(ResponseHeaderBag $bag): array
+    {
+        $headers = $bag->all();
+
+        if (!empty($cookies = $bag->getCookies())) {
+            $headers['Set-Cookie'] = [];
+            foreach ($cookies as $cookie) {
+                $headers['Set-Cookie'][] = (string) $cookie;
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Return a static response if the request is for a public asset.
+     *
+     * @param  ServerRequestInterface  $request
+     * @return Promise|null
+     */
+    protected function staticResponse(ServerRequestInterface $request): ?Promise
+    {
+        $path = $request->getUri()->getPath();
+
+        if (Str::contains($path, '../')) {
+            return null;
+        }
+
+        $filepath = public_path($path);
+
+        if (file_exists($filepath) && !is_dir($filepath)) {
+            $this->requestsInFlight++;
+
+            return new Promise(function (callable $resolve) use ($filepath) {
+                $resolve(new Response(status: 200, headers: [
+                    'Content-Type' => match (pathinfo($filepath, PATHINFO_EXTENSION)) {
+                        'css' => 'text/css',
+                        'js' => 'application/javascript',
+                        'png' => 'image/png',
+                        'jpg', 'jpeg' => 'image/jpeg',
+                        'svg' => 'image/svg+xml',
+                        'woff' => 'font/woff',
+                        'woff2' => 'font/woff2',
+                        'eot' => 'application/vnd.ms-fontobject',
+                        'ttf' => 'font/ttf',
+                        default => (new MimeTypes())->guessMimeType($filepath),
+                    },
+                ], body: new ReadableResourceStream(fopen($filepath, 'r'))));
+
+                $this->requestsInFlight--;
+            });
+        }
+
+        return null;
+    }
+
+    /**
+     * Flush pending requests and close all connections.
+     *
+     * @return void
+     */
+    public function flush(): void
+    {
+        if ($this->flushing) {
+            return;
+        }
+
+        $this->flushing = true;
+
+        $this->loop->addPeriodicTimer(0.1, function (TimerInterface $timer) {
+            if ($this->requestsInFlight === 0) {
+                foreach ($this->connections as $connection) {
+                    $connection->close();
+                }
+                $this->connections = [];
+                $this->socket->close();
+                $this->loop->cancelTimer($timer);
+            }
+        });
+
+        $this->loop->run();
+    }
+
+    /**
+     * Ensure that connections are flushed when server is destroyed.
+     */
+    public function __destruct()
+    {
+        $this->flush();
+    }
+}

--- a/src/Http/UrlGenerator.php
+++ b/src/Http/UrlGenerator.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Laravel\Dusk\Http;
+
+use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
+use Illuminate\Support\Traits\ForwardsCalls;
+
+/**
+ * @method string query(string $path, array $query = [], mixed $extra = [], bool|null $secure = null)
+ */
+class UrlGenerator implements UrlGeneratorContract
+{
+    use ForwardsCalls;
+
+    public function __construct(
+        protected string $endpoint,
+        protected string $appHost,
+        protected UrlGeneratorContract $url,
+    ) {
+    }
+
+    public function current()
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    public function previous($fallback = false)
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    public function to($path, $extra = [], $secure = null)
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    public function secure($path, $parameters = [])
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    public function asset($path, $secure = null)
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    public function route($name, $parameters = [], $absolute = true)
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    public function signedRoute($name, $parameters = [], $expiration = null, $absolute = true)
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    public function temporarySignedRoute($name, $expiration, $parameters = [], $absolute = true)
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    public function action($action, $parameters = [], $absolute = true)
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    public function getRootControllerNamespace()
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    public function setRootControllerNamespace($rootNamespace)
+    {
+        return $this->__call(__FUNCTION__, func_get_args());
+    }
+
+    public function proxy(string $url): string
+    {
+        // TODO: Provide a way to register a callback that allows for more complex matching
+
+        $host = parse_url($url, PHP_URL_HOST);
+
+        return $host === $this->appHost
+            ? $this->endpoint.'?url='.urlencode($url)
+            : $url;
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+        $result = $this->forwardDecoratedCallTo($this->url, $name, $arguments);
+
+        if (is_string($result) && filter_var($result, FILTER_VALIDATE_URL)) {
+            return $this->proxy($result);
+        }
+
+        return $result;
+    }
+}

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -8,10 +8,13 @@ use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Illuminate\Foundation\Testing\TestCase as FoundationTestCase;
 use Laravel\Dusk\Chrome\SupportsChrome;
 use Laravel\Dusk\Concerns\ProvidesBrowser;
+use Laravel\Dusk\Concerns\ProvidesProxyServer;
+use Laravel\Dusk\Driver\AsyncWebDriver;
+use Laravel\Dusk\Driver\AsyncWebDriverFactory;
 
 abstract class TestCase extends FoundationTestCase
 {
-    use ProvidesBrowser, SupportsChrome;
+    use ProvidesBrowser, ProvidesProxyServer, SupportsChrome;
 
     /**
      * Register the base URL with Dusk.
@@ -38,11 +41,11 @@ abstract class TestCase extends FoundationTestCase
     /**
      * Create the RemoteWebDriver instance.
      *
-     * @return \Facebook\WebDriver\Remote\RemoteWebDriver
+     * @return \Laravel\Dusk\Driver\AsyncWebDriver
      */
     protected function driver()
     {
-        return RemoteWebDriver::create(
+        return AsyncWebDriver::create(
             $_ENV['DUSK_DRIVER_URL'] ?? env('DUSK_DRIVER_URL') ?? 'http://localhost:9515',
             DesiredCapabilities::chrome()
         );

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -4,8 +4,8 @@ namespace Tests;
 
 use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
-use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Illuminate\Support\Collection;
+use Laravel\Dusk\Driver\AsyncWebDriver;
 use Laravel\Dusk\TestCase as BaseTestCase;
 use PHPUnit\Framework\Attributes\BeforeClass;
 
@@ -25,13 +25,14 @@ abstract class DuskTestCase extends BaseTestCase
     }
 
     /**
-     * Create the RemoteWebDriver instance.
+     * Create the AsyncWebDriver instance.
      */
-    protected function driver(): RemoteWebDriver
+    protected function driver(): AsyncWebDriver
     {
         $options = (new ChromeOptions)->addArguments(collect([
             $this->shouldStartMaximized() ? '--start-maximized' : '--window-size=1920,1080',
             '--disable-search-engine-choice-screen',
+            '--disable-smooth-scrolling',
         ])->unless($this->hasHeadlessDisabled(), function (Collection $items) {
             return $items->merge([
                 '--disable-gpu',
@@ -39,7 +40,7 @@ abstract class DuskTestCase extends BaseTestCase
             ]);
         })->all());
 
-        return RemoteWebDriver::create(
+        return AsyncWebDriver::create(
             $_ENV['DUSK_DRIVER_URL'] ?? env('DUSK_DRIVER_URL') ?? 'http://localhost:9515',
             DesiredCapabilities::chrome()->setCapability(
                 ChromeOptions::CAPABILITY, $options

--- a/tests/Browser/DuskTestCase.php
+++ b/tests/Browser/DuskTestCase.php
@@ -7,6 +7,7 @@ use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Illuminate\Support\Collection;
 use Laravel\Dusk\Browser;
+use Laravel\Dusk\Driver\AsyncWebDriver;
 use Laravel\Dusk\TestCase;
 use Orchestra\Testbench\Concerns\CreatesApplication;
 use PHPUnit\Framework\Attributes\BeforeClass;
@@ -58,6 +59,7 @@ class DuskTestCase extends TestCase
         $options = (new ChromeOptions)->addArguments(collect([
             $this->shouldStartMaximized() ? '--start-maximized' : '--window-size=1920,1080',
             '--disable-search-engine-choice-screen',
+            '--disable-smooth-scrolling',
         ])->unless($this->hasHeadlessDisabled(), function (Collection $items) {
             return $items->merge([
                 '--disable-gpu',
@@ -65,11 +67,9 @@ class DuskTestCase extends TestCase
             ]);
         })->all());
 
-        return RemoteWebDriver::create(
+        return AsyncWebDriver::create(
             $_ENV['DUSK_DRIVER_URL'] ?? 'http://localhost:9515',
-            DesiredCapabilities::chrome()->setCapability(
-                ChromeOptions::CAPABILITY, $options
-            )
+                DesiredCapabilities::chrome()->setCapability(ChromeOptions::CAPABILITY, $options)
         );
     }
 


### PR DESCRIPTION
Right now, Dusk makes requests to a separate server process. This has a few downsides:

1. Test setup needs to run via special `_dusk/` routes rather than using normal factories/setup
2. Special `.env.dusk` handling is necessary
3. Certain testing affordances, like `RefreshDatabase`, aren't available
4. Dusk tests need, generally, to be treated differently from other tests

This *proof-of-concept* adds an HTTP server and custom web driver implementation that lets us handle the entire Dusk lifecycle inside our test process. This allows us to treat incoming browser requests as though they were the same as `$this->get(...)` or `$this->post(...)` right in the test case.

#### Considerations

For the most part, this is a pretty minimal change for the impact it could have. That said, there are a few things to consider:

1. Right now I'm essentially translating `https://demo-app.test/profile` into `http://localhost:8099/profile`. This doesn't account for things like domain-routing. Probably the easiest solution is to just pass the entire request as a query string, so something like `http://localhost:8099/?url=https://demo-app.test/profile`. This shouldn't be that hard, but might need some further thought.
2. There's a bunch of code that could/should be removed. Things like `Laravel\Dusk\Http\Controllers\UserController` which is no longer necessary with this approach, and the logic around `.env.dusk` that is also not necessary. Before I go ahead and make the diff that much larger, I'd like a little bit of community/maintainer feedback.
3. Overall, this is changing how Dusk works pretty significantly. That said, it should be fairly backwards compatible, and I think the upside is well worth it, but I get it if there's not appetite to introduce a big breaking change.

If anyone out there has a big Dusk testsuite that they want to try this with, I'd love some real-world feedback!

#### How to test

If you don't have `repositories` key in your `composer.json` file, add one, and then add my fork to it.

```json
"repositories": [
  {
    "type": "vcs",
    "url": "https://github.com/inxilpro/laravel-dusk-fork"
  }
]
```

Then, install my branch:

```sh
composer require laravel/dusk:dev-proxy-requests --dev
```

Finally, if you `DuskTestCase` implements the `driver()` method, you need to swap `Facebook\WebDriver\Remote\RemoteWebDriver` for `Laravel\Dusk\Driver\AsyncWebDriver`.