### PR TITLE
[8.x] Update doc blocks

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -639,7 +639,7 @@ class Browser
      * Return a browser scoped to the given component.
      *
      * @param  \Laravel\Dusk\Component  $component
-     * @return \Laravel\Dusk\Browser
+     * @return static
      */
     public function component(Component $component)
     {

--- a/src/Chrome/SupportsChrome.php
+++ b/src/Chrome/SupportsChrome.php
@@ -14,7 +14,7 @@ trait SupportsChrome
     /**
      * The Chromedriver process instance.
      *
-     * @var \Symfony\Component\Process\Process
+     * @var \Symfony\Component\Process\Process|null
      */
     protected static $chromeProcess;
 

--- a/src/Concerns/InteractsWithAuthentication.php
+++ b/src/Concerns/InteractsWithAuthentication.php
@@ -20,7 +20,7 @@ trait InteractsWithAuthentication
     /**
      * Log into the application using a given user ID or email.
      *
-     * @param  object|string  $userId
+     * @param  object|string|int  $userId
      * @param  string|null  $guard
      * @return $this
      */

--- a/src/Concerns/InteractsWithCookies.php
+++ b/src/Concerns/InteractsWithCookies.php
@@ -16,7 +16,7 @@ trait InteractsWithCookies
      * @param  string|null  $value
      * @param  int|DateTimeInterface|null  $expiry
      * @param  array  $options
-     * @return $this|string|null
+     * @return ($value is null ? string|null : $this)
      */
     public function cookie($name, $value = null, $expiry = null, array $options = [])
     {
@@ -46,7 +46,7 @@ trait InteractsWithCookies
      * @param  string|null  $value
      * @param  int|DateTimeInterface|null  $expiry
      * @param  array  $options
-     * @return $this|string|null
+     * @return ($value is null ? string|null : $this)
      */
     public function plainCookie($name, $value = null, $expiry = null, array $options = [])
     {

--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -59,7 +59,7 @@ trait InteractsWithElements
      *
      * @param  string  $selector
      * @param  string|null  $value
-     * @return $this
+     * @return ($value is null ? string|true|null : $this)
      */
     public function value($selector, $value = null)
     {
@@ -92,7 +92,7 @@ trait InteractsWithElements
      *
      * @param  string  $selector
      * @param  string  $attribute
-     * @return string
+     * @return string|true|null
      */
     public function attribute($selector, $attribute)
     {

--- a/src/Concerns/MakesAssertions.php
+++ b/src/Concerns/MakesAssertions.php
@@ -435,7 +435,7 @@ JS;
      * Get the value of the given input or text area field.
      *
      * @param  string  $field
-     * @return string
+     * @return string|true|null
      */
     public function inputValue($field)
     {
@@ -1199,7 +1199,7 @@ JS;
     /**
      * Retrieve the value of the Vue component's attribute at the given key.
      *
-     * @param  string  $componentSelector
+     * @param  string|null  $componentSelector
      * @param  string  $key
      * @return mixed
      */

--- a/src/Concerns/MakesUrlAssertions.php
+++ b/src/Concerns/MakesUrlAssertions.php
@@ -258,7 +258,7 @@ trait MakesUrlAssertions
      * Assert that the given query string parameter is present and has a given value.
      *
      * @param  string  $name
-     * @param  string|null  $value
+     * @param  string|array|null  $value
      * @return $this
      */
     public function assertQueryStringHas($name, $value = null)

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -16,7 +16,7 @@ trait ProvidesBrowser
     /**
      * All of the active browser instances.
      *
-     * @var array
+     * @var \Illuminate\Support\Collection|array
      */
     protected static $browsers = [];
 
@@ -57,7 +57,7 @@ trait ProvidesBrowser
      * Create a new browser instance.
      *
      * @param  \Closure  $callback
-     * @return \Laravel\Dusk\Browser|void
+     * @return void
      *
      * @throws \Exception
      * @throws \Throwable
@@ -89,7 +89,7 @@ trait ProvidesBrowser
      * Create the browser instances needed for the given callback.
      *
      * @param  \Closure  $callback
-     * @return array
+     * @return \Illuminate\Support\Collection
      *
      * @throws \ReflectionException
      */

--- a/src/Concerns/WaitsForElements.php
+++ b/src/Concerns/WaitsForElements.php
@@ -73,7 +73,7 @@ trait WaitsForElements
     /**
      * Wait for the given text to be removed.
      *
-     * @param  string  $text
+     * @param  array|string  $text
      * @param  int|null  $seconds
      * @return $this
      *

--- a/src/Console/ChromeDriverCommand.php
+++ b/src/Console/ChromeDriverCommand.php
@@ -158,7 +158,7 @@ class ChromeDriverCommand extends Command
      * Detect the installed Chrome / Chromium major version.
      *
      * @param  string  $os
-     * @return int|bool
+     * @return string|false
      */
     protected function detectChromeVersion($os)
     {

--- a/src/Console/DuskCommand.php
+++ b/src/Console/DuskCommand.php
@@ -156,7 +156,7 @@ class DuskCommand extends Command
     /**
      * Get the PHP binary environment variables.
      *
-     * @return array|null
+     * @return array
      */
     protected function env()
     {

--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -404,7 +404,7 @@ class ElementResolver
     /**
      * Format the given selector with the current prefix.
      *
-     * @param  string  $selector
+     * @param  \Laravel\Dusk\Component|string  $selector
      * @return string
      */
     public function format($selector)


### PR DESCRIPTION
As we make efforts to convert our existing Dusk suite to Pest we're required to dig deeper and deeper into code to see what's what.

Updating these doc blocks will help those in a similar position.

I settled on a conditional return type `@return ($value is null ? string|null : $this)` rather than a flat `$this|string|null` union, so the setter branch keeps its fluent-chaining hint to match the established convention in the framework.

Every change is doc-block-only with zero runtime impact, though projects running stricter static analysis may surface new findings, i.e from `attribute()` and `inputValue()`, where the previous string was masking a genuine null.