### PR TITLE
Restrict Dusk test routes to local and testing environments by default

### DIFF
--- a/src/DuskServiceProvider.php
+++ b/src/DuskServiceProvider.php
@@ -14,7 +14,7 @@ class DuskServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (! $this->app->environment('production')) {
+        if ($this->app->environment(config('dusk.environments', ['local', 'testing']))) {
             Route::group(array_filter([
                 'prefix' => config('dusk.path', '_dusk'),
                 'domain' => config('dusk.domain', null),


### PR DESCRIPTION
## What

Dusk registers its test-support routes (`_dusk/login/{userId}`, `_dusk/logout`, `_dusk/user`) in every environment except `production`. This narrows the default to `local` and `testing`, configurable via `dusk.environments`.

## Why

`_dusk/login/{userId}` logs in as an arbitrary user id with no authentication, by design, so browser tests can assume an identity. Registering it everywhere that isn't literally `production` means any non-`production` environment with Dusk's dev dependency installed and reachable on a network (a shared `staging` box, for example) exposes those routes. Gating on an explicit allow-list of the environments Dusk actually runs in keeps the default tight, and matches the "never run Dusk in production" guidance already in the docs.

## Behavior change

- Default: routes register only when `APP_ENV` is `local` or `testing`.
- Custom environments (a CI env named `dusk` or `ci`, say) opt back in:
  ```php
  'environments' => ['local', 'testing', 'dusk'],
  ```
  Follows the existing `config('dusk.path' | 'dusk.domain' | 'dusk.middleware')` pattern, so no new config file is required.

Before:
```php
if (! $this->app->environment('production')) {
```

After:
```php
if ($this->app->environment(config('dusk.environments', ['local', 'testing']))) {
```