### PR TITLE
GitHub Actions hardening

### DIFF
--- a/.github/workflows/update-jquery.yml
+++ b/.github/workflows/update-jquery.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
We are doing 3 things across the organization:

1. Pinning GitHub Actions to full commit SHAs (instead of mutable tags/branches).
2. Tightening workflow `permissions:` to least-privilege (write scope only where a step needs it).
3. Adding a Dependabot config to keep the pinned actions updated.

This pull request is part of that work.