### PR TITLE
[8.x] Fix typo in teardown method name

### DIFF
--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -256,7 +256,7 @@ class DuskCommand extends Command
         try {
             return $callback();
         } finally {
-            $this->teardownDuskEnviroment();
+            $this->teardownDuskEnvironment();
         }
     }
 
@@ -331,7 +331,7 @@ class DuskCommand extends Command
             pcntl_async_signals(true);
 
             pcntl_signal(SIGINT, function () {
-                $this->teardownDuskEnviroment();
+                $this->teardownDuskEnvironment();
             });
         }
     }
@@ -341,7 +341,7 @@ class DuskCommand extends Command
      *
      * @return void
      */
-    protected function teardownDuskEnviroment()
+    protected function teardownDuskEnvironment()
     {
         $this->removeConfiguration();
 


### PR DESCRIPTION
## Summary

- Fixes typo `teardownDuskEnviroment` → `teardownDuskEnvironment` (missing 'n' in Environment)
- Affects the method definition and both call sites in `DuskCommand.php`

Fixes #1190