### PR TITLE
[8.x] Add  art & workbench to .gitattributes &  update gtiginore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,8 +8,8 @@
 
 /.github export-ignore
 /art export-ignore
-/tests export-ignore
 /workbench export-ignore
+/tests export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,9 @@
 *.php diff=php
 
 /.github export-ignore
+/art export-ignore
 /tests export-ignore
+/workbench export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules
 /vendor
 composer.lock
+/.idea
 /phpunit.xml
 .phpunit.cache/*
 .phpunit.result.cache


### PR DESCRIPTION
This adds the art and workbench to .gitattributes, so the end user doesn't have them kicking around in vendor. 

I was going through our vendor files and spotted this.

Also ignored /.idea while I was here, as I use phpstorm