### PR TITLE
[8.x] Restore 204 response for login and logout endpoints

### DIFF
--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -33,7 +33,7 @@ class UserController
      *
      * @param  string  $userId
      * @param  string|null  $guard
-     * @return void
+     * @return \Illuminate\Http\Response
      */
     public function login($userId, $guard = null)
     {
@@ -46,13 +46,15 @@ class UserController
                     : $provider->retrieveById($userId);
 
         Auth::guard($guard)->login($user);
+
+        return response(status: 204);
     }
 
     /**
      * Log the user out of the application.
      *
      * @param  string|null  $guard
-     * @return void
+     * @return \Illuminate\Http\Response
      */
     public function logout($guard = null)
     {
@@ -61,6 +63,8 @@ class UserController
         Auth::guard($guard)->logout();
 
         Session::forget('password_hash_'.$guard);
+
+        return response(status: 204);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Restores `response(status: 204)` return from `UserController::login()` and `UserController::logout()` that was present in 7.x (PR #1061) but lost during the 8.x branch creation
- Without the 204 response, WebDriver waits indefinitely for page readiness after auth actions, causing intermittent `loginAs()` failures (#1152) and unnecessary favicon 404 requests

## Problem

The fix from PR #1061 (commit 076865d) correctly returned a `204 No Content` response from both endpoints to signal to WebDriver that navigation is complete with no content to render. This fix exists on `7.x` and `master` but was never ported to `8.x` — the file was recreated from the pre-fix version.

Without the explicit 204 response:
1. Laravel returns an implicit 200 with empty body
2. WebDriver waits for document readyState, favicon loads, etc.
3. Subsequent browser actions may execute before auth session is fully established
4. Results in intermittent `loginAs()` failures in CI

## Test plan

- [x] All 199 existing tests pass locally
- [x] Diff matches the original #1061 fix exactly
- [x] Verified fix only exists on `7.x`/`master` branches, not `8.x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)