### PR TITLE
[8.x] Me again, with `assertAcceptingDialog/Dismissing()`

### DIFF
--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -987,6 +987,36 @@ JS;
         );
 
         return $this;
+    }    
+
+    /**
+     * Assert that a JavaScript dialog with the given message was opened, then accepted.
+     *
+     * @param  string  $message
+     * @return $this
+     */
+    public function assertDialogAccepted($message)
+    {
+        $this->waitForDialog();
+        $this->assertDialogOpened($message);
+        $this->acceptDialog();
+
+        return $this;
+    }
+
+    /**
+     * Assert that a JavaScript dialog with the given message was opened, then dismissed.
+     *
+     * @param  string  $message
+     * @return $this
+     */
+    public function assertDialogDismissed($message)
+    {
+        $this->waitForDialog();
+        $this->assertDialogOpened($message);
+        $this->dismissDialog();
+
+        return $this;
     }
 
     /**

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -995,7 +995,7 @@ JS;
      * @param  string  $message
      * @return $this
      */
-    public function assertDialogAccepted($message)
+    public function assertAcceptingDialog($message)
     {
         $this->waitForDialog();
         $this->assertDialogOpened($message);
@@ -1010,7 +1010,7 @@ JS;
      * @param  string  $message
      * @return $this
      */
-    public function assertDialogDismissed($message)
+    public function assertDismissingDialog($message)
     {
         $this->waitForDialog();
         $this->assertDialogOpened($message);

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -987,7 +987,7 @@ JS;
         );
 
         return $this;
-    }    
+    }
 
     /**
      * Assert that a JavaScript dialog with the given message was opened, then accepted.


### PR DESCRIPTION
I know we must wait for dialogs, but don't wanna read all about it in our tests.

Maybe other Dusk aficionados feel the same? 🤓

No tests as super boring proxies, that I pinky promise to add to docs...