### PR TITLE
[8.x] Fix docblock typo in assertVueContains

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -1140,7 +1140,7 @@ JS;
     }
 
     /**
-     * Assert that a given Vue component data propertys is an array and contains the given value.
+     * Assert that a given Vue component data property is an array and contains the given value.
      *
      * @param  string  $key
      * @param  string  $value


### PR DESCRIPTION
## Summary

- Fix `propertys` → `property` in `MakesAssertions.php` docblock for `assertVueContains()`