### PR TITLE
Fix resolver not formatting properly when selector has a closing parenthesis

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -410,7 +410,7 @@ class ElementResolver
         );
 
         if (Str::startsWith($selector, '@') && $selector === $originalSelector) {
-            $selector = preg_replace('/@(\S+)/', '['.Dusk::$selectorHtmlAttribute.'="$1"]', $selector);
+            $selector = preg_replace('/@([^\s\)]+)/', '['.Dusk::$selectorHtmlAttribute.'="$1"]', $selector);
         }
 
         return trim($this->prefix.' '.$selector);

--- a/tests/Unit/ElementResolverTest.php
+++ b/tests/Unit/ElementResolverTest.php
@@ -150,6 +150,12 @@ class ElementResolverTest extends TestCase
         $this->assertSame('prefix [dusk="missing-element"] > div', $resolver->format('@missing-element > div'));
     }
 
+    public function test_format_does_not_capture_closing_parenthesis_in_dusk_selector()
+    {
+        $resolver = new ElementResolver(new stdClass, 'prefix');
+        $this->assertSame('prefix [dusk="products"] div:nth-child(2 of [dusk="product"])', $resolver->format('@products div:nth-child(2 of @product)'));
+    }
+
     public function test_find_by_id_with_colon()
     {
         $driver = m::mock(stdClass::class);


### PR DESCRIPTION
I'm trying to do something like this:

```php
$browser->assertSeeIn('@products div:nth-child(2 of @product)', '...');
```

The selector resolves into a broken selector where the closing parenthesis from `@product)` is included in the dusk attribute because the current pattern is `@(\S+)`.

```
body [dusk="products"] div:nth-child(2 of [dusk="product)"]
```

With the new pattern `@([^\s\)]+)`, we get a fully functional selector:

```
body [dusk="products"] div:nth-child(2 of [dusk="product"])
```
