### PR TITLE
[8.x] do not pause initially while waiting for an element

### DIFF
--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -393,8 +393,6 @@ trait WaitsForElements
     {
         $seconds = is_null($seconds) ? static::$waitSeconds : $seconds;
 
-        $this->pause($interval);
-
         $this->driver->wait($seconds, $interval)->until(
             function ($driver) use ($callback) {
                 try {


### PR DESCRIPTION
Currently the `waitFor` calls are pausing for `$interval` before checking that an element is visible. In a lot of cases this pause is obsolete because the element could be visible initially. 

Potentially this could speed up many tests where a lot of `waitFor` calls are done while elements are visible initially. 