### PR TITLE
[8.x] Support multiple elements in assertSeeIn and related assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased](https://github.com/laravel/dusk/compare/v8.4.1...8.x)
 
+* [8.x] Support multiple elements in `assertSeeIn` and related assertions by [@JoshSalway](https://github.com/JoshSalway) in https://github.com/laravel/dusk/pull/1194
+
+#### Breaking Changes
+
+`assertSeeIn`, `assertDontSeeIn`, `assertSeeAnythingIn`, and `assertSeeNothingIn` now check **all** elements matching the selector instead of only the first. Tests using `assertDontSeeIn` or `assertSeeNothingIn` with selectors that match multiple elements may now fail if a non-first element contains the text. To preserve old behavior, narrow your selector to match a single element (e.g. `.row:first-child` or `#specific-id`).
+
 ## [v8.4.1](https://github.com/laravel/dusk/compare/v8.4.0...v8.4.1) - 2026-03-10
 
 * [8.x] Makes imports consistent by [@nunomaduro](https://github.com/nunomaduro) in https://github.com/laravel/dusk/pull/1188

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -181,10 +181,16 @@ trait MakesAssertions
 
         $fullSelector = $this->resolver->format($selector);
 
-        $element = $this->resolver->findOrFail($selector);
+        $elements = $this->resolver->allOrFail($selector);
+
+        foreach ($elements as $element) {
+            if (Str::contains($element->getText(), $text, $ignoreCase)) {
+                return $this;
+            }
+        }
 
         PHPUnit::assertTrue(
-            Str::contains($element->getText(), $text, $ignoreCase),
+            false,
             "Did not see expected text [{$text}] within element [{$fullSelector}]."
         );
 
@@ -203,12 +209,14 @@ trait MakesAssertions
     {
         $fullSelector = $this->resolver->format($selector);
 
-        $element = $this->resolver->findOrFail($selector);
+        $elements = $this->resolver->allOrFail($selector);
 
-        PHPUnit::assertFalse(
-            Str::contains($element->getText(), $text, $ignoreCase),
-            "Saw unexpected text [{$text}] within element [{$fullSelector}]."
-        );
+        foreach ($elements as $element) {
+            PHPUnit::assertFalse(
+                Str::contains($element->getText(), $text, $ignoreCase),
+                "Saw unexpected text [{$text}] within element [{$fullSelector}]."
+            );
+        }
 
         return $this;
     }
@@ -223,10 +231,16 @@ trait MakesAssertions
     {
         $fullSelector = $this->resolver->format($selector);
 
-        $element = $this->resolver->findOrFail($selector);
+        $elements = $this->resolver->allOrFail($selector);
+
+        foreach ($elements as $element) {
+            if ($element->getText() !== '') {
+                return $this;
+            }
+        }
 
         PHPUnit::assertTrue(
-            $element->getText() !== '',
+            false,
             "Saw unexpected text [''] within element [{$fullSelector}]."
         );
 
@@ -243,12 +257,14 @@ trait MakesAssertions
     {
         $fullSelector = $this->resolver->format($selector);
 
-        $element = $this->resolver->findOrFail($selector);
+        $elements = $this->resolver->allOrFail($selector);
 
-        PHPUnit::assertTrue(
-            $element->getText() === '',
-            "Did not see expected text [''] within element [{$fullSelector}]."
-        );
+        foreach ($elements as $element) {
+            PHPUnit::assertTrue(
+                $element->getText() === '',
+                "Did not see expected text [''] within element [{$fullSelector}]."
+            );
+        }
 
         return $this;
     }

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -383,6 +383,25 @@ class ElementResolver
     }
 
     /**
+     * Find all elements by the given selector or throw an exception.
+     *
+     * @param  string  $selector
+     * @return \Facebook\WebDriver\Remote\RemoteWebElement[]
+     *
+     * @throws \Facebook\WebDriver\Exception\NoSuchElementException
+     */
+    public function allOrFail($selector)
+    {
+        $elements = $this->all($selector);
+
+        if (empty($elements)) {
+            $this->findOrFail($selector);
+        }
+
+        return $elements;
+    }
+
+    /**
      * Find the elements by the given selector or return an empty array.
      *
      * @param  string  $selector

--- a/tests/Unit/ElementResolverTest.php
+++ b/tests/Unit/ElementResolverTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Dusk\Tests\Unit;
 
+use Facebook\WebDriver\Exception\NoSuchElementException;
 use InvalidArgumentException;
 use Laravel\Dusk\ElementResolver;
 use Mockery as m;
@@ -229,5 +230,35 @@ class ElementResolverTest extends TestCase
         $result = $method->invoke($resolver, 'Create');
 
         $this->assertSame($button, $result);
+    }
+
+    public function test_all_or_fail_returns_elements()
+    {
+        $element1 = m::mock(stdClass::class);
+        $element2 = m::mock(stdClass::class);
+
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('findElements')->andReturn([$element1, $element2]);
+
+        $resolver = new ElementResolver($driver);
+
+        $result = $resolver->allOrFail('div');
+
+        $this->assertCount(2, $result);
+        $this->assertSame($element1, $result[0]);
+        $this->assertSame($element2, $result[1]);
+    }
+
+    public function test_all_or_fail_throws_when_no_elements()
+    {
+        $driver = m::mock(stdClass::class);
+        $driver->shouldReceive('findElements')->andReturn([]);
+        $driver->shouldReceive('findElement')->andThrow(new NoSuchElementException('No element found'));
+
+        $resolver = new ElementResolver($driver);
+
+        $this->expectException(NoSuchElementException::class);
+
+        $resolver->allOrFail('div');
     }
 }

--- a/tests/Unit/MakesAssertionsTest.php
+++ b/tests/Unit/MakesAssertionsTest.php
@@ -1323,7 +1323,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('')->andReturn('body');
-        $resolver->shouldReceive('findOrFail')->with('')->andReturn($element);
+        $resolver->shouldReceive('allOrFail')->with('')->andReturn([$element]);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1348,7 +1348,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('')->andReturn('body');
-        $resolver->shouldReceive('findOrFail')->with('')->andReturn($element);
+        $resolver->shouldReceive('allOrFail')->with('')->andReturn([$element]);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1373,7 +1373,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
-        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $resolver->shouldReceive('allOrFail')->with('foo')->andReturn([$element]);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1389,6 +1389,38 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_see_in_with_multiple_elements()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element1 = m::mock(stdClass::class);
+        $element1->shouldReceive('getText')->andReturn('First');
+
+        $element2 = m::mock(stdClass::class);
+        $element2->shouldReceive('getText')->andReturn('Second');
+
+        $element3 = m::mock(stdClass::class);
+        $element3->shouldReceive('getText')->andReturn('Third');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('div')->andReturn('body div');
+        $resolver->shouldReceive('allOrFail')->with('div')->andReturn([$element1, $element2, $element3]);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertSeeIn('div', 'Second');
+        $browser->assertSeeIn('div', 'Third');
+
+        try {
+            $browser->assertSeeIn('div', 'Fourth');
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Did not see expected text [Fourth] within element [body div].',
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_dont_see_in()
     {
         $driver = m::mock(stdClass::class);
@@ -1398,7 +1430,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
-        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $resolver->shouldReceive('allOrFail')->with('foo')->andReturn([$element]);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1414,6 +1446,34 @@ class MakesAssertionsTest extends TestCase
         }
     }
 
+    public function test_assert_dont_see_in_with_multiple_elements()
+    {
+        $driver = m::mock(stdClass::class);
+
+        $element1 = m::mock(stdClass::class);
+        $element1->shouldReceive('getText')->andReturn('First');
+
+        $element2 = m::mock(stdClass::class);
+        $element2->shouldReceive('getText')->andReturn('Second');
+
+        $resolver = m::mock(stdClass::class);
+        $resolver->shouldReceive('format')->with('div')->andReturn('body div');
+        $resolver->shouldReceive('allOrFail')->with('div')->andReturn([$element1, $element2]);
+
+        $browser = new Browser($driver, $resolver);
+
+        $browser->assertDontSeeIn('div', 'Third');
+
+        try {
+            $browser->assertDontSeeIn('div', 'Second');
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString(
+                'Saw unexpected text [Second] within element [body div].',
+                $e->getMessage()
+            );
+        }
+    }
+
     public function test_assert_see_empty_text_in_element_with_empty_text()
     {
         $driver = m::mock(stdClass::class);
@@ -1423,7 +1483,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
-        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $resolver->shouldReceive('allOrFail')->with('foo')->andReturn([$element]);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1439,7 +1499,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
-        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $resolver->shouldReceive('allOrFail')->with('foo')->andReturn([$element]);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1462,7 +1522,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
-        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $resolver->shouldReceive('allOrFail')->with('foo')->andReturn([$element]);
 
         $browser = new Browser($driver, $resolver);
 
@@ -1485,7 +1545,7 @@ class MakesAssertionsTest extends TestCase
 
         $resolver = m::mock(stdClass::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
-        $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $resolver->shouldReceive('allOrFail')->with('foo')->andReturn([$element]);
 
         $browser = new Browser($driver, $resolver);
 

--- a/tests/Unit/WaitsForElementsTest.php
+++ b/tests/Unit/WaitsForElementsTest.php
@@ -32,6 +32,7 @@ class WaitsForElementsTest extends TestCase
             return new WebDriverWait($driver, $seconds, $interval);
         });
         $driver->shouldReceive('findElement')->andReturn($element);
+        $driver->shouldReceive('findElements')->andReturn([$element]);
 
         $resolver = m::mock(ElementResolver::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
@@ -401,6 +402,7 @@ class WaitsForElementsTest extends TestCase
         $resolver = m::mock(ElementResolver::class);
         $resolver->shouldReceive('format')->with('foo')->andReturn('body foo');
         $resolver->shouldReceive('findOrFail')->with('foo')->andReturn($element);
+        $resolver->shouldReceive('allOrFail')->with('foo')->andReturn([$element]);
 
         $browser = new Browser($driver, $resolver);
 


### PR DESCRIPTION
## Summary

Fixes #1150

When a CSS selector matches multiple elements, `assertSeeIn()` and related methods now check **all** matched elements instead of only the first one.

### Behavior

| Method | Old behavior | New behavior |
|--------|-------------|--------------|
| `assertSeeIn` | Checks first element only | Passes if text found in **any** matched element |
| `assertDontSeeIn` | Checks first element only | Passes if text found in **none** of the matched elements |
| `assertSeeAnythingIn` | Checks first element only | Passes if **any** matched element has non-empty text |
| `assertSeeNothingIn` | Checks first element only | Passes if **all** matched elements have empty text |

When a selector matches a single element, behavior is identical to before.

### ⚠️ Breaking Changes

This is a bugfix, but tests that relied on the old (incorrect) behavior may now fail. Specifically:

**`assertDontSeeIn` is the highest risk.** Tests like this were silently wrong and will now correctly fail:

```php
// Old: only checked the first .row — passed even if a later .row contained "Error"
// New: checks ALL .row elements — fails if ANY contains "Error"
$browser->assertDontSeeIn('.row', 'Error');
```

**`assertSeeNothingIn`** may also surface false passes if a non-first matched element has text.

**`assertSeeIn` / `assertSeeAnythingIn`** are low risk — these would have been producing false negatives (failing when they should pass), so existing passing tests will continue to pass.

**Fix for affected tests:** Narrow the selector to match a single element:

```php
// Before (ambiguous — matches multiple elements)
$browser->assertDontSeeIn('.row', 'Error');

// After (specific — matches exactly one element)
$browser->assertDontSeeIn('.row:first-child', 'Error');
// or
$browser->assertDontSeeIn('#specific-row', 'Error');
```

Recommend noting this in the upgrade guide for the next release.

### Before / After

Given:
```html
<div id="app">
    <div>First</div>
    <div>Second</div>
    <div>Third</div>
</div>
```

| Assertion | Stock Dusk | This PR |
|-----------|:---------:|:-------:|
| `assertSeeIn('#app > div', 'First')` | ✅ | ✅ |
| `assertSeeIn('#app > div', 'Second')` | ❌ | ✅ |
| `assertSeeIn('#app > div', 'Third')` | ❌ | ✅ |
| `assertDontSeeIn('#app > div', 'Missing')` | ✅ | ✅ |
| `assertSeeIn('#unique-id', 'text')` | ✅ | ✅ |

Real-world table column example from the issue:
```php
// First column names across 3 rows — stock Dusk only checks row 1
$browser->assertSeeIn('#table > tbody > tr > td:nth-child(1) > span', 'Alice');   // ✅ both
$browser->assertSeeIn('#table > tbody > tr > td:nth-child(1) > span', 'Bob');     // ❌ stock, ✅ this PR
$browser->assertSeeIn('#table > tbody > tr > td:nth-child(1) > span', 'Charlie'); // ❌ stock, ✅ this PR
```

### Changes

- **`ElementResolver::allOrFail()`** — new method returning all matching elements, throwing `NoSuchElementException` if none found
- Updated `assertSeeIn`, `assertDontSeeIn`, `assertSeeAnythingIn`, `assertSeeNothingIn` to iterate all matched elements
- Error messages unchanged for backward compatibility

### Testing

All 202 existing unit tests pass, plus 4 new tests added:
- `test_assert_see_in_with_multiple_elements`
- `test_assert_dont_see_in_with_multiple_elements`
- `test_all_or_fail_returns_elements`
- `test_all_or_fail_throws_when_no_elements`

Additionally validated with 67 browser tests covering:
- Scoped selectors (`within()`, nested scopes, `@dusk` attributes)
- Visibility edge cases (`display:none`, `visibility:hidden`, `opacity:0`, `overflow:hidden`, tabs)
- 200-row tables, 100-item lists, 48 deeply nested leaf nodes
- Unicode (Japanese, Greek, Spanish, diacritics, emoji)
- Special characters (currency symbols, backslashes, SQL quotes, HTML entities)
- CSS `text-transform` affecting `getText()` return values
- Dynamic JS-added elements
- Performance: 200-row table assertions complete in <2s