### PR TITLE
[master] Document upgrade steps from 8.x to 9.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,9 +2,7 @@
 
 ## Upgrading To 9.0 From 8.x
 
-jQuery has been [removed as a dependency](https://github.com/laravel/dusk/pull/1166), improving performance.
-
-Sites using the jQuery library should find version conflicts are avoided during Dusk tests.
+jQuery has been [removed as a dependency](https://github.com/laravel/dusk/pull/1166), improving performance. Sites using the jQuery library should find version conflicts are now avoided during Dusk tests.
 
 Dusk tests that interact with jQuery via `script()` calls will need adjustment.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade Guide
 
+## Upgrading To 9.0 From 8.x
+
+jQuery has been [removed as a dependency](https://github.com/laravel/dusk/pull/1166), improving performance.
+
+Sites using the jQuery library should find version conflicts are avoided during Dusk tests.
+
+Dusk tests that interact with jQuery via `script()` calls will need adjustment.
+
 ## Upgrading To 8.0 From 7.x
 
 ### Minimum Versions


### PR DESCRIPTION
I won't be disingenuous, this pull request is pretty much:

> Please Taylor, can we have Dusk 9? 🤣

For `$reasons`, we still use Dusk, and any performance boost would be appreciated.

How'd I end up here? We've a flaky Dusk test involving `scrollTo()`, so I was digging around in there. Almost choked on my cup of tea when I saw `$this->ensurejQueryIsAvailable();` since I thought that dragon was slain.

Turns out [it was](https://github.com/laravel/dusk/pull/1166) back in Feb '25 🙈

(also, while jQuery 3.7.1 is supported, they've moved on to 4.x now)