### PR TITLE
[8.x] Change clickOnce methods to clickWhen

### DIFF
--- a/src/Concerns/InteractsWithMouse.php
+++ b/src/Concerns/InteractsWithMouse.php
@@ -124,7 +124,7 @@ trait InteractsWithMouse
      * @param  string  $selector
      * @return $this
      */
-    public function clickOnceEnabled($selector)
+    public function clickWhenEnabled($selector)
     {
         $this->waitUntilEnabled($selector);
         $this->click($selector);
@@ -138,7 +138,7 @@ trait InteractsWithMouse
      * @param  string  $selector
      * @return $this
      */
-    public function clickOnceVisible($selector)
+    public function clickWhenVisible($selector)
     {
         $this->waitFor($selector);
         $this->click($selector);


### PR DESCRIPTION
This just got merged, but I think "when" fits better, and fits existing consistency like `whenAvailable` and `elsewhereWhenAvailable`so thought I'd try a super fast PR.  

This just got merged, so no b/c as not public yet 🥳 

This means:
`clickOnceEnabled` becomes `clickWhenEnabled`
`clickOnceVisible` becomes `clickWhenVisible`


The guy who just got it merged is my boss, so I am trudging in deep waters, pray for me. (im serious)