### PR TITLE
Allows Chrome driver's path to be configured

### DIFF
--- a/config/dusk.php
+++ b/config/dusk.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Dusk driver path
+    |--------------------------------------------------------------------------
+    |
+    | This value holds the path where the chrome's driver will be installed
+    | when the command dusk:chrome-driver is run.
+    | You typically don't need to change this path, but there may be some
+    | situation when you need to change it, for instance if you build a phar
+    | standalone app.
+    |
+    */
+
+    'driver_path' => env('DUSK_DRIVER_PATH', __DIR__.'/../bin'),
+
+];

--- a/src/Chrome/ChromeProcess.php
+++ b/src/Chrome/ChromeProcess.php
@@ -47,7 +47,7 @@ class ChromeProcess
                 'win' => 'chromedriver-win.exe',
             ];
 
-            $driver = __DIR__.'/../../bin'.DIRECTORY_SEPARATOR.$filenames[$this->operatingSystemId()];
+            $driver = config('dusk.driver_path').DIRECTORY_SEPARATOR.$filenames[$this->operatingSystemId()];
         }
 
         $this->driver = realpath($driver);

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -76,7 +76,7 @@ class ChromeDriverCommand extends Command
      *
      * @var string
      */
-    protected $directory = __DIR__.'/../../bin/';
+    protected $directory;
 
     /**
      * Execute the console command.
@@ -85,6 +85,8 @@ class ChromeDriverCommand extends Command
      */
     public function handle()
     {
+        $this->directory = config('dusk.driver_path').DIRECTORY_SEPARATOR;
+
         $version = $this->version();
 
         $all = $this->option('all');

--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -48,6 +48,20 @@ class DuskServiceProvider extends ServiceProvider
                 Console\ComponentCommand::class,
                 Console\ChromeDriverCommand::class,
             ]);
+
+            $this->publishes([
+                __DIR__.'/../config/dusk.php' => config_path('dusk.php'),
+            ], 'config');
         }
+    }
+
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../config/dusk.php', 'dusk');
     }
 }


### PR DESCRIPTION
Allows to customize Chrome driver path using a `dusk.php` configuration file. Can be useful when building a phar standalone app (ie. Laravel-zero)

Implements #1006