### PR TITLE
Proxy empty text passed to `assertSeeIn()`

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -175,6 +175,10 @@ trait MakesAssertions
      */
     public function assertSeeIn($selector, $text, $ignoreCase = false)
     {
+        if ($text === '') {
+            return $this->assertSeeNothingIn($selector);
+        }
+
         $fullSelector = $this->resolver->format($selector);
 
         $element = $this->resolver->findOrFail($selector);


### PR DESCRIPTION
Wanna avoid this particular style of ugliness in our Dusk tests, while we give them some love on a gentle path to Pest 4:

```php
if ($started === '') {
    $browser->assertSeeNothingIn('td[data-result-started]');
} else {
    $browser->assertSeeIn('td[data-result-started]', $started);
}
```

@taylorotwell juice is hand-squeezed already, don't mind whether you savour it, or pour it away 🤣 
