### PR TITLE
[8.x] Remove 204 response and instead be explicit with ignores

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -491,8 +491,7 @@ class Browser
     {
         if (in_array($this->driver->getCapabilities()->getBrowserName(), static::$supportsRemoteLogs)) {
             $console = collect($this->driver->manage()->getLog('browser'))
-                ->reject(fn ($entry) => str(($entry['message'] ?? ''))
-                    ->contains(static::$ignoreConsoleMessages))
+                ->reject(fn ($entry) => Str::contains($entry['message'] ?? '', static::$ignoreConsoleMessages))
                 ->values()
                 ->all();
 

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -86,6 +86,15 @@ class Browser
     public static $storeSourceAt;
 
     /**
+     * Console log messages to ignore when storing console logs.
+     *
+     * @var array
+     */
+    public static $ignoreConsoleMessages = [
+        'favicon.ico',
+    ];
+
+    /**
      * The browsers that support retrieving logs.
      *
      * @var array
@@ -481,7 +490,11 @@ class Browser
     public function storeConsoleLog($name)
     {
         if (in_array($this->driver->getCapabilities()->getBrowserName(), static::$supportsRemoteLogs)) {
-            $console = $this->driver->manage()->getLog('browser');
+            $console = collect($this->driver->manage()->getLog('browser'))
+                ->reject(fn ($entry) => str(($entry['message'] ?? ''))
+                    ->contains(static::$ignoreConsoleMessages))
+                ->values()
+                ->all();
 
             if (! empty($console)) {
                 $filePath = sprintf('%s/%s.log', rtrim(static::$storeConsoleLogAt, '/'), $name);

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -33,6 +33,7 @@ class UserController
      *
      * @param  string  $userId
      * @param  string|null  $guard
+     * @return void
      */
     public function login($userId, $guard = null)
     {
@@ -51,6 +52,7 @@ class UserController
      * Log the user out of the application.
      *
      * @param  string|null  $guard
+     * @return void
      */
     public function logout($guard = null)
     {

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -46,8 +46,6 @@ class UserController
                     : $provider->retrieveById($userId);
 
         Auth::guard($guard)->login($user);
-
-        return response(status: 204);
     }
 
     /**
@@ -63,8 +61,6 @@ class UserController
         Auth::guard($guard)->logout();
 
         Session::forget('password_hash_'.$guard);
-
-        return response(status: 204);
     }
 
     /**

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -33,7 +33,6 @@ class UserController
      *
      * @param  string  $userId
      * @param  string|null  $guard
-     * @return \Illuminate\Http\Response
      */
     public function login($userId, $guard = null)
     {
@@ -52,7 +51,6 @@ class UserController
      * Log the user out of the application.
      *
      * @param  string|null  $guard
-     * @return \Illuminate\Http\Response
      */
     public function logout($guard = null)
     {

--- a/tests/Unit/BrowserTest.php
+++ b/tests/Unit/BrowserTest.php
@@ -314,6 +314,21 @@ class BrowserTest extends TestCase
         $this->assertTrue($this->browser->fitOnFailure);
     }
 
+    public function test_ignores_favicon_console_messages()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('manage->getLog')->with('browser')->andReturn([
+            ['message' => 'https://example.com/favicon.ico - Failed to load resource: the server responded with a status of 404 ()', 'level' => 'SEVERE'],
+        ]);
+        $driver->shouldReceive('getCapabilities->getBrowserName')->andReturn(WebDriverBrowserType::CHROME);
+        $browser = new Browser($driver);
+        Browser::$storeConsoleLogAt = sys_get_temp_dir();
+
+        $browser->storeConsoleLog('ignore-test');
+
+        $this->assertFileDoesNotExist(sys_get_temp_dir().'/ignore-test.log');
+    }
+
     public function test_source_code_can_be_stored()
     {
         $this->driver->shouldReceive('getPageSource')->andReturn('source content');


### PR DESCRIPTION
Ive had loaaads of flaky tests which made me deep dive this..

The login and logout routes were returning a 204 No Content response. This was originally added to suppress favicon.ico 404 errors appearing in the browser console log via https://github.com/laravel/dusk/pull/1061

However, the browser treats a 204 as a "no navigation" response, which means in fast CI it sees it and immediately continues without waiting for the session to be updated. This can cause a race condition see below of my access log:

```
127.0.0.1 - - [24/Feb/2026:21:02:03 +0000] "GET /_dusk/logout HTTP/2.0" 204 1138 "-" "Laravel/Dusk"
127.0.0.1 - - [24/Feb/2026:21:02:03 +0000] "GET /item/1 HTTP/2.0" 302 1477 "-" "Laravel/Dusk" // This should be logged in... but its been sent away :( 
127.0.0.1 - - [24/Feb/2026:21:02:03 +0000] "GET /login HTTP/2.0" 200 2066 "-" "Laravel/Dusk"
``` 


Rather than do a 204 response which causes flakiness, I've just added a way to ignore specific messages, which ignores favicon issues from the browser log, and it also means users can tap into it too.   The alternative is to just drop the response and let users worry about the log, but felt nice to add a way to tap into as its prevented atm

TLDR is this stops a huge amount of flaky tests 

I've ran this with a local branch for the past few hours and had no flaky tests, where as usually we'd have to re-run the tests 2-5 times per time.