### PR TITLE
[8.x] Return JSON response from auth endpoints to prevent browser race condition in fast CI environments

### DIFF
--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -47,7 +47,7 @@ class UserController
 
         Auth::guard($guard)->login($user);
 
-        return response(status: 204);
+        return response()->json();
     }
 
     /**
@@ -64,7 +64,7 @@ class UserController
 
         Session::forget('password_hash_'.$guard);
 
-        return response(status: 204);
+        return response()->json();
     }
 
     /**

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -64,9 +64,7 @@ class UserController
 
         Session::forget('password_hash_'.$guard);
 
-        Session::save();
-
-        return response(status: 204);
+        return response()->json();
     }
 
     /**

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -47,7 +47,7 @@ class UserController
 
         Auth::guard($guard)->login($user);
 
-        return response()->json();
+        return response(status: 204);
     }
 
     /**
@@ -64,7 +64,9 @@ class UserController
 
         Session::forget('password_hash_'.$guard);
 
-        return response()->json();
+        Session::save();
+
+        return response(status: 204);
     }
 
     /**


### PR DESCRIPTION
When using fast CI runners browser tests can flake because loginAs() and logout() use visit() to hit endpoints that return 204. 

The browser receives the 204 but has no page load event to wait for, so the WebDriver considers the navigation complete immediately and fires the next command before the browser has fully processed and stored the session cookie.

Changing the response from 204 to 200 gives the browser a proper response to settle on. It was originally 204 to prevent favicon errors, but by doing json() we ensure the content-type is json - so no favicons requested :) 

Here's a real example... (all three are in the same second)  
```
127.0.0.1 - - [24/Feb/2026:21:02:03 +0000] "GET /_dusk/logout HTTP/2.0" 204 1138 "-" "Laravel/Dusk"
127.0.0.1 - - [24/Feb/2026:21:02:03 +0000] "GET /item/1 HTTP/2.0" 302 1477 "-" "Laravel/Dusk"
127.0.0.1 - - [24/Feb/2026:21:02:03 +0000] "GET /login HTTP/2.0" 200 2066 "-" "Laravel/Dusk"
```

I have an override for this in my project which seems to work..